### PR TITLE
v100 disable torch.compile for attention processor

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ if __name__ == "__main__":
             "distvae",
             "yunchang==0.3",
             "flash_attn>=2.6.3",
+            "pytest",
         ],
         url="https://github.com/xdit-project/xDiT.",
         description="xDiT: A Scalable Inference Engine for Diffusion Transformers (DiTs) on multi-GPU Clusters",


### PR DESCRIPTION
On V100, ulysses=2, pipefusion=2. The output images are noise with torch.compile.
I found that its reason comes from the torch compile on attention processor.