### PR TITLE
[fix] move all platform dependent code to xfuser/envs.py

### DIFF
--- a/xfuser/core/distributed/group_coordinator.py
+++ b/xfuser/core/distributed/group_coordinator.py
@@ -136,14 +136,7 @@ class GroupCoordinator:
         assert self.cpu_group is not None
         assert self.device_group is not None
 
-        if torch.cuda.is_available():
-            self.device = torch.device(f"cuda:{local_rank}")
-        else:
-            try:
-                if torch.musa.is_available():
-                    self.device = torch.device(f"musa:{local_rank}")
-            except ModuleNotFoundError:
-                self.device = torch.device("cpu")
+        self.device = envs.get_device(local_rank)
 
     @property
     def first_rank(self):
@@ -703,14 +696,7 @@ class PipelineGroupCoordinator(GroupCoordinator):
         assert self.cpu_group is not None
         assert self.device_group is not None
 
-        if torch.cuda.is_available():
-            self.device = torch.device(f"cuda:{local_rank}")
-        else:
-            try:
-                if torch.musa.is_available():
-                    self.device = torch.device(f"musa:{local_rank}")
-            except ModuleNotFoundError:
-                self.device = torch.device("cpu")
+        self.device = envs.get_device(local_rank)
 
         self.recv_buffer_set: bool = False
         self.recv_tasks_queue: List[Tuple[str, int]] = []

--- a/xfuser/core/distributed/parallel_state.py
+++ b/xfuser/core/distributed/parallel_state.py
@@ -210,13 +210,8 @@ def init_distributed_environment(
     rank: int = -1,
     distributed_init_method: str = "env://",
     local_rank: int = -1,
-    backend: str = "nccl",
+    backend: str = envs.get_torch_distributed_backend(),
 ):
-    try:
-        if torch.musa.is_available():
-            backend = "mccl"
-    except ModuleNotFoundError:
-        pass
     logger.debug(
         "world_size=%d rank=%d local_rank=%d " "distributed_init_method=%s backend=%s",
         world_size,

--- a/xfuser/core/long_ctx_attention/ring/ring_flash_attn.py
+++ b/xfuser/core/long_ctx_attention/ring/ring_flash_attn.py
@@ -2,7 +2,6 @@ from typing import List
 import math
 import torch
 import torch.nn.functional as F
-from torch.nn.attention.flex_attention import flex_attention
 
 from xfuser.core.long_ctx_attention import xFuserLongContextAttention
 from xfuser.core.cache_manager.cache_manager import get_cache_manager
@@ -165,7 +164,7 @@ class xFuserRingFlashAttnFunc(RingFlashAttnFunc):
         joint_strategy,
     ):
         if softmax_scale is None:
-            softmax_scale = q.shape[-1] ** (-0.5)
+            softmax_scale = 1.0 / math.sqrt(q.size(-1))
 
         assert alibi_slopes is None
         if attn_layer is None:


### PR DESCRIPTION
# Description

The source code of xDiT contains few problems:

1. In file `xfuser/core/long_ctx_attention/ring/ring_flash_attn.py:5` , `flex_attention` was imported but never be used. Since this module is introduced in PyTorch 2.5， adding this unused module may prevent xDiT from applying to the models which requires PyTorch < 2.5.

2. In file `xfuser/core/long_ctx_attention/ring/ring_flash_attn.py:108` , the implicit default `softmax_scale` was calculated via `q.shape[-1] ** (-0.5)`, which truncates to an integer number that brokes the entire workflow. The right way to calculate this value is by `1.0 / math.sqrt(q.size(-1))` which ends up with a float-point number.

3. In `xfuser/core/distributed/parallel_state.py`, [previous patch](https://github.com/xdit-project/xDiT/pull/539) involves platform-dependent codes with try-except blocks. This can be improved by moving all platform-dependent codes to `xfuser/envs.py`.

# Features

* remove unused module `flex_attention` from `xfuser/core/long_ctx_attention/ring/ring_flash_attn.py`.
* get rid of the type trunction error when calculate implicit default `softmax_scale`.
* move platform dependent codes to `xfuser/envs.py`

# Risks

* xDiT is now available on PyTorch < 2.5 environment. But I haven't test lots of those models. The stability and accuracy may not be guaranteed.
