### PR TITLE
feat：add pixart support for setting height & width

### DIFF
--- a/distrifuser/pipelines/pixartalpha.py
+++ b/distrifuser/pipelines/pixartalpha.py
@@ -12,6 +12,114 @@ from distrifuser.logger import init_logger
 
 logger = init_logger(__name__)
 
+ASPECT_RATIO_1024_BIN = {
+    "0.25": [512.0, 2048.0],
+    "0.28": [512.0, 1856.0],
+    "0.32": [576.0, 1792.0],
+    "0.33": [576.0, 1728.0],
+    "0.35": [576.0, 1664.0],
+    "0.4": [640.0, 1600.0],
+    "0.42": [640.0, 1536.0],
+    "0.48": [704.0, 1472.0],
+    "0.5": [704.0, 1408.0],
+    "0.52": [704.0, 1344.0],
+    "0.57": [768.0, 1344.0],
+    "0.6": [768.0, 1280.0],
+    "0.68": [832.0, 1216.0],
+    "0.72": [832.0, 1152.0],
+    "0.78": [896.0, 1152.0],
+    "0.82": [896.0, 1088.0],
+    "0.88": [960.0, 1088.0],
+    "0.94": [960.0, 1024.0],
+    "1.0": [1024.0, 1024.0],
+    "1.07": [1024.0, 960.0],
+    "1.13": [1088.0, 960.0],
+    "1.21": [1088.0, 896.0],
+    "1.29": [1152.0, 896.0],
+    "1.38": [1152.0, 832.0],
+    "1.46": [1216.0, 832.0],
+    "1.67": [1280.0, 768.0],
+    "1.75": [1344.0, 768.0],
+    "2.0": [1408.0, 704.0],
+    "2.09": [1472.0, 704.0],
+    "2.4": [1536.0, 640.0],
+    "2.5": [1600.0, 640.0],
+    "3.0": [1728.0, 576.0],
+    "4.0": [2048.0, 512.0],
+}
+
+ASPECT_RATIO_512_BIN = {
+    "0.25": [256.0, 1024.0],
+    "0.28": [256.0, 928.0],
+    "0.32": [288.0, 896.0],
+    "0.33": [288.0, 864.0],
+    "0.35": [288.0, 832.0],
+    "0.4": [320.0, 800.0],
+    "0.42": [320.0, 768.0],
+    "0.48": [352.0, 736.0],
+    "0.5": [352.0, 704.0],
+    "0.52": [352.0, 672.0],
+    "0.57": [384.0, 672.0],
+    "0.6": [384.0, 640.0],
+    "0.68": [416.0, 608.0],
+    "0.72": [416.0, 576.0],
+    "0.78": [448.0, 576.0],
+    "0.82": [448.0, 544.0],
+    "0.88": [480.0, 544.0],
+    "0.94": [480.0, 512.0],
+    "1.0": [512.0, 512.0],
+    "1.07": [512.0, 480.0],
+    "1.13": [544.0, 480.0],
+    "1.21": [544.0, 448.0],
+    "1.29": [576.0, 448.0],
+    "1.38": [576.0, 416.0],
+    "1.46": [608.0, 416.0],
+    "1.67": [640.0, 384.0],
+    "1.75": [672.0, 384.0],
+    "2.0": [704.0, 352.0],
+    "2.09": [736.0, 352.0],
+    "2.4": [768.0, 320.0],
+    "2.5": [800.0, 320.0],
+    "3.0": [864.0, 288.0],
+    "4.0": [1024.0, 256.0],
+}
+
+ASPECT_RATIO_256_BIN = {
+    "0.25": [128.0, 512.0],
+    "0.28": [128.0, 464.0],
+    "0.32": [144.0, 448.0],
+    "0.33": [144.0, 432.0],
+    "0.35": [144.0, 416.0],
+    "0.4": [160.0, 400.0],
+    "0.42": [160.0, 384.0],
+    "0.48": [176.0, 368.0],
+    "0.5": [176.0, 352.0],
+    "0.52": [176.0, 336.0],
+    "0.57": [192.0, 336.0],
+    "0.6": [192.0, 320.0],
+    "0.68": [208.0, 304.0],
+    "0.72": [208.0, 288.0],
+    "0.78": [224.0, 288.0],
+    "0.82": [224.0, 272.0],
+    "0.88": [240.0, 272.0],
+    "0.94": [240.0, 256.0],
+    "1.0": [256.0, 256.0],
+    "1.07": [256.0, 240.0],
+    "1.13": [272.0, 240.0],
+    "1.21": [272.0, 224.0],
+    "1.29": [288.0, 224.0],
+    "1.38": [288.0, 208.0],
+    "1.46": [304.0, 208.0],
+    "1.67": [320.0, 192.0],
+    "1.75": [336.0, 192.0],
+    "2.0": [352.0, 176.0],
+    "2.09": [368.0, 176.0],
+    "2.4": [384.0, 160.0],
+    "2.5": [400.0, 160.0],
+    "3.0": [432.0, 144.0],
+    "4.0": [512.0, 128.0],
+}
+
 class DistriPixArtAlphaPipeline:
     def __init__(self, pipeline: PixArtAlphaPipeline, module_config: DistriConfig):
         self.pipeline = pipeline
