### PR TITLE
fix: keep guidance_scale default value consistent with diffusers

### DIFF
--- a/examples/cogvideox_example.py
+++ b/examples/cogvideox_example.py
@@ -66,6 +66,7 @@ def main():
         num_frames=input_config.num_frames,
         prompt=input_config.prompt,
         num_inference_steps=input_config.num_inference_steps,
+        guidance_scale=input_config.guidance_scale,
         generator=torch.Generator(device="cuda").manual_seed(input_config.seed),
     ).frames[0]
 

--- a/examples/cogvideox_usp_example.py
+++ b/examples/cogvideox_usp_example.py
@@ -193,6 +193,7 @@ def main():
         num_frames=input_config.num_frames,
         prompt=input_config.prompt,
         num_inference_steps=input_config.num_inference_steps,
+        guidance_scale=input_config.guidance_scale,
         generator=torch.Generator(device="cuda").manual_seed(input_config.seed),
     ).frames[0]
 

--- a/examples/consisid_example.py
+++ b/examples/consisid_example.py
@@ -89,8 +89,8 @@ def main():
         width=input_config.width,
         num_frames=input_config.num_frames,
         num_inference_steps=input_config.num_inference_steps,
+        guidance_scale=input_config.guidance_scale,
         generator=torch.Generator(device="cuda").manual_seed(input_config.seed),
-        guidance_scale=6.0,
         use_dynamic_cfg=False,
     ).frames[0]
 

--- a/examples/consisid_usp_example.py
+++ b/examples/consisid_usp_example.py
@@ -208,8 +208,8 @@ def main():
             width=input_config.width,
             num_frames=input_config.num_frames,
             num_inference_steps=1,
+            guidance_scale=input_config.guidance_scale,
             generator=torch.Generator(device="cuda").manual_seed(input_config.seed),
-            guidance_scale=6.0,
             use_dynamic_cfg=False,
         ).frames[0]
 
@@ -226,8 +226,8 @@ def main():
         width=input_config.width,
         num_frames=input_config.num_frames,
         num_inference_steps=input_config.num_inference_steps,
+        guidance_scale=input_config.guidance_scale,
         generator=torch.Generator(device="cuda").manual_seed(input_config.seed),
-        guidance_scale=6.0,
         use_dynamic_cfg=False,
     ).frames[0]
 

--- a/examples/flux_example.py
+++ b/examples/flux_example.py
@@ -68,7 +68,7 @@ def main():
         num_inference_steps=input_config.num_inference_steps,
         output_type=input_config.output_type,
         max_sequence_length=256,
-        guidance_scale=0.0,
+        guidance_scale=input_config.guidance_scale,
         generator=torch.Generator(device="cuda").manual_seed(input_config.seed),
     )
     end_time = time.time()

--- a/examples/flux_usp_example.py
+++ b/examples/flux_usp_example.py
@@ -133,6 +133,7 @@ def main():
             prompt=input_config.prompt,
             num_inference_steps=1,
             output_type=input_config.output_type,
+            guidance_scale=input_config.guidance_scale,
             generator=torch.Generator(device="cuda").manual_seed(input_config.seed),
         ).images
 
@@ -145,6 +146,7 @@ def main():
         prompt=input_config.prompt,
         num_inference_steps=input_config.num_inference_steps,
         output_type=input_config.output_type,
+        guidance_scale=input_config.guidance_scale,
         generator=torch.Generator(device="cuda").manual_seed(input_config.seed),
     )
     end_time = time.time()

--- a/examples/hunyuan_video_usp_example.py
+++ b/examples/hunyuan_video_usp_example.py
@@ -280,6 +280,7 @@ def main():
             num_frames=input_config.num_frames,
             prompt=input_config.prompt,
             num_inference_steps=1,
+            guidance_scale=input_config.guidance_scale,
             generator=torch.Generator(device="cuda").manual_seed(
                 input_config.seed),
         ).frames[0]
@@ -293,6 +294,7 @@ def main():
         num_frames=input_config.num_frames,
         prompt=input_config.prompt,
         num_inference_steps=input_config.num_inference_steps,
+        guidance_scale=input_config.guidance_scale,
         generator=torch.Generator(device="cuda").manual_seed(
             input_config.seed),
     ).frames[0]

--- a/examples/hunyuandit_example.py
+++ b/examples/hunyuandit_example.py
@@ -47,6 +47,7 @@ def main():
         num_inference_steps=input_config.num_inference_steps,
         output_type=input_config.output_type,
         use_resolution_binning=input_config.use_resolution_binning,
+        guidance_scale=input_config.guidance_scale,
         generator=torch.Generator(device="cuda").manual_seed(input_config.seed),
     )
     end_time = time.time()

--- a/examples/latte_example.py
+++ b/examples/latte_example.py
@@ -43,6 +43,7 @@ def main():
         prompt=input_config.prompt,
         num_inference_steps=input_config.num_inference_steps,
         output_type="pt",
