### PR TITLE
support fp8 t5 encoder in examples

### DIFF
--- a/examples/hunyuandit_example.py
+++ b/examples/hunyuandit_example.py
@@ -2,6 +2,7 @@ import time
 import os
 import torch
 import torch.distributed
+from transformers import T5EncoderModel
 from xfuser import xFuserHunyuanDiTPipeline, xFuserArgs
 from xfuser.config import FlexibleArgumentParser
 from xfuser.core.distributed import (
@@ -19,10 +20,18 @@ def main():
     engine_args = xFuserArgs.from_cli_args(args)
     engine_config, input_config = engine_args.create_config()
     local_rank = get_world_group().local_rank
+    text_encoder_2 = T5EncoderModel.from_pretrained(engine_config.model_config.model, subfolder="text_encoder_2", torch_dtype=torch.bfloat16)
+    if args.use_fp8_t5_encoder:
+        from optimum.quanto import freeze, qfloat8, quantize
+        print(f"rank {local_rank} quantizing text encoder 2")
+        quantize(text_encoder_2, weights=qfloat8)
+        freeze(text_encoder_2)
+
     pipe = xFuserHunyuanDiTPipeline.from_pretrained(
         pretrained_model_name_or_path=engine_config.model_config.model,
         engine_config=engine_config,
         torch_dtype=torch.float16,
+        text_encoder_2=text_encoder_2,
     ).to(f"cuda:{local_rank}")
 
     parameter_peak_memory = torch.cuda.max_memory_allocated(device=f"cuda:{local_rank}")

--- a/examples/pixartsigma_example.py
+++ b/examples/pixartsigma_example.py
@@ -2,6 +2,7 @@ import time
 import os
 import torch
 import torch.distributed
+from transformers import T5EncoderModel
 from xfuser import xFuserPixArtSigmaPipeline, xFuserArgs
 from xfuser.config import FlexibleArgumentParser
 from xfuser.core.distributed import (
@@ -19,10 +20,18 @@ def main():
     engine_args = xFuserArgs.from_cli_args(args)
     engine_config, input_config = engine_args.create_config()
     local_rank = get_world_group().local_rank
+    text_encoder = T5EncoderModel.from_pretrained(engine_config.model_config.model, subfolder="text_encoder", torch_dtype=torch.float16)
+    if args.use_fp8_t5_encoder:
+        from optimum.quanto import freeze, qfloat8, quantize
+        print(f"rank {local_rank} quantizing text encoder")
+        quantize(text_encoder, weights=qfloat8)
+        freeze(text_encoder)
+
     pipe = xFuserPixArtSigmaPipeline.from_pretrained(
         pretrained_model_name_or_path=engine_config.model_config.model,
         engine_config=engine_config,
         torch_dtype=torch.float16,
+        text_encoder=text_encoder,
     ).to(f"cuda:{local_rank}")
     pipe.prepare_run(input_config)
 

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -46,6 +46,9 @@ PARALLEL_ARGS="--pipefusion_parallel_degree 2 --ulysses_degree 2 --ring_degree 2
 # COMPILE_FLAG="--use_torch_compile"
 
 
+# Use this flag to quantize the T5 text encoder, which could reduce the memory usage and have no effect on the result quality.
+# QUANTIZE_FLAG="--use_fp8_t5_encoder"
+
 # export CUDA_VISIBLE_DEVICES=4,5,6,7
 
 torchrun --nproc_per_node=$N_GPUS ./examples/$SCRIPT \
@@ -59,4 +62,5 @@ $OUTPUT_ARGS \
 --prompt "brown dog laying on the ground with a metal bowl in front of him." \
 $CFG_ARGS \
 $PARALLLEL_VAE \
-$COMPILE_FLAG
+$COMPILE_FLAG \
+$QUANTIZE_FLAG \

--- a/examples/sd3_example.py
+++ b/examples/sd3_example.py
@@ -2,6 +2,7 @@ import time
 import os
 import torch
 import torch.distributed
+from transformers import T5EncoderModel
 from xfuser import xFuserStableDiffusion3Pipeline, xFuserArgs
 from xfuser.config import FlexibleArgumentParser
 from xfuser.core.distributed import (
@@ -19,10 +20,18 @@ def main():
     engine_args = xFuserArgs.from_cli_args(args)
     engine_config, input_config = engine_args.create_config()
     local_rank = get_world_group().local_rank
+    text_encoder_3 = T5EncoderModel.from_pretrained(engine_config.model_config.model, subfolder="text_encoder_3", torch_dtype=torch.float16)
+    if args.use_fp8_t5_encoder:
+        from optimum.quanto import freeze, qfloat8, quantize
+        print(f"rank {local_rank} quantizing text encoder 2")
+        quantize(text_encoder_3, weights=qfloat8)
+        freeze(text_encoder_3)
+
     pipe = xFuserStableDiffusion3Pipeline.from_pretrained(
         pretrained_model_name_or_path=engine_config.model_config.model,
         engine_config=engine_config,
         torch_dtype=torch.float16,
+        text_encoder_3=text_encoder_3,
     ).to(f"cuda:{local_rank}")
 
     parameter_peak_memory = torch.cuda.max_memory_allocated(device=f"cuda:{local_rank}")

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
         install_requires=[
             "torch>=2.1.0",
             "accelerate>=0.33.0",
-            "diffusers>=0.31",  # NOTE: diffusers>=0.31.0 is necessary for CogVideoX and Flux
+            "diffusers==0.31",  # NOTE: diffusers>=0.31.0 is necessary for CogVideoX and Flux
             "transformers>=4.39.1",
             "sentencepiece>=0.1.99",
             "beautifulsoup4>=4.12.3",

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ if __name__ == "__main__":
             "opencv-python",
             "imageio",
             "imageio-ffmpeg",
+            "optimum-quanto"
         ],
         extras_require={
             "flash_attn": [

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -105,6 +105,7 @@ class xFuserArgs:
     window_size: int = 64
     coco_path: Optional[str] = None
     use_cache: bool = False
+    use_fp8_t5_encoder: bool = False
 
     @staticmethod
     def add_cli_args(parser: FlexibleArgumentParser):
@@ -265,6 +266,11 @@ class xFuserArgs:
             action="store_true",
             help="Making VAE decode a tile at a time to save GPU memory.",
         )
+        runtime_group.add_argument(
+            "--use_fp8_t5_encoder",
+            action="store_true",
+            help="Quantize the T5 text encoder.",
+        )
 
         # DiTFastAttn arguments
         fast_attn_group = parser.add_argument_group("DiTFastAttn Options")
@@ -335,6 +341,7 @@ class xFuserArgs:
             use_torch_compile=self.use_torch_compile,
             use_onediff=self.use_onediff,
             # use_profiler=self.use_profiler,
+            use_fp8_t5_encoder=self.use_fp8_t5_encoder,
         )
 
         parallel_config = ParallelConfig(

--- a/xfuser/config/config.py
+++ b/xfuser/config/config.py
@@ -59,6 +59,7 @@ class RuntimeConfig:
     use_profiler: bool = False
     use_torch_compile: bool = False
     use_onediff: bool = False
+    use_fp8_t5_encoder: bool = False
 
     def __post_init__(self):
         check_packages()


### PR DESCRIPTION
The examples now support T5 encoder FP8 quantization, which could save GPU memory usage without affecting the result quality.

