### PR TITLE
ring_flash_attn forward compatible with FA>=2.7.0

### DIFF
--- a/xfuser/core/long_ctx_attention/ring/ring_flash_attn.py
+++ b/xfuser/core/long_ctx_attention/ring/ring_flash_attn.py
@@ -1,4 +1,5 @@
 import torch
+import flash_attn
 from flash_attn.flash_attn_interface import _flash_attn_forward
 from xfuser.core.long_ctx_attention import xFuserLongContextAttention
 from xfuser.core.cache_manager.cache_manager import get_cache_manager
@@ -79,18 +80,33 @@ def xdit_ring_flash_attn_forward(
             key, value = k, v
 
         if not causal or step <= comm.rank:
-            block_out, _, _, _, _, block_lse, _, _ = _flash_attn_forward(
-                q,
-                key,
-                value,
-                dropout_p,
-                softmax_scale,
-                causal=causal and step == 0,
-                window_size=window_size,
-                softcap=0.0,
-                alibi_slopes=alibi_slopes,
-                return_softmax=True and dropout_p > 0,
-            )
+            if flash_attn.__version__ <= "2.6.3":
+                block_out, _, _, _, _, block_lse, _, _ = _flash_attn_forward(
+                    q,
+                    key,
+                    value,
+                    dropout_p,
+                    softmax_scale,
+                    causal=causal and step == 0,
+                    window_size=window_size,
+                    softcap=0.0,
+                    alibi_slopes=alibi_slopes,
+                    return_softmax=True and dropout_p > 0,
+                )
+            else:
+                block_out, block_lse, _, _ = _flash_attn_forward(
+                    q,
+                    key,
+                    value,
+                    dropout_p,
+                    softmax_scale,
+                    causal=causal and step == 0,
+                    window_size_left=window_size[0],
+                    window_size_right=window_size[1],
+                    softcap=0.0,
+                    alibi_slopes=alibi_slopes,
+                    return_softmax=True and dropout_p > 0,
+                )
             out, lse = update_out_and_lse(out, lse, block_out, block_lse)
 
         if step + 1 != comm.world_size:


### PR DESCRIPTION
make ring_flash_attn forward compatible with FA>=2.7.0, _flash_attn_forward interface were changed after v2.7.0.  
- before

https://github.com/Dao-AILab/flash-attention/blob/418d677192b483dfc1decfdf9aadca40b402485d/flash_attn/flash_attn_interface.py#L48

```python
def _flash_attn_forward(
    q, k, v, dropout_p, softmax_scale, causal, window_size, softcap, alibi_slopes, return_softmax
):
    q, k, v = [maybe_contiguous(x) for x in (q, k, v)]
    out, q, k, v, out_padded, softmax_lse, S_dmask, rng_state = flash_attn_cuda.fwd(
        q,
        k,
        v,
        None,
        alibi_slopes,
        dropout_p,
        softmax_scale,
        causal,
        window_size[0],
        window_size[1],
        softcap,
        return_softmax,
        None,
    )
    return out, q, k, v, out_padded, softmax_lse, S_dmask, rng_state
```

- after

https://github.com/Dao-AILab/flash-attention/blob/c555642172e281cae6da8a6cff4dfd9ff678ae85/flash_attn/flash_attn_interface.py#L77

```python
@_torch_custom_op_wrapper("flash_attn::_flash_attn_forward", mutates_args=(), device_types="cuda")
def _flash_attn_forward(
    q: torch.Tensor,
    k: torch.Tensor,
    v: torch.Tensor,
    dropout_p: float,
    softmax_scale: float,
    causal: bool,
    window_size_left: int,
    window_size_right: int,
    softcap: float,
    alibi_slopes: Optional[torch.Tensor],
    return_softmax: bool
) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
    q, k, v = [maybe_contiguous(x) for x in (q, k, v)]
    out, softmax_lse, S_dmask, rng_state = flash_attn_cuda.fwd(
        q,
        k,
        v,
        None,
        alibi_slopes,
        dropout_p,
        softmax_scale,
        causal,
        window_size_left,
        window_size_right,
        softcap,
        return_softmax,
        None,
    )
    return out, softmax_lse, S_dmask, rng_state
```