### PR TITLE
fix rlt when using fb cache for flux

### DIFF
--- a/xfuser/model_executor/cache/diffusers_adapters/flux.py
+++ b/xfuser/model_executor/cache/diffusers_adapters/flux.py
@@ -35,7 +35,7 @@ def create_cached_transformer_blocks(use_cache, transformer, rel_l1_thresh, retu
 def apply_cache_on_transformer(
     transformer: FluxTransformer2DModel,
     *,
-    rel_l1_thresh=0.6,
+    rel_l1_thresh=0.12,
     return_hidden_states_first=False,
     num_steps=8,
     use_cache="Fb",


### PR DESCRIPTION
Adapt from: https://github.com/chengzeyi/ParaAttention/blob/main/doc/fastest_flux.md
I find xDiT use rlt to 0.6, This will cause a degradation in generate quality. 0.12 rlt might be a more reasonable value.

When using rlt to 0.6 may cause: 
![WechatIMG746](https://github.com/user-attachments/assets/36a586f5-88df-4c6b-b5d8-7fbfce07fe61)

Compare with 0.12 and not cache: 
![WechatIMG747](https://github.com/user-attachments/assets/aefaba71-dbe8-4d6d-bed3-1e64e7c53ccf)