@@ -54,8 +162,11 @@ class DistriPixArtAlphaPipeline:
 
     @torch.no_grad()
     def __call__(self, prompt, *args, **kwargs):
+        assert "height" not in kwargs, "height should not be in kwargs"
+        assert "width" not in kwargs, "width should not be in kwargs"
         self.pipeline.transformer.set_counter(0)
-        return self.pipeline(prompt=prompt, *args, **kwargs)
+        config = self.distri_config
+        return self.pipeline(height=config.height, width=config.width, prompt=prompt, use_resolution_binning=config.use_resolution_binning, *args, **kwargs)
 
     @torch.no_grad()
     def prepare(self, **kwargs):
@@ -74,7 +185,21 @@ class DistriPixArtAlphaPipeline:
 
         batch_size = distri_config.batch_size or 1
         num_images_per_prompt = 1
-        # 3. Encode input prompt
+
+        # Resolution binning
+        if distri_config.use_resolution_binning:
+            if pipeline.transformer.config.sample_size == 128:
+                aspect_ratio_bin = ASPECT_RATIO_1024_BIN
+            elif pipeline.transformer.config.sample_size == 64:
+                aspect_ratio_bin = ASPECT_RATIO_512_BIN
+            elif pipeline.transformer.config.sample_size == 32:
+                aspect_ratio_bin = ASPECT_RATIO_256_BIN
+            else:
+                raise ValueError("Invalid sample size")
+            orig_height, orig_width = height, width
+            height, width = pipeline.height, width = pipeline.classify_height_width_bin(height, width, ratios=aspect_ratio_bin)
+
+        # Encode input prompt
         (
             prompt_embeds,
             prompt_attention_mask,
@@ -90,18 +215,22 @@ class DistriPixArtAlphaPipeline:
             prompt_embeds = torch.cat([negative_prompt_embeds, prompt_embeds], dim=0)
             prompt_attention_mask = torch.cat([negative_prompt_attention_mask, prompt_attention_mask], dim=0)
 
-        # 7. Prepare added time ids & embeddings
+        # Prepare added time ids & embeddings
 
         t = torch.zeros([2], device=device, dtype=torch.long)
 
         guidance_scale = 4.0
         latent_size = pipeline.transformer.config.sample_size
+        # latents = torch.zeros(
+        #     [batch_size, latent_channels, latent_size, latent_size],
+        #     device=device,
+        #     dtype=pipeline.transformer.dtype,
+        # )
+
         latent_channels = pipeline.transformer.config.in_channels
-        latents = torch.zeros(
-            [batch_size, latent_channels, latent_size, latent_size],
-            device=device,
-            dtype=pipeline.transformer.dtype,
-        )
+        latents = pipeline.prepare_latents(
+            batch_size, latent_channels, height, width, prompt_embeds.dtype, device, None
+        ) 
         latent_model_input = torch.cat([latents, latents], 0) if guidance_scale > 1 else latents
 
         # encoder_hidden_states.shape torch.Size([2, 120, 4096])

--- a/distrifuser/utils.py
+++ b/distrifuser/utils.py
@@ -44,6 +44,7 @@ class DistriConfig:
         use_seq_parallel_attn: bool = False,
         batch_size: Optional[int] = None,
         verbose: bool = False,
+        use_resolution_binning: bool = True,
     ):
         try:
             # Initialize the process group
@@ -78,6 +79,7 @@ class DistriConfig:
         self.use_seq_parallel_attn = use_seq_parallel_attn
 
         self.verbose = verbose
+        self.use_resolution_binning = use_resolution_binning
 
         if do_classifier_free_guidance and split_batch:
             n_device_per_batch = world_size // 2

--- a/scripts/pixart_example.py
+++ b/scripts/pixart_example.py
@@ -57,19 +57,31 @@ def main():
         default=1024,
         help="The height of image",
     )
+    parser.add_argument(
+        "--width",
+        type=int,
+        default=1024,
+        help="The width of image",
+    )
+    parser.add_argument(
+        "--no_use_resolution_binning",
+        action="store_true",
+    )
 
     args = parser.parse_args()
 
     # for DiT the height and width are fixed according to the model
     distri_config = DistriConfig(
         height=args.height,
-        width=args.height,
+        width=args.width,
         warmup_steps=4,
         do_classifier_free_guidance=True,
         split_batch=False,
         parallelism=args.parallelism,
         mode=args.sync_mode,
         use_seq_parallel_attn=args.use_seq_parallel_attn,
+        use_resolution_binning=not args.no_use_resolution_binning,
+        use_cuda_graph=False,
     )
 
     if distri_config.use_seq_parallel_attn and HAS_LONG_CTX_ATTN:


### PR DESCRIPTION
` torchrun --nproc_per_node=2 scripts/pixart_example.py --height 1536 --width 2048` 
the requested height and width are first mapped to the closest resolutions using ASPECT_RATIO_1024_BIN. After the produced latents are decoded into images, they are resized back to the requested resolution.
` torchrun --nproc_per_node=2 scripts/pixart_example.py --height 1536 --width 2048 --no_use_resolution_binning`（不使用 resolution binning 可以使得 seq_len 更大）