### PR TITLE
Cache applied with torch.compile

### DIFF
--- a/docs/performance/flux.md
+++ b/docs/performance/flux.md
@@ -117,15 +117,48 @@ The quality of image generation at 2048px, 3072px, and 4096px resolutions is as 
 
 ## Cache Methods
 
-We tested the performance of TeaCache and First-Block-Cache on 4xH20 with SP=4.
+We tested the performance of TeaCache and First-Block-Cache on 4xH20 with SP=4 and 1xH20 respectively.
 The Performance shown as below:
 
 <div align="center">
 
-| Method          | Latency (s) |
-|----------------|--------|
-| Baseline       | 2.02s  |
-| use_teacache   | 1.58s  |
-| use_fbcache    | 0.93s  |
+<table>
+  <tr>
+    <th rowspan="2">Method</th>
+    <th colspan="4">Latency (s)</th>
+  </tr>
+  <tr>
+    <th colspan="2">without torch.compile</th>
+    <th colspan="2">with torch.compile</th>
+  </tr>
+  <tr>
+    <th></th>
+    <th>4xH20</th>
+    <th>1xH20</th>
+    <th>4xH20</th>
+    <th>1xH20</th>
+  </tr>
+  <tr>
+    <td>Baseline</td>
+    <td>2.02s</td>
+    <td>6.10s</td>
+    <td>1.81s</td>
+    <td>5.02s</td>
+  </tr>
+  <tr>
+    <td>use_teacache</td>
+    <td>1.60s</td>
+    <td>4.67s</td>
+    <td>1.50s</td>
+    <td>3.92s</td>
+  </tr>
+  <tr>
+    <td>use_fbcache</td>
+    <td>0.93s</td>
+    <td>2.51s</td>
+    <td>0.85s</td>
+    <td>2.09s</td>
+  </tr>
+</table>
 
 </div>

--- a/xfuser/model_executor/cache/diffusers_adapters/__init__.py
+++ b/xfuser/model_executor/cache/diffusers_adapters/__init__.py
@@ -5,12 +5,16 @@ adapted from https://github.com/chengzeyi/ParaAttention.git
 import importlib
 from typing import Type, Dict, TypeVar
 from xfuser.model_executor.cache.diffusers_adapters.registry import TRANSFORMER_ADAPTER_REGISTRY
+from xfuser.logger import init_logger
+
+logger = init_logger(__name__)
 
 
 def apply_cache_on_transformer(transformer, *args, **kwargs):
     adapter_name = TRANSFORMER_ADAPTER_REGISTRY.get(type(transformer))
     if not adapter_name:
-        raise ValueError(f"Unknown transformer class: {transformer.__class__.__name__}")
+        logger.error(f"Unknown transformer class: {transformer.__class__.__name__}")
+        return transformer
 
     adapter_module = importlib.import_module(f".{adapter_name}", __package__)
     apply_cache_on_transformer_fn = getattr(adapter_module, "apply_cache_on_transformer")

--- a/xfuser/model_executor/pipelines/pipeline_flux.py
+++ b/xfuser/model_executor/pipelines/pipeline_flux.py
@@ -57,13 +57,14 @@ class xFuserFluxPipeline(xFuserPipelineBaseWrapper):
         cls,
         pretrained_model_name_or_path: Optional[Union[str, os.PathLike]],
         engine_config: EngineConfig,
+        cache_args: Dict={},
         return_org_pipeline: bool = False,
         **kwargs,
     ):
         pipeline = FluxPipeline.from_pretrained(pretrained_model_name_or_path, **kwargs)
         if return_org_pipeline:
             return pipeline
-        return cls(pipeline, engine_config)
+        return cls(pipeline, engine_config, cache_args)
 
     def prepare_run(
         self,


### PR DESCRIPTION
This PR:
- [x] Add the Performance of Teacache and FBCache on 1xH20
- [x] Add the Performance of Teacache and FBCache on 1xH20 and  4xH20 with torch.compile
- [x] refracture the code to make torch.compile as efficient as possible 
- [x] Fix the bug, postpone the logic to update modulated_inputs of FBCache (which is equivalent to the paraAttn)

The performance table is listed below:
<div align="center">

<table>
  <tr>
    <th rowspan="2">Method</th>
    <th colspan="4">Latency (s)</th>
  </tr>
  <tr>
    <th colspan="2">without torch.compile</th>
    <th colspan="2">with torch.compile</th>
  </tr>
  <tr>
    <th></th>
    <th>4xH20</th>
    <th>1xH20</th>
    <th>4xH20</th>
    <th>1xH20</th>
  </tr>
  <tr>
    <td>Baseline</td>
    <td>2.02s</td>
    <td>6.10s</td>
    <td>1.81s</td>
    <td>5.02s</td>
  </tr>
  <tr>
    <td>use_teacache</td>
    <td>1.60s</td>
    <td>4.67s</td>
    <td>1.50s</td>
    <td>3.92s</td>
  </tr>
  <tr>
    <td>use_fbcache</td>
    <td>0.93s</td>
    <td>2.51s</td>
    <td>0.85s</td>
    <td>2.09s</td>
  </tr>
</table>
