### PR TITLE
Refactor setup.py and add instruction for cu124

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,36 @@
 from setuptools import find_packages, setup
 import os
+import subprocess
+import sys
 
+def get_cuda_version():
+    try:
+        nvcc_version = subprocess.check_output(["nvcc", "--version"]).decode("utf-8")
+        version_line = [line for line in nvcc_version.split('\n') if "release" in line][0]
+        cuda_version = version_line.split(' ')[-2].replace(',', '')
+        return 'cu' + cuda_version.replace('.', '')
+    except Exception as e:
+        return 'no_cuda'
+
+def get_install_requires(cuda_version):
+    if cuda_version == 'cu124':
+        sys.stderr.write("ERROR: Manual installation required for CUDA 12.4 specific PyTorch version.\n")
+        sys.stderr.write("Please install PyTorch for CUDA 12.4 using the following command:\n")
+        sys.stderr.write("pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124\n")
+
+    return [
+        "torch==2.3.0",
+        "diffusers>=0.30.0",
+        "transformers>=4.39.1",
+        "sentencepiece>=0.1.99",
+        "accelerate==0.33.0",
+        "beautifulsoup4>=4.12.3",
+        "distvae",
+        "yunchang==0.3",
+        "flash_attn>=2.6.3",
+        "pytest",
+        "flask",
+    ]
 
 if __name__ == "__main__":
     with open("README.md", "r") as f:
@@ -8,24 +38,14 @@ if __name__ == "__main__":
     fp = open("xfuser/__version__.py", "r").read()
     version = eval(fp.strip().split()[-1])
 
+    cuda_version = get_cuda_version()
+
     setup(
         name="xfuser",
         author="xDiT Team",
         author_email="fangjiarui123@gmail.com",
         packages=find_packages(),
-        install_requires=[
-            "torch==2.3.0",
-            "diffusers>=0.30.0",
-            "transformers>=4.39.1",
-            "sentencepiece>=0.1.99",
-            "accelerate==0.33.0",
-            "beautifulsoup4>=4.12.3",
-            "distvae",
-            "yunchang==0.3",
-            "flash_attn>=2.6.3",
-            "pytest",
-            "flask",
-        ],
+        install_requires=get_install_requires(cuda_version),
         url="https://github.com/xdit-project/xDiT.",
         description="xDiT: A Scalable Inference Engine for Diffusion Transformers (DiTs) on multi-GPU Clusters",
         long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_cuda_version():
 
 def get_install_requires(cuda_version):
     if cuda_version == 'cu124':
-        sys.stderr.write("ERROR: Manual installation required for CUDA 12.4 specific PyTorch version.\n")
+        sys.stderr.write("WARNING: Manual installation required for CUDA 12.4 specific PyTorch version.\n")
         sys.stderr.write("Please install PyTorch for CUDA 12.4 using the following command:\n")
         sys.stderr.write("pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124\n")
 


### PR DESCRIPTION
This PR is done:

- [x] Refactored setup.py, with special attention to adding clear installation instructions for users with CUDA 12.4 to prevent errors with `torchrun`.