### PR TITLE
feat: DiTFastAttn for PixArt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ xfuser.egg-info/
 dist/*
 latte_output.mp4
 *.sh
+cache/

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -11,6 +11,7 @@ from xfuser.logger import init_logger
 from xfuser.core.distributed import init_distributed_environment
 from xfuser.config.config import (
     EngineConfig,
+    FastAttnConfig,
     ParallelConfig,
     TensorParallelConfig,
     PipeFusionParallelConfig,
@@ -94,6 +95,13 @@ class xFuserArgs:
     seed: int = 42
     output_type: str = "pil"
     enable_sequential_cpu_offload: bool = False
+    # DiTFastAttn arguments
+    use_fast_attn: bool = False
+    n_calib: int = 8
+    threshold: float = 0.5
+    window_size: int = 64
+    coco_path: Optional[str] = None
+    use_cache: bool = False
 
     @staticmethod
     def add_cli_args(parser: FlexibleArgumentParser):
@@ -240,6 +248,43 @@ class xFuserArgs:
             help="Offloading the weights to the CPU.",
         )
 
+        # DiTFastAttn arguments
+        fast_attn_group = parser.add_argument_group("DiTFastAttn Options")
+        fast_attn_group.add_argument(
+            "--use_fast_attn",
+            action="store_true",
+            help="Use DiTFastAttn to accelerate single inference. Only data parallelism can be used with DITFastAttn.",
+        )
+        fast_attn_group.add_argument(
+            "--n_calib",
+            type=int,
+            default=8,
+            help="Number of prompts for compression method seletion.",
+        )
+        fast_attn_group.add_argument(
+            "--threshold",
+            type=float,
+            default=0.5,
+            help="Threshold for selecting attention compression method.",
+        )
+        fast_attn_group.add_argument(
+            "--window_size",
+            type=int,
+            default=64,
+            help="Size of window attention.",
+        )
+        fast_attn_group.add_argument(
+            "--coco_path",
+            type=str,
+            default=None,
+            help="Path of MS COCO annotation json file.",
+        )
+        fast_attn_group.add_argument(
+            "--use_cache",
+            action="store_true",
+            help="Use cache config for attention compression.",
+        )
+
         return parser
 
     @classmethod
@@ -294,10 +339,21 @@ class xFuserArgs:
             ),
         )
 
+        fast_attn_config = FastAttnConfig(
+            use_fast_attn=self.use_fast_attn,
+            n_step=self.num_inference_steps,
+            n_calib=self.n_calib,
+            threshold=self.threshold,
+            window_size=self.window_size,
+            coco_path=self.coco_path,
+            use_cache=self.use_cache,
+        )
+
         engine_config = EngineConfig(
             model_config=model_config,
             runtime_config=runtime_config,
             parallel_config=parallel_config,
+            fast_attn_config=fast_attn_config,
         )
 
         input_config = InputConfig(

--- a/xfuser/core/fast_attention/__init__.py
+++ b/xfuser/core/fast_attention/__init__.py
@@ -1,0 +1,37 @@
+from .fast_attn_state import (
+    get_fast_attn_state,
+    get_fast_attn_enable,
+    get_fast_attn_step,
+    get_fast_attn_calib,
+    get_fast_attn_threshold,
+    get_fast_attn_window_size,
+    get_fast_attn_coco_path,
+    get_fast_attn_use_cache,
+    get_fast_attn_config_file,
+    get_fast_attn_layer_name,
+    initialize_fast_attn_state,
+)
+
+from .attn_layer import (
+    FastAttnMethod,
+    xFuserFastAttention,
+)
+
+from .utils import fast_attention_compression
+
+__all__ = [
+    "get_fast_attn_state",
+    "get_fast_attn_enable",
+    "get_fast_attn_step",
+    "get_fast_attn_calib",
+    "get_fast_attn_threshold",
+    "get_fast_attn_window_size",
+    "get_fast_attn_coco_path",
+    "get_fast_attn_use_cache",
+    "get_fast_attn_config_file",
+    "get_fast_attn_layer_name",
+    "initialize_fast_attn_state",
+    "xFuserFastAttention",
+    "FastAttnMethod",
+    "fast_attention_compression",
+]

--- a/xfuser/core/fast_attention/attn_layer.py
+++ b/xfuser/core/fast_attention/attn_layer.py
@@ -1,0 +1,215 @@
+import torch
+from diffusers.models.attention_processor import Attention
+from typing import Optional
+import torch.nn.functional as F
+import flash_attn
+from enum import Flag, auto
+from .fast_attn_state import get_fast_attn_window_size
+
+
+class FastAttnMethod(Flag):
+    FULL_ATTN = auto()
+    RESIDUAL_WINDOW_ATTN = auto()
+    OUTPUT_SHARE = auto()
+    CFG_SHARE = auto()
+    RESIDUAL_WINDOW_ATTN_CFG_SHARE = RESIDUAL_WINDOW_ATTN | CFG_SHARE
+    FULL_ATTN_CFG_SHARE = FULL_ATTN | CFG_SHARE
+
+    def has(self, method: "FastAttnMethod"):
+        return bool(self & method)
+
+
+class xFuserFastAttention:
+    window_size: list[int] = [-1, -1]
+    steps_method: list[FastAttnMethod] = []
+    cond_first: bool = False
+    need_compute_residual: list[bool] = []
+    need_cache_output: bool = False
+
+    def __init__(
+        self,
+        steps_method: list[FastAttnMethod] = [],
+        cond_first: bool = False,
+    ):
+        window_size = get_fast_attn_window_size()
+        self.window_size = [window_size, window_size]
+        self.steps_method = steps_method
+        # CFG order flag (conditional first or unconditional first)
+        self.cond_first = cond_first
+        self.need_compute_residual = self.compute_need_compute_residual()
+        self.need_cache_output = True
+
+    def set_methods(
+        self,
+        steps_method: list[FastAttnMethod],
+        selecting: bool = False,
+    ):
+        self.steps_method = steps_method
+        if selecting:
+            if len(self.need_compute_residual) != len(self.steps_method):
+                self.need_compute_residual = [False] * len(self.steps_method)
+        else:
+            self.need_compute_residual = self.compute_need_compute_residual()
+
+    def compute_need_compute_residual(self):
+        """Check at which timesteps do we need to compute the full-window residual of this attention module"""
+        need_compute_residual = []
+        for i, method in enumerate(self.steps_method):
+            need = False
+            if method.has(FastAttnMethod.FULL_ATTN):
+                for j in range(i + 1, len(self.steps_method)):
+                    if self.steps_method[j].has(FastAttnMethod.RESIDUAL_WINDOW_ATTN):
+                        # If encountered a step that conduct WA-RS,
+                        # this step needs the residual computation
+                        need = True
+                    if self.steps_method[j].has(FastAttnMethod.FULL_ATTN):
+                        # If encountered another step using the `full-attn` strategy,
+                        # this step doesn't need the residual computation
+                        break
+            need_compute_residual.append(need)
+        return need_compute_residual
+
+    def __call__(
+        self,
+        attn: Attention,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        temb: Optional[torch.Tensor] = None,
+        *args,
+        **kwargs,
+    ):
+
+        # Before calculating the attention, prepare the related parameters
+        method = self.steps_method[attn.stepi] if attn.stepi < len(self.steps_method) else FastAttnMethod.FULL_ATTN
+        need_compute_residual = self.need_compute_residual[attn.stepi] if attn.stepi < len(self.need_compute_residual) else False
+
+        # Run the forward method according to the selected strategy
+        residual = hidden_states
+        if method.has(FastAttnMethod.OUTPUT_SHARE):
+            hidden_states = attn.cached_output
+        else:
+            if method.has(FastAttnMethod.CFG_SHARE):
+                # Directly use the unconditional branch's attention output
+                # as the conditional branch's attention output
+
+                batch_size = hidden_states.shape[0]
+                if self.cond_first:
+                    hidden_states = hidden_states[: batch_size // 2]
+                else:
+                    hidden_states = hidden_states[batch_size // 2 :]
+                if encoder_hidden_states is not None:
+                    if self.cond_first:
+                        encoder_hidden_states = encoder_hidden_states[: batch_size // 2]
+                    else:
+                        encoder_hidden_states = encoder_hidden_states[batch_size // 2 :]
+                if attention_mask is not None:
+                    if self.cond_first:
+                        attention_mask = attention_mask[: batch_size // 2]
+                    else:
+                        attention_mask = attention_mask[batch_size // 2 :]
+
+            if attn.spatial_norm is not None:
+                hidden_states = attn.spatial_norm(hidden_states, temb)
+
+            input_ndim = hidden_states.ndim
+
+            if input_ndim == 4:
+                batch_size, channel, height, width = hidden_states.shape
+                hidden_states = hidden_states.view(batch_size, channel, height * width).transpose(1, 2)
+
+            batch_size, sequence_length, _ = hidden_states.shape if encoder_hidden_states is None else encoder_hidden_states.shape
+            if attention_mask is not None:
+                attention_mask = attn.prepare_attention_mask(attention_mask, sequence_length, batch_size)
+                # scaled_dot_product_attention expects attention_mask shape to be
+                # (batch, heads, source_length, target_length)
+                attention_mask = attention_mask.view(batch_size, attn.heads, -1, attention_mask.shape[-1])
+
+            if attn.group_norm is not None:
+                hidden_states = attn.group_norm(hidden_states.transpose(1, 2)).transpose(1, 2)
+
+            query = attn.to_q(hidden_states)
+
+            if encoder_hidden_states is None:
+                encoder_hidden_states = hidden_states
+            elif attn.norm_cross:
+                encoder_hidden_states = attn.norm_encoder_hidden_states(encoder_hidden_states)
+
+            key = attn.to_k(encoder_hidden_states)
+            value = attn.to_v(encoder_hidden_states)
+
+            inner_dim = key.shape[-1]
+            head_dim = inner_dim // attn.heads
+
+            query = query.view(batch_size, -1, attn.heads, head_dim)
+
+            key = key.view(batch_size, -1, attn.heads, head_dim)
+            value = value.view(batch_size, -1, attn.heads, head_dim)
+
+            if attention_mask is not None:
+                assert (
+                    method.has(FastAttnMethod.RESIDUAL_WINDOW_ATTN) == False
+                ), "Attention mask is not supported in windowed attention"
+
+                hidden_states = F.scaled_dot_product_attention(
+                    query.transpose(1, 2),
+                    key.transpose(1, 2),
+                    value.transpose(1, 2),
+                    attn_mask=attention_mask,
+                    dropout_p=0.0,
+                    is_causal=False,
+                ).transpose(1, 2)
+            elif method.has(FastAttnMethod.FULL_ATTN):
+                all_hidden_states = flash_attn.flash_attn_func(query, key, value)
+                if need_compute_residual:
+                    # Compute the full-window attention residual
+                    w_hidden_states = flash_attn.flash_attn_func(query, key, value, window_size=self.window_size)
+                    window_residual = all_hidden_states - w_hidden_states
+                    if method.has(FastAttnMethod.CFG_SHARE):
+                        window_residual = torch.cat([window_residual, window_residual], dim=0)
+                    # Save the residual for usage in follow-up steps
+                    attn.cached_residual = window_residual
+                hidden_states = all_hidden_states
+            elif method.has(FastAttnMethod.RESIDUAL_WINDOW_ATTN):
+                w_hidden_states = flash_attn.flash_attn_func(query, key, value, window_size=self.window_size)
+                hidden_states = w_hidden_states + attn.cached_residual[:batch_size].view_as(w_hidden_states)
+
+            hidden_states = hidden_states.reshape(batch_size, -1, attn.heads * head_dim)
+            hidden_states = hidden_states.to(query.dtype)
+
+            # linear proj
+            hidden_states = attn.to_out[0](hidden_states)
+            # dropout
+            hidden_states = attn.to_out[1](hidden_states)
+
+            if input_ndim == 4:
+                hidden_states = hidden_states.transpose(-1, -2).reshape(batch_size, channel, height, width)
+
+            if method.has(FastAttnMethod.CFG_SHARE):
+                hidden_states = torch.cat([hidden_states, hidden_states], dim=0)
+
+            if self.need_cache_output:
+                attn.cached_output = hidden_states
+
+        if attn.residual_connection:
+            hidden_states = hidden_states + residual
+
+        hidden_states = hidden_states / attn.rescale_output_factor
+
+        # After been call once, add the timestep index of this attention module by 1
+        attn.stepi += 1
+
+        return hidden_states
+
+
+# TODO: Implement classes to support DiTFastAttn in different diffusion models
+class xFuserJointFastAttention(xFuserFastAttention):
+    pass
+
+
+class xFuserFluxFastAttention(xFuserFastAttention):
+    pass
+
+
+class xFuserHunyuanFastAttention(xFuserFastAttention):
+    pass

--- a/xfuser/core/fast_attention/attn_layer.py
+++ b/xfuser/core/fast_attention/attn_layer.py
@@ -1,3 +1,8 @@
+# Copyright 2024 xDiT team.
+# Adapted from
+# https://github.com/thu-nics/DiTFastAttn/blob/main/modules/fast_attn_processor.py
+# Copyright (c) 2024 NICS-EFC Lab of Tsinghua University.
+
 import torch
 from diffusers.models.attention_processor import Attention
 from typing import Optional

--- a/xfuser/core/fast_attention/fast_attn_state.py
+++ b/xfuser/core/fast_attention/fast_attn_state.py
@@ -1,0 +1,111 @@
+from typing import Optional
+from diffusers import DiffusionPipeline
+from xfuser.config.config import (
+    ParallelConfig,
+    RuntimeConfig,
+    InputConfig,
+    FastAttnConfig,
+    EngineConfig,
+)
+from xfuser.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class FastAttnState:
+    enable: bool = False
+    n_step: int = 20
+    n_calib: int = 8
+    threshold: float = 0.5
+    window_size: int = 64
+    coco_path: Optional[str] = None
+    use_cache: bool = False
+    config_file: str
+    layer_name: str
+
+    def __init__(self, pipe: DiffusionPipeline, config: FastAttnConfig):
+        self.enable = config.use_fast_attn
+        if self.enable:
+            self.n_step = config.n_step
+            self.n_calib = config.n_calib
+            self.threshold = config.threshold
+            self.window_size = config.window_size
+            self.coco_path = config.coco_path
+            self.use_cache = config.use_cache
+            self.config_file = self.config_file_path(pipe, config)
+            self.layer_name = self.attn_name_to_wrap(pipe)
+
+    def config_file_path(self, pipe: DiffusionPipeline, config: FastAttnConfig):
+        """Return the config file path."""
+        return f"cache/{pipe.config._name_or_path.replace('/', '_')}_{config.n_step}_{config.n_calib}_{config.threshold}_{config.window_size}.json"
+
+    def attn_name_to_wrap(self, pipe: DiffusionPipeline):
+        """Return the attr name of attention layer to wrap."""
+        names = ["attn1", "attn"]  # names of self attention layer
+        assert hasattr(pipe, "transformer"), "transformer is not found in pipeline."
+        assert hasattr(pipe.transformer, "transformer_blocks"), "transformer_blocks is not found in pipeline."
+        block = pipe.transformer.transformer_blocks[0]
+        for name in names:
+            if hasattr(block, name):
+                return name
+        raise AttributeError(f"Attention layer name is not found in {names}.")
+
+
+_FASTATTN: Optional[FastAttnState] = None
+
+
+def get_fast_attn_state() -> FastAttnState:
+    # assert _FASTATTN is not None, "FastAttn state is not initialized"
+    return _FASTATTN
+
+
+def get_fast_attn_enable() -> bool:
+    """Return whether fast attention is enabled."""
+    return get_fast_attn_state().enable
+
+
+def get_fast_attn_step() -> int:
+    """Return the fast attention step."""
+    return get_fast_attn_state().n_step
+
+
+def get_fast_attn_calib() -> int:
+    """Return the fast attention calibration."""
+    return get_fast_attn_state().n_calib
+
+
+def get_fast_attn_threshold() -> float:
+    """Return the fast attention threshold."""
+    return get_fast_attn_state().threshold
+
+
+def get_fast_attn_window_size() -> int:
+    """Return the fast attention window size."""
+    return get_fast_attn_state().window_size
+
+
+def get_fast_attn_coco_path() -> Optional[str]:
+    """Return the fast attention coco path."""
+    return get_fast_attn_state().coco_path
+
+
+def get_fast_attn_use_cache() -> bool:
+    """Return the fast attention use_cache."""
+    return get_fast_attn_state().use_cache
+
+
+def get_fast_attn_config_file() -> str:
+    """Return the fast attention config file."""
+    return get_fast_attn_state().config_file
+
+
+def get_fast_attn_layer_name() -> str:
+    """Return the fast attention layer name."""
+    return get_fast_attn_state().layer_name
+
+
+def initialize_fast_attn_state(pipeline: DiffusionPipeline, single_config: FastAttnConfig):
+    global _FASTATTN
+    if _FASTATTN is not None:
+        logger.warning("FastAttn state is already initialized, reinitializing with pipeline...")
+    _FASTATTN = FastAttnState(pipe=pipeline, config=single_config)

--- a/xfuser/core/fast_attention/utils.py
+++ b/xfuser/core/fast_attention/utils.py
@@ -1,0 +1,227 @@
+import torch
+from xfuser.core.distributed import (
+    get_dp_group,
+    get_data_parallel_rank,
+)
+from diffusers import DiffusionPipeline
+from diffusers.models.transformers.transformer_2d import Transformer2DModel
+from xfuser.model_executor.layers.attention_processor import xFuserAttentionBaseWrapper
+from collections import Counter
+import os
+import json
+import numpy as np
+
+
+from .fast_attn_state import (
+    get_fast_attn_step,
+    get_fast_attn_calib,
+    get_fast_attn_threshold,
+    get_fast_attn_coco_path,
+    get_fast_attn_use_cache,
+    get_fast_attn_config_file,
+    get_fast_attn_layer_name,
+)
+
+from .attn_layer import (
+    xFuserFastAttention,
+    FastAttnMethod,
+)
+
+from xfuser.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+def save_config_file(step_methods, file_path):
+    folder = os.path.dirname(file_path)
+    if not os.path.exists(folder):
+        os.makedirs(folder)
+    format_data = {
+        f"block{blocki}": {f"step{stepi}": method.name for stepi, method in enumerate(methods)}
+        for blocki, methods in enumerate(step_methods)
+    }
+    with open(file_path, "w") as file:
+        json.dump(format_data, file, indent=2)
+
+
+def load_config_file(file_path):
+    with open(file_path, "r") as file:
+        format_data = json.load(file)
+    steps_methods = [[FastAttnMethod[method] for method in format_method.values()] for format_method in format_data.values()]
+    return steps_methods
+
+
+def compression_loss(a, b):
+    ls = []
+    if a.__class__.__name__ == "Transformer2DModelOutput":
+        a = [a.sample]
+        b = [b.sample]
+    weight = torch.tensor(0.0)
+    for ai, bi in zip(a, b):
+        if isinstance(ai, torch.Tensor):
+            weight += ai.numel()
+            diff = (ai - bi) / (torch.max(ai, bi) + 1e-6)
+            loss = diff.abs().clip(0, 10).mean()
+            ls.append(loss)
+    weight_sum = get_dp_group().all_reduce(weight.clone().to(ai.device))
+    local_loss = (weight / weight_sum) * (sum(ls) / len(ls))
+    global_loss = get_dp_group().all_reduce(local_loss.clone().to(ai.device)).item()
+    return global_loss
+
+
+def transformer_forward_pre_hook(m: Transformer2DModel, args, kwargs):
+    attn_name = get_fast_attn_layer_name()
+    now_stepi = getattr(m.transformer_blocks[0], attn_name).stepi
+    # batch_size = get_fast_attn_calib()
+    # dp_degree =
+
+    for blocki, block in enumerate(m.transformer_blocks):
+        # Set `need_compute_residual` to False to avoid the process of trying different
+        # compression strategies to override the saved residual.
+        fast_attn = getattr(block, attn_name).processor.fast_attn
+        fast_attn.need_compute_residual[now_stepi] = False
+        fast_attn.need_cache_output = False
+    raw_outs = m.forward(*args, **kwargs)
+    for blocki, block in enumerate(m.transformer_blocks):
+        if now_stepi == 0:
+            continue
+        fast_attn = getattr(block, attn_name).processor.fast_attn
+        method_candidates = [
+            FastAttnMethod.OUTPUT_SHARE,
+            FastAttnMethod.RESIDUAL_WINDOW_ATTN_CFG_SHARE,
+            FastAttnMethod.RESIDUAL_WINDOW_ATTN,
+            FastAttnMethod.FULL_ATTN_CFG_SHARE,
+        ]
+        selected_method = FastAttnMethod.FULL_ATTN
+        for method in method_candidates:
+            # Try compress this attention using `method`
+            fast_attn.steps_method[now_stepi] = method
+
+            # Set the timestep index of every layer back to now_stepi
+            # (which are increased by one in every forward)
+            for _block in m.transformer_blocks:
+                for layer in _block.children():
+                    if isinstance(layer, xFuserAttentionBaseWrapper):
+                        layer.stepi = now_stepi
+
+            # Compute the overall transformer output
+            outs = m.forward(*args, **kwargs)
+
+            loss = compression_loss(raw_outs, outs)
+            threshold = m.loss_thresholds[now_stepi][blocki]
+
+            if loss < threshold:
+                selected_method = method
+                break
+
+        fast_attn.steps_method[now_stepi] = selected_method
+        del loss, outs
+    del raw_outs
+
+    # Set the timestep index of every layer back to now_stepi
+    # (which are increased by one in every forward)
+    for _block in m.transformer_blocks:
+        for layer in _block.children():
+            if isinstance(layer, xFuserAttentionBaseWrapper):
+                layer.stepi = now_stepi
+
+    for blocki, block in enumerate(m.transformer_blocks):
+        # During the compression plan decision process,
+        # we set the `need_compute_residual` property of all attention modules to `True`,
+        # so that all full attention modules will save its residual for convenience.
+        # The residual will be saved in the follow-up forward call.
+        fast_attn = getattr(block, attn_name).processor.fast_attn
+        fast_attn.need_compute_residual[now_stepi] = True
+        fast_attn.need_cache_output = True
+
+
+def select_methods(pipe: DiffusionPipeline):
+    blocks = pipe.transformer.transformer_blocks
+    transformer: Transformer2DModel = pipe.transformer
+    attn_name = get_fast_attn_layer_name()
+    n_steps = get_fast_attn_step()
+    # reset all processors
+    for block in blocks:
+        fast_attn: xFuserFastAttention = getattr(block, attn_name).processor.fast_attn
+        fast_attn.set_methods(
+            [FastAttnMethod.FULL_ATTN] * n_steps,
+            selecting=True,
+        )
+
+    # Setup loss threshold for each timestep and layer
+    loss_thresholds = []
+    for step_i in range(n_steps):
+        sub_list = []
+        for blocki in range(len(blocks)):
+            threshold_i = (blocki + 1) / len(blocks) * get_fast_attn_threshold()
+            sub_list.append(threshold_i)
+        loss_thresholds.append(sub_list)
+
+    # calibration
+    hook = transformer.register_forward_pre_hook(transformer_forward_pre_hook, with_kwargs=True)
+    transformer.loss_thresholds = loss_thresholds
+
+    seed = 3
+    guidance_scale = 4.5
+    if not os.path.exists(get_fast_attn_coco_path()):
+        raise FileNotFoundError(f"File {get_fast_attn_coco_path()} not found")
+    with open(get_fast_attn_coco_path(), "r") as file:
+        mscoco_anno = json.load(file)
+    np.random.seed(seed)
+    slice_ = np.random.choice(mscoco_anno["annotations"], get_fast_attn_calib())
+    calib_x = [d["caption"] for d in slice_]
+    pipe(
+        prompt=calib_x,
+        num_inference_steps=n_steps,
+        generator=torch.manual_seed(seed),
+        output_type="latent",
+        negative_prompt="",
+        return_dict=False,
+        guidance_scale=guidance_scale,
+    )
+
+    hook.remove()
+    del transformer.loss_thresholds
+
+    blocks_methods = [getattr(block, attn_name).processor.fast_attn.steps_method for block in blocks]
+    return blocks_methods
+
+
+def set_methods(
+    pipe: DiffusionPipeline,
+    blocks_methods: list,
+):
+    attn_name = get_fast_attn_layer_name()
+    blocks = pipe.transformer.transformer_blocks
+    for blocki, block in enumerate(blocks):
+        getattr(block, attn_name).processor.fast_attn.set_methods(blocks_methods[blocki])
+
+
+def statistics(pipe: DiffusionPipeline):
+    attn_name = get_fast_attn_layer_name()
+    blocks = pipe.transformer.transformer_blocks
+    counts = Counter([method for block in blocks for method in getattr(block, attn_name).processor.fast_attn.steps_method])
+    total = sum(counts.values())
+    for k, v in counts.items():
+        logger.info(f"{attn_name} {k} {v/total}")
+
+
+def fast_attention_compression(pipe: DiffusionPipeline):
+    config_file = get_fast_attn_config_file()
+    logger.info(f"config file is {config_file}")
+
+    if get_fast_attn_use_cache() and os.path.exists(config_file):
+        logger.info(f"load config file {config_file} as DiTFastAttn compression methods.")
+        blocks_methods = load_config_file(config_file)
+    else:
+        if get_fast_attn_use_cache():
+            logger.warning(f"config file {config_file} not found.")
+        logger.info("start to select DiTFastAttn compression methods.")
+        blocks_methods = select_methods(pipe)
+        if get_data_parallel_rank() == 0:
+            save_config_file(blocks_methods, config_file)
+            logger.info(f"save DiTFastAttn compression methods to {config_file}")
+
+    set_methods(pipe, blocks_methods)
+
+    statistics(pipe)

--- a/xfuser/core/fast_attention/utils.py
+++ b/xfuser/core/fast_attention/utils.py
@@ -1,3 +1,8 @@
+# Copyright 2024 xDiT team.
+# Adapted from
+# https://github.com/thu-nics/DiTFastAttn/blob/main/dit_fast_attention.py
+# Copyright (c) 2024 NICS-EFC Lab of Tsinghua University.
+
 import torch
 from xfuser.core.distributed import (
     get_dp_group,

--- a/xfuser/model_executor/base_wrapper.py
+++ b/xfuser/model_executor/base_wrapper.py
@@ -9,6 +9,7 @@ from xfuser.core.distributed.parallel_state import (
     get_tensor_model_parallel_world_size,
 )
 from xfuser.core.distributed.runtime_state import get_runtime_state
+from xfuser.core.fast_attention import get_fast_attn_enable
 
 
 class xFuserBaseWrapper(metaclass=ABCMeta):
@@ -40,6 +41,7 @@ class xFuserBaseWrapper(metaclass=ABCMeta):
                 and get_classifier_free_guidance_world_size() == 1
                 and get_sequence_parallel_world_size() == 1
                 and get_tensor_model_parallel_world_size() == 1
+                and get_fast_attn_enable() == False
             ):
                 return func(self, *args, **kwargs)
             if not get_runtime_state().is_ready():

--- a/xfuser/model_executor/models/transformers/base_transformer.py
+++ b/xfuser/model_executor/models/transformers/base_transformer.py
@@ -11,6 +11,7 @@ from xfuser.core.distributed import (
     get_sequence_parallel_world_size,
     get_tensor_model_parallel_world_size,
 )
+from xfuser.core.fast_attention import get_fast_attn_enable
 from xfuser.core.distributed.runtime_state import get_runtime_state
 from xfuser.logger import init_logger
 from xfuser.model_executor.models import xFuserModelBaseWrapper
@@ -46,6 +47,7 @@ class xFuserTransformerBaseWrapper(xFuserModelBaseWrapper, metaclass=ABCMeta):
             get_pipeline_parallel_world_size() == 1
             and get_sequence_parallel_world_size() == 1
             and get_tensor_model_parallel_world_size() == 1
+            and get_fast_attn_enable() == False
         ):
             return transformer
         else:

--- a/xfuser/model_executor/pipelines/pipeline_pixart_alpha.py
+++ b/xfuser/model_executor/pipelines/pipeline_pixart_alpha.py
@@ -47,6 +47,7 @@ class xFuserPixArtAlphaPipeline(xFuserPipelineBaseWrapper):
         return cls(pipeline, engine_config)
 
     @torch.no_grad()
+    @xFuserPipelineBaseWrapper.enable_fast_attn
     @xFuserPipelineBaseWrapper.enable_data_parallel
     @xFuserPipelineBaseWrapper.check_to_use_naive_forward
     def __call__(

--- a/xfuser/model_executor/pipelines/pipeline_pixart_sigma.py
+++ b/xfuser/model_executor/pipelines/pipeline_pixart_sigma.py
@@ -47,6 +47,7 @@ class xFuserPixArtSigmaPipeline(xFuserPipelineBaseWrapper):
         return cls(pipeline, engine_config)
 
     @torch.no_grad()
+    @xFuserPipelineBaseWrapper.enable_fast_attn
     @xFuserPipelineBaseWrapper.enable_data_parallel
     @xFuserPipelineBaseWrapper.check_to_use_naive_forward
     def __call__(


### PR DESCRIPTION
## Summary
[DiTFastAttn](https://github.com/thu-nics/DiTFastAttn) is an attention compression method for Diffusion Transformer Models. Using the redundancy of DiT. It introduces some compression methods for the self-attention to accelerate the inference speed on a single GPU. 

## Implementation
- A new config class and a new argument group are added for the DiTFastAttn in `xfuser\config\`
- Following the implementation of Long Context Attention, DiTFastAttn module is implemented in `xfuser\core\fast_attention`
- As it can only be used with data parallelism, the attention processor is implemented independently instead of greatly modify the original attention processor in `xfuser\model_executor\layers\attention_processor.py`.
- Before the DiTFastAttn works, the compression method need to be set. Thus when the function `prepare_run` is called, the compression method is set if the DiTFastAttn is enabled.

## How to use
- To use the DiTFastAttn, the following arguments are required:
  - `use_fast_attn`: enable the fast attention.
  - `n_calib`: Number of prompts for compression method selection.
  - `threshold`: Threshold for selecting attention compression method. It relatively determines the compression ratio.
  - `window_size`: Size of window attention. According to the paper, the window size is recommended to be 1/8 of the token size.
- When using the DiTFastAttn for a model for the first time, some arguments need to be set for the compression.
  - `coco_path`: Path of MS COCO annotation json file(e.g. `captions_val2014.json` from [official site](https://cocodataset.org/#download)). The file contains the captions of the images, which are sampled for the compression.
- After the compression, the method will be saved in a json file in `cache` folder. This file can be loaded for the same models with same arguments if `use_cache` is set.
- Note: The DiTFastAttn can only be used with data parallelism. If other parallelism methods are used, the program will raise an error.

## Test
So far, only the implementation of DiTFastAttn for PixArt models are done. I have tested it with data parallelism on `PixArt-alpha/PixArt-Sigma-XL-2-1024-MS` and `PixArt-alpha/PixArt-XL-2-1024-MS`. As the `PixArt-alpha/PixArt-Sigma-XL-2-2K-MS` model is not available on the Huggingface now, I have not tested it yet.

## WIP
Implementation of DiTFastAttn for other models is still in progress. 
The benchmark of the DiTFastAttn is not done yet. I will do it after the implementation of DiTFastAttn for other models is done.