### PR TITLE
Change opencv-python, pytest, and imageio requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
+from setuptools import find_packages, setup
 import subprocess
 
-from setuptools import find_packages, setup
 
 
 def get_cuda_version():
@@ -55,7 +55,7 @@ if __name__ == "__main__":
             ],
             "ray": [
                 "ray",  # NOTE: ray is necessary if RayDiffusionPipeline is used
-            ],
+            ]
         },
         url="https://github.com/xdit-project/xDiT.",
         description="A Scalable Inference Engine for Diffusion Transformers (DiTs) on Multiple Computing Devices",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ from setuptools import find_packages, setup
 import subprocess
 
 
-
 def get_cuda_version():
     try:
         nvcc_version = subprocess.check_output(["nvcc", "--version"]).decode("utf-8")
@@ -34,10 +33,6 @@ if __name__ == "__main__":
             "beautifulsoup4>=4.12.3",
             "distvae",
             "yunchang>=0.6.0",
-            "pytest",
-            "opencv-python-headless",
-            "imageio",
-            "imageio-ffmpeg",
             "einops",
         ],
         extras_require={
@@ -55,6 +50,14 @@ if __name__ == "__main__":
             ],
             "ray": [
                 "ray",  # NOTE: ray is necessary if RayDiffusionPipeline is used
+            ],
+            "opencv-python": [
+                "opencv-python-headless", # NOTE: opencv-python is necessary if ConsisIDPipeline is used
+            ],
+            "test": [
+                "pytest",
+                "imageio",
+                "imageio-ffmpeg"
             ]
         },
         url="https://github.com/xdit-project/xDiT.",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
-from setuptools import find_packages, setup
 import subprocess
+
+from setuptools import find_packages, setup
 
 
 def get_cuda_version():
@@ -34,7 +35,7 @@ if __name__ == "__main__":
             "distvae",
             "yunchang>=0.6.0",
             "pytest",
-            "opencv-python",
+            "opencv-python-headless",
             "imageio",
             "imageio-ffmpeg",
             "einops",
@@ -54,7 +55,7 @@ if __name__ == "__main__":
             ],
             "ray": [
                 "ray",  # NOTE: ray is necessary if RayDiffusionPipeline is used
-            ]
+            ],
         },
         url="https://github.com/xdit-project/xDiT.",
         description="A Scalable Inference Engine for Diffusion Transformers (DiTs) on Multiple Computing Devices",


### PR DESCRIPTION
- The code in [xfuser.model_executor.pipelines.pipeline_consisid](https://github.com/xdit-project/xDiT/blob/main/xfuser/model_executor/pipelines/pipeline_consisid.py) doesn't use any of the GUI functionality in cv2, so opencv-python-headless is simplified dependency.
- pytest is not required to install xfusers
- imageio and imageio-ffmpeg is only used in examples


I also wanted to remove sentencepiece and beautifulsoup4, as neither appear to be used
