### PR TITLE
add seq parallel flag to ditxl and pixart examples.

### DIFF
--- a/scripts/ditxl_example.py
+++ b/scripts/ditxl_example.py
@@ -37,6 +37,12 @@ def main():
         ],
         help="Different GroupNorm synchronization modes",
     )
+    parser.add_argument(
+        "--use_seq_parallel_attn",
+        action="store_true",
+        default=False,
+        help="Enable sequence parallel attention.",
+    )
     args = parser.parse_args()
 
     # for DiT the height and width are fixed according to the model
@@ -48,7 +54,7 @@ def main():
         split_batch=False,
         parallelism=args.parallelism,
         mode=args.sync_mode,
-        use_seq_parallel_attn=False,
+        use_seq_parallel_attn=args.use_seq_parallel_attn,
     )
     pipeline = DistriDiTPipeline.from_pretrained(
         distri_config=distri_config,

--- a/scripts/pixart_example.py
+++ b/scripts/pixart_example.py
@@ -3,17 +3,59 @@ import torch
 
 from distrifuser.pipelines.pixartalpha import DistriPixArtAlphaPipeline
 from distrifuser.utils import DistriConfig
+import time
+
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--model_id", default="PixArt-alpha/PixArt-XL-2-1024-MS", type=str, help="Path to the pretrained model.")
-    parser.add_argument("--parallelism", "-p", default="patch", type=str, choices=["patch", "naive_patch"],help="Parallelism to use.")
+    parser.add_argument(
+        "--model_id",
+        default="PixArt-alpha/PixArt-XL-2-1024-MS",
+        type=str,
+        help="Path to the pretrained model.",
+    )
+    parser.add_argument(
+        "--parallelism",
+        "-p",
+        default="patch",
+        type=str,
+        choices=["patch", "naive_patch"],
+        help="Parallelism to use.",
+    )
+    parser.add_argument(
+        "--use_seq_parallel_attn",
+        action="store_true",
+        default=False,
+        help="Enable sequence parallel attention.",
+    )
+    parser.add_argument(
+        "--sync_mode",
+        type=str,
+        default="corrected_async_gn",
+        choices=[
+            "separate_gn",
+            "async_gn",
+            "corrected_async_gn",
+            "sync_gn",
+            "full_sync",
+            "no_sync",
+        ],
+        help="Different GroupNorm synchronization modes",
+    )
     args = parser.parse_args()
 
     # for DiT the height and width are fixed according to the model
-    distri_config = DistriConfig(height=1024, width=1024, warmup_steps=4, 
-                                 do_classifier_free_guidance=False, split_batch=False, 
-                                 parallelism=args.parallelism)
+    distri_config = DistriConfig(
+        height=1024,
+        width=1024,
+        warmup_steps=4,
+        do_classifier_free_guidance=False,
+        split_batch=False,
+        parallelism=args.parallelism,
+        mode=args.sync_mode,
+        use_seq_parallel_attn=args.use_seq_parallel_attn,
+    )
+
     pipeline = DistriPixArtAlphaPipeline.from_pretrained(
         distri_config=distri_config,
         pretrained_model_name_or_path=args.model_id,
@@ -26,8 +68,21 @@ def main():
         prompt="An astronaut riding a green horse",
         generator=torch.Generator(device="cuda").manual_seed(42),
     )
+
+    start_time = time.time()
+
+    output = pipeline(
+        prompt="An astronaut riding a green horse",
+        generator=torch.Generator(device="cuda").manual_seed(42),
+    )
+
+    end_time = time.time()
+
     if distri_config.rank == 0:
+        elapsed_time = end_time - start_time
+        print(f"epoch time: {elapsed_time:.2f}s")
         output.images[0].save("astronaut.png")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
加入seq parallel attn flag、
pixart 1024x1024
<img width="288" alt="image" src="https://github.com/Steaunk/distrifuser-DiT/assets/5706969/a2cce4d6-4871-4403-9330-27add4a9467c">

bechmark脚本
```
export N_GPUS=8

# docker exec -it 888c58e74578 bash
export CUDA_VISIBLE_DEVICES="0,1,2,3,4,5,6,7"

export PYTHONPATH=$PWD

export SCRIPT=ditxl_example.py
export MODEL_ID="/mnt/models/SD/DiT-XL-2-256"

export SCRIPT=pixart_example.py
export MODEL_ID="/mnt/models/SD/PixArt-XL-2-1024-MS"

export ACC_FLAG="--use_seq_parallel_attn"
torchrun --nproc_per_node=$N_GPUS scripts/$SCRIPT --model_id $MODEL_ID --sync_mode "full_sync" $ACC_FLAG

```