### PR TITLE
ADD FP8 forward for FA3

### DIFF
--- a/xfuser/core/long_ctx_attention/hybrid/attn_layer.py
+++ b/xfuser/core/long_ctx_attention/hybrid/attn_layer.py
@@ -32,6 +32,9 @@ class xFuserLongContextAttention(LongContextAttention):
         use_sync: bool = False,
         attn_type: AttnType = AttnType.FA,
         attn_processor: torch.nn.Module = None,
+        q_descale=None,
+        k_descale=None,
+        v_descale=None,
     ) -> None:
         """
         Arguments:
@@ -52,6 +55,9 @@ class xFuserLongContextAttention(LongContextAttention):
             attn_type = attn_type,
         )
         self.use_kv_cache = use_kv_cache
+        self.q_descale = q_descale
+        self.k_descale = k_descale
+        self.v_descale = v_descale
         if (
             use_kv_cache
             and ring_impl_type not in self.ring_impl_type_supported_kv_cache
@@ -192,6 +198,9 @@ class xFuserLongContextAttention(LongContextAttention):
             joint_tensor_key=joint_tensor_key,
             joint_tensor_value=joint_tensor_value,
             joint_strategy=joint_strategy,
+            q_descale=self.q_descale,
+            k_descale=self.k_descale,
+            v_descale=self.v_descale,
         )
 
         if type(out) == tuple:

--- a/xfuser/core/long_ctx_attention/ring/ring_flash_attn.py
+++ b/xfuser/core/long_ctx_attention/ring/ring_flash_attn.py
@@ -31,6 +31,9 @@ def xdit_ring_flash_attn_forward(
     joint_tensor_key=None,
     joint_tensor_value=None,
     joint_strategy="none",
+    q_descale=None,
+    k_descale=None,
+    v_descale=None
 ):
     is_joint = False
     if (joint_tensor_key is not None and 
@@ -90,18 +93,32 @@ def xdit_ring_flash_attn_forward(
 
         if not causal or step <= comm.rank:
             fn = select_flash_attn_impl(attn_type, stage="fwd-only", attn_processor=attn_processor)
-            block_out, block_lse = fn(
-                q,
-                key,
-                value,
-                dropout_p=dropout_p,
-                softmax_scale=softmax_scale,
-                causal=causal and step == 0,
-                window_size=window_size,
-                softcap=0.0,
-                alibi_slopes=alibi_slopes,
-                return_softmax=True and dropout_p > 0,
-            )
+            if attn_type == AttnType.FA3: 
+                block_out, block_lse = fn(
+                    q,
+                    key,
+                    value,
+                    dropout_p=dropout_p,
+                    softmax_scale=softmax_scale,
+                    causal=causal and step == 0,
+                    window_size=window_size,
+                    softcap=0.0,
+                    alibi_slopes=alibi_slopes,
+                    return_softmax=True and dropout_p > 0,
+                )
+            else:
+                block_out, block_lse = fn(
+                    q,
+                    key,
+                    value,
+                    dropout_p=dropout_p,
+                    softmax_scale=softmax_scale,
+                    causal=causal and step == 0,
+                    window_size=window_size,
+                    softcap=0.0,
+                    alibi_slopes=alibi_slopes,
+                    return_softmax=True and dropout_p > 0,
+                )
             if attn_type == AttnType.SPARSE_SAGE:
                 out, lse = block_out, block_lse
             else:
@@ -198,23 +215,50 @@ def xdit_ring_flash_attn_func(
     joint_tensor_key=None,
     joint_tensor_value=None,
     joint_strategy="none",
+    q_descale=None,
+    k_descale=None,
+    v_descale=None,
 ):
-    return xFuserRingFlashAttnFunc.apply(
-        q,
-        k,
-        v,
-        dropout_p,
-        softmax_scale,
-        causal,
-        window_size,
-        alibi_slopes,
-        deterministic,
-        return_attn_probs,
-        group,
-        attn_type,
-        attn_processor,
-        attn_layer,
-        joint_tensor_key,
-        joint_tensor_value,
-        joint_strategy,
-    )
+    if attn_type == AttnType.FA3:
+        return xFuserRingFlashAttnFunc.apply(
+            q,
+            k,
+            v,
+            dropout_p,
+            softmax_scale,
+            causal,
+            window_size,
+            alibi_slopes,
+            deterministic,
+            return_attn_probs,
+            group,
+            attn_type,
+            attn_processor,
+            attn_layer,
+            joint_tensor_key,
+            joint_tensor_value,
+            joint_strategy,
+            q_descale=q_descale,
+            k_descale=k_descale,
+            v_descale=v_descale
+        )
+    else:
+        return xFuserRingFlashAttnFunc.apply(
+            q,
+            k,
+            v,
+            dropout_p,
+            softmax_scale,
+            causal,
+            window_size,
+            alibi_slopes,
+            deterministic,
+            return_attn_probs,
+            group,
+            attn_type,
+            attn_processor,
+            attn_layer,
+            joint_tensor_key,
+            joint_tensor_value,
+            joint_strategy,
+        )


### PR DESCRIPTION
FA3 now supports FP8 (torch.float8_e4m3fn) reasoning. However, the forward stage still lacks FP8 support. 

I added the necessary parameters qkv scale for quantization and selected the Attention that supports FP8 for forwarding according to AttnType in yunchang (USP). This function will support USP forward of FP8 quantization.

In addition, pull requests have been initiated for quantization-related parameter support for yunchang and FA3.

yunchang (USP): https://github.com/feifeibear/long-context-attention/pull/151（merged into main）
FA3: https://github.com/Dao-AILab/flash-attention/pull/1686