+        guidance_scale=input_config.guidance_scale,
         generator=torch.Generator(device="cuda").manual_seed(input_config.seed),
     )
     end_time = time.time()

--- a/examples/pixartalpha_example.py
+++ b/examples/pixartalpha_example.py
@@ -45,6 +45,7 @@ def main():
         num_inference_steps=input_config.num_inference_steps,
         output_type=input_config.output_type,
         use_resolution_binning=input_config.use_resolution_binning,
+        guidance_scale=input_config.guidance_scale,
         generator=torch.Generator(device="cuda").manual_seed(input_config.seed),
     )
     end_time = time.time()

--- a/examples/pixartsigma_example.py
+++ b/examples/pixartsigma_example.py
@@ -44,6 +44,7 @@ def main():
         num_inference_steps=input_config.num_inference_steps,
         output_type=input_config.output_type,
         use_resolution_binning=input_config.use_resolution_binning,
+        guidance_scale=input_config.guidance_scale,
         generator=torch.Generator(device="cuda").manual_seed(input_config.seed),
         clean_caption=False,
     )

--- a/examples/run.sh
+++ b/examples/run.sh
@@ -26,7 +26,7 @@ fi
 mkdir -p ./results
 
 # task args
-TASK_ARGS="--height 1024 --width 1024 --no_use_resolution_binning"
+TASK_ARGS="--height 1024 --width 1024 --no_use_resolution_binning --guidance_scale 3.5"
 
 # cache args
 # CACHE_ARGS="--use_teacache"

--- a/examples/run_cogvideo.sh
+++ b/examples/run_cogvideo.sh
@@ -11,7 +11,7 @@ INFERENCE_STEP=50
 mkdir -p ./results
 
 # CogVideoX specific task args
-TASK_ARGS="--height 768 --width 1360 --num_frames 17"
+TASK_ARGS="--height 768 --width 1360 --num_frames 17 --guidance_scale 6.0"
 
 # CogVideoX parallel configuration
 N_GPUS=8

--- a/examples/run_consisid.sh
+++ b/examples/run_consisid.sh
@@ -11,7 +11,7 @@ INFERENCE_STEP=50
 mkdir -p ./results
 
 # ConsisID specific task args
-TASK_ARGS="--height 480 --width 720 --num_frames 49"
+TASK_ARGS="--height 480 --width 720 --num_frames 49 --guidance_scale 6.0"
 
 # ConsisID parallel configuration
 N_GPUS=6

--- a/examples/run_consisid_usp.sh
+++ b/examples/run_consisid_usp.sh
@@ -11,7 +11,7 @@ INFERENCE_STEP=50
 mkdir -p ./results
 
 # ConsisID specific task args
-TASK_ARGS="--height 480 --width 720 --num_frames 49"
+TASK_ARGS="--height 480 --width 720 --num_frames 49 --guidance_scale 6.0"
 
 # ConsisID parallel configuration
 N_GPUS=4

--- a/examples/run_fastditattn.sh
+++ b/examples/run_fastditattn.sh
@@ -38,7 +38,7 @@ fi
 
 mkdir -p ./results
 
-TASK_ARGS="--height 1024 --width 1024 --no_use_resolution_binning"
+TASK_ARGS="--height 1024 --width 1024 --no_use_resolution_binning --guidance_scale 4.5"
 FAST_ATTN_ARGS="--use_fast_attn --window_size 512 --n_calib 4 --threshold 0.15 --use_cache --coco_path $COCO_PATH"
 
 

--- a/examples/run_hunyuan_video_usp.sh
+++ b/examples/run_hunyuan_video_usp.sh
@@ -12,7 +12,7 @@ INFERENCE_STEP=50
 mkdir -p ./results
 
 # CogVideoX specific task args
-TASK_ARGS="--height 720 --width 1280 --num_frames 129"
+TASK_ARGS="--height 720 --width 1280 --num_frames 129 --guidance_scale 5.0"
 
 # CogVideoX parallel configuration
 N_GPUS=8

--- a/examples/run_multinodes.sh
+++ b/examples/run_multinodes.sh
@@ -31,8 +31,9 @@ MODEL_ID="/cfs/dit/PixArt-XL-2-1024-MS/"
 INFERENCE_STEP=20
 
 SIZE=1024
+GUIDANCE_SCALE=4.5
 PARALLEL_ARGS="--ulysses_degree=1 --ring_degree=1 --pipefusion_parallel_degree=8"
-TASK_ARGS="--height=${SIZE} --width=${SIZE} --no_use_resolution_binning"
+TASK_ARGS="--height=${SIZE} --width=${SIZE} --no_use_resolution_binning --guidance_scale=${GUIDANCE_SCALE}"
 OUTPUT_ARGS="--output_type=latent"
 CFG_ARGS="--use_cfg_parallel"
 

