### PR TITLE
Enable warm up for VAE

### DIFF
--- a/xfuser/model_executor/pipelines/pipeline_flux.py
+++ b/xfuser/model_executor/pipelines/pipeline_flux.py
@@ -72,7 +72,6 @@ class xFuserFluxPipeline(xFuserPipelineBaseWrapper):
             width=input_config.width,
             prompt=prompt,
             num_inference_steps=steps,
-            output_type="latent",
             max_sequence_length=input_config.max_sequence_length,
             generator=torch.Generator(device="cuda").manual_seed(42),
         )

--- a/xfuser/model_executor/pipelines/pipeline_stable_diffusion_3.py
+++ b/xfuser/model_executor/pipelines/pipeline_stable_diffusion_3.py
@@ -77,7 +77,6 @@ class xFuserStableDiffusion3Pipeline(xFuserPipelineBaseWrapper):
             width=input_config.width,
             prompt=prompt,
             num_inference_steps=steps,
-            output_type="latent",
             generator=torch.Generator(device="cuda").manual_seed(42),
         )
         get_runtime_state().runtime_config.warmup_steps = warmup_steps


### PR DESCRIPTION
This PR enables warm up run for VAE. The insight is that warm up can accelerate the execution of VAE.
> The tested model is Flux. The output is two pic of 2048x1024. I use four L20 card and set ulysses degree to 4.

|parallel VAE|warm up|elapsed time| memory|
|-|-|-|-|
|N|N| 7.27s | 42.34 GB|
|N|Y| 7.02s | 42.34 GB|
|Y|N| 6.99s | 36.85 GB|
|Y|Y| 6.31s  | 36.85 GB|

```
The first Patch vae: [elapsed_time: 0.98 sec, peak_memory: 36.853204992 GB]
The second Patch vae: [elapsed_time: 0.37 sec, peak_memory: 36.852156416 GB]
```
I guess the overhead of warm up mainly comes from tensor allocation. 

Also fix compatibility issue between parallel vae and naive forward.
