### PR TITLE
Update get_2d_sincos_pos_embed to use output_type='pt' for Diffusers compat

### DIFF
--- a/xfuser/model_executor/layers/embeddings.py
+++ b/xfuser/model_executor/layers/embeddings.py
@@ -71,9 +71,10 @@ class xFuserPatchEmbedWrapper(xFuserLayerBaseWrapper):
                     grid_size=(height, width),
                     base_size=self.module.base_size,
                     interpolation_scale=self.module.interpolation_scale,
+                    device=latent.device,  # Place tensor on the correct device directly
+                    output_type="pt",  # Return a PyTorch tensor instead of NumPy array
                 )
-                pos_embed = torch.from_numpy(pos_embed)
-                self.module.pos_embed = pos_embed.float().unsqueeze(0).to(latent.device)
+                self.module.pos_embed = pos_embed.unsqueeze(0)  # Shape adjustment
                 self.module.height = height
                 self.module.width = width
                 pos_embed = self.module.pos_embed

--- a/xfuser/model_executor/layers/embeddings.py
+++ b/xfuser/model_executor/layers/embeddings.py
@@ -1,5 +1,6 @@
 # adapted from https://github.com/huggingface/diffusers/blob/v0.29.0/src/diffusers/models/embeddings.py
 import torch
+import inspect
 
 from diffusers.models.embeddings import PatchEmbed, get_2d_sincos_pos_embed, CogVideoXPatchEmbed
 import torch.distributed
@@ -66,15 +67,30 @@ class xFuserPatchEmbedWrapper(xFuserLayerBaseWrapper):
             pos_embed = self.module.cropped_pos_embed(height, width)
         else:
             if self.module.height != height or self.module.width != width:
-                pos_embed = get_2d_sincos_pos_embed(
-                    embed_dim=self.module.pos_embed.shape[-1],
-                    grid_size=(height, width),
-                    base_size=self.module.base_size,
-                    interpolation_scale=self.module.interpolation_scale,
-                    device=latent.device,  # Place tensor on the correct device directly
-                    output_type="pt",  # Return a PyTorch tensor instead of NumPy array
-                )
-                self.module.pos_embed = pos_embed.unsqueeze(0)  # Shape adjustment
+                sig = inspect.signature(get_2d_sincos_pos_embed)
+
+                if "device" in sig.parameters and "output_type" in sig.parameters:
+                    # diffusers >= 0.33.0
+                    pos_embed = get_2d_sincos_pos_embed(
+                        embed_dim=self.module.pos_embed.shape[-1],
+                        grid_size=(height, width),
+                        base_size=self.module.base_size,
+                        interpolation_scale=self.module.interpolation_scale,
+                        device=latent.device,
+                        output_type="pt",
+                    )
+                    self.module.pos_embed = pos_embed.unsqueeze(0)
+                else:
+                    # diffusers < 0.33.0 fallback
+                    pos_embed = get_2d_sincos_pos_embed(
+                        embed_dim=self.module.pos_embed.shape[-1],
+                        grid_size=(height, width),
+                        base_size=self.module.base_size,
+                        interpolation_scale=self.module.interpolation_scale,
+                    )
+                    pos_embed = torch.from_numpy(pos_embed)
+                    self.module.pos_embed = pos_embed.float().unsqueeze(0).to(latent.device)
+
                 self.module.height = height
                 self.module.width = width
                 pos_embed = self.module.pos_embed


### PR DESCRIPTION
**Description**  
This PR addresses a deprecation warning in Diffusers 0.33.0 related to the `output_type` parameter in `get_2d_sincos_pos_embed`. The function now recommends using `output_type='pt'` to return a PyTorch tensor directly, which is more efficient and avoids unnecessary conversions from NumPy.

**Changes**  
- Modified `get_2d_sincos_pos_embed` in `xfuser/model_executor/layers/embeddings.py` to use `output_type='pt'`.  
- Added the `device` parameter to ensure the tensor is placed directly on the correct device, removing the need for manual device transfer.  
- Removed the previous `torch.from_numpy` conversion and `.to(latent.device)` call, as they are no longer required these changes.

**Benefits**  
- Ensures xFuser remains compatible with Diffusers' updated API, avoiding future issues.  
- Improves performance by eliminating NumPy-to-PyTorch conversions and redundant device transfers.  
- Simplifies the code.

**Testing**  
- Tested with Diffusers 0.33.0.dev0 live on a 8x H200 machine. Can report back testings on a more variety of machines if needed.

Cheers