--- a/examples/run_service.sh
+++ b/examples/run_service.sh
@@ -41,7 +41,7 @@ do
 for N_GPUS in 1;
 do 
 
-TASK_ARGS="--height $HEIGHT --width $HEIGHT --no_use_resolution_binning"
+TASK_ARGS="--height $HEIGHT --width $HEIGHT --no_use_resolution_binning --guidance_scale 3.5"
 
 PARALLEL_ARGS="--ulysses_degree 1 --ring_degree 1"
 

--- a/examples/sd3_example.py
+++ b/examples/sd3_example.py
@@ -46,6 +46,7 @@ def main():
         prompt=input_config.prompt,
         num_inference_steps=input_config.num_inference_steps,
         output_type=input_config.output_type,
+        guidance_scale=input_config.guidance_scale,
         generator=torch.Generator(device="cuda").manual_seed(input_config.seed),
     )
     end_time = time.time()

--- a/examples/sdxl_example.py
+++ b/examples/sdxl_example.py
@@ -53,7 +53,7 @@ def main():
         prompt=input_config.prompt,
         num_inference_steps=input_config.num_inference_steps,
         output_type=input_config.output_type,
-        guidance_scale=7.5,  # SDXL默认guidance scale
+        guidance_scale=input_config.guidance_scale,
         generator=torch.Generator(device="cuda").manual_seed(input_config.seed),
     )
     end_time = time.time()

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -100,7 +100,7 @@ class xFuserArgs:
     no_use_resolution_binning: bool = False
     seed: int = 42
     output_type: str = "pil"
-    guidance_scale: float = 0.0
+    guidance_scale: float = 3.5
     enable_model_cpu_offload: bool = False
     enable_sequential_cpu_offload: bool = False
     enable_tiling: bool = False
@@ -294,7 +294,7 @@ class xFuserArgs:
         input_group.add_argument(
             "--guidance_scale",
             type=float,
-            default=0.0,
+            default=3.5,
             help="Guidance scale for classifier free guidance.",
         )
         runtime_group.add_argument(

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -100,6 +100,7 @@ class xFuserArgs:
     no_use_resolution_binning: bool = False
     seed: int = 42
     output_type: str = "pil"
+    guidance_scale: float = 0.0
     enable_model_cpu_offload: bool = False
     enable_sequential_cpu_offload: bool = False
     enable_tiling: bool = False
@@ -290,6 +291,12 @@ class xFuserArgs:
             default="pil",
             help="Output type of the pipeline.",
         )
+        input_group.add_argument(
+            "--guidance_scale",
+            type=float,
+            default=0.0,
+            help="Guidance scale for classifier free guidance.",
+        )
         runtime_group.add_argument(
             "--enable_sequential_cpu_offload",
             action="store_true",
@@ -452,6 +459,7 @@ class xFuserArgs:
             max_sequence_length=self.max_sequence_length,
             seed=self.seed,
             output_type=self.output_type,
+            guidance_scale=self.guidance_scale,
         )
 
         return engine_config, input_config

--- a/xfuser/config/config.py
+++ b/xfuser/config/config.py
@@ -263,7 +263,7 @@ class InputConfig:
     max_sequence_length: int = 256
     seed: int = 42
     output_type: str = "pil"
-    guidance_scale: float = 0.0
+    guidance_scale: float = 3.5
 
     def __post_init__(self):
         if isinstance(self.prompt, list):

--- a/xfuser/config/config.py
+++ b/xfuser/config/config.py
@@ -263,6 +263,7 @@ class InputConfig:
     max_sequence_length: int = 256
     seed: int = 42
     output_type: str = "pil"
+    guidance_scale: float = 0.0
 
     def __post_init__(self):
         if isinstance(self.prompt, list):

--- a/xfuser/model_executor/pipelines/pipeline_flux.py
+++ b/xfuser/model_executor/pipelines/pipeline_flux.py
@@ -114,7 +114,7 @@ class xFuserFluxPipeline(xFuserPipelineBaseWrapper):
         width: Optional[int] = None,
         num_inference_steps: int = 28,
         timesteps: List[int] = None,
-        guidance_scale: float = 7.0,
+        guidance_scale: float = 3.5,
         num_images_per_prompt: Optional[int] = 1,
         generator: Optional[Union[torch.Generator, List[torch.Generator]]] = None,
         latents: Optional[torch.FloatTensor] = None,


### PR DESCRIPTION
Since the default value of guidance_scale in diffusers was changed from 7.0 to 3.5, the outputs of examples/flux_examples.py now differ between the XDiT forward and the naive forward implementations.
- default value of guidance_scale in diffusers
https://github.com/huggingface/diffusers/blob/f4fa3beee7f49b80ce7a58f9c8002f43299175c9/src/diffusers/pipelines/flux/pipeline_flux.py#L640
- diffusers commit
https://github.com/huggingface/diffusers/commit/089cf798eb199ddc0d396c7bbb0172fecf2845e9