### PR TITLE
Enable AITER in USP code path

### DIFF
--- a/tests/layers/usp_test.py
+++ b/tests/layers/usp_test.py
@@ -63,8 +63,10 @@ class TestUSP(unittest.TestCase):
     def test_ring_attn_flash_attn(self):
         """
         Verifies ring_attn results with flash_attn are close to F.SDPA results
-        Calling ring_attn directly and not through USP due to not using real parallelization
-        which doesn't then call ring_attn at all
+
+        Ring_attn function is called through the USP function when using ring attention, but that requires
+        multi-GPU parallelization, which this test is not using. Therefore the function is called
+        directly to test its output.
         """
         if not self.HAS_FLASH_ATTN:
             self.skipTest("flash_attn library is not available in the environment.")
@@ -103,8 +105,10 @@ class TestUSP(unittest.TestCase):
     def test_ring_attn_aiter(self):
         """
         Verifies ring_attn results with aiter are close to F.SDPA results
-        Calling ring_attn directly and not through USP due to not using real parallelization,
-        which doesn't then call ring_attn at all
+
+        Ring_attn function is called through the USP function when using ring attention, but that requires
+        multi-GPU parallelization, which this test is not using. Therefore the function is called
+        directly to test its output.
         """
         if not self.HAS_AITER:
             self.skipTest("aiter library is not available in the environment.")

--- a/tests/layers/usp_test.py
+++ b/tests/layers/usp_test.py
@@ -72,10 +72,10 @@ class TestUSP(unittest.TestCase):
         # Disabling flash_attn and aiter to get SDPA results
         usp.HAS_FLASH_ATTN = False
         usp.HAS_AITER = False
-        fsdpa_results = usp.USP(self.query, self.key, self.value, dropout_p=0.0, is_causal=False)
+        fsdpa_results = usp.ring_attn(self.query, self.key, self.value, dropout_p=0.0, is_causal=False)
 
         usp.HAS_FLASH_ATTN = True
-        flash_attn_results = usp.USP(self.query, self.key, self.value, dropout_p=0.0, is_causal=False)
+        flash_attn_results = usp.ring_attn(self.query, self.key, self.value, dropout_p=0.0, is_causal=False)
 
         result_diff = (fsdpa_results - flash_attn_results).abs().max()
         self.assertNotEqual(result_diff, 0) # Different implementations won't produce same output

--- a/tests/layers/usp_test.py
+++ b/tests/layers/usp_test.py
@@ -1,0 +1,122 @@
+import os
+import torch
+import unittest
+import importlib
+from xfuser.envs import PACKAGES_CHECKER
+from xfuser.model_executor.layers import usp
+
+from xfuser.core.distributed import (
+    init_distributed_environment,
+    initialize_model_parallel,
+    get_runtime_state,
+)
+from xfuser.core.distributed.parallel_state import destroy_model_parallel, destroy_distributed_environment
+
+
+class TestUSP(unittest.TestCase):
+
+    def setUp(self):
+        self._init_environment()
+        env_info = PACKAGES_CHECKER.get_packages_info()
+        self.HAS_FLASH_ATTN = env_info["has_flash_attn"]
+        self.HAS_AITER = env_info["has_aiter"]
+        self.query = torch.randn(29760, 2, 5, 128, device="cuda", dtype=torch.bfloat16)
+        self.key = torch.randn(29760, 2, 5, 128, device="cuda", dtype=torch.bfloat16)
+        self.value = torch.randn(29760, 2, 5, 128, device="cuda", dtype=torch.bfloat16)
+
+
+    def _init_environment(self):
+        os.environ["RANK"] = "0"
+        os.environ["WORLD_SIZE"] = "1"
+        os.environ["MASTER_ADDR"] = "localhost"
+        os.environ["MASTER_PORT"] = "12355"
+        os.environ["LOCAL_RANK"] = "0"
+        init_distributed_environment(rank=0, world_size=1)
+        initialize_model_parallel(ring_degree=1, ulysses_degree=1)
+
+
+
+    def tearDown(self):
+        destroy_model_parallel()
+        destroy_distributed_environment()
+
+
+    def test_usp_flash_attn(self):
+        """
+        Verifies USP results with flash_attn are close to F.SDPA results
+        """
+        if not self.HAS_FLASH_ATTN:
+            self.skipTest("flash_attn library is not available in the environment.")
+
+        # Disabling flash_attn and aiter to get SDPA results
+        usp.HAS_FLASH_ATTN = False
+        usp.HAS_AITER = False
+        fsdpa_results = usp.USP(self.query, self.key, self.value, dropout_p=0.0, is_causal=False)
+
+        usp.HAS_FLASH_ATTN = True
+        flash_attn_results = usp.USP(self.query, self.key, self.value, dropout_p=0.0, is_causal=False)
+
+        result_diff = (fsdpa_results - flash_attn_results).abs().max()
+        self.assertNotEqual(result_diff, 0) # Different implementations won't produce same output
+        self.assertAlmostEqual(result_diff.item(), 0, places=1) # Difference can be 0.15ish
+
+    def test_ring_attn_flash_attn(self):
+        """
+        Verifies ring_attn results with flash_attn are close to F.SDPA results
+        Calling ring_attn directly and not through USP due to not using real parallelization
+        which doesn't then call ring_attn at all
+        """
+        if not self.HAS_FLASH_ATTN:
+            self.skipTest("flash_attn library is not available in the environment.")
+
+        # Disabling flash_attn and aiter to get SDPA results
+        usp.HAS_FLASH_ATTN = False
+        usp.HAS_AITER = False
+        fsdpa_results = usp.USP(self.query, self.key, self.value, dropout_p=0.0, is_causal=False)
+
+        usp.HAS_FLASH_ATTN = True
+        flash_attn_results = usp.USP(self.query, self.key, self.value, dropout_p=0.0, is_causal=False)
+
+        result_diff = (fsdpa_results - flash_attn_results).abs().max()
+        self.assertNotEqual(result_diff, 0) # Different implementations won't produce same output
+        self.assertAlmostEqual(result_diff.item(), 0, places=1) # Difference can be 0.15ish
+
+    def test_usp_aiter(self):
+        """
+        Verifies USP results with aiter are close to F.SDPA results
+        """
+        if not self.HAS_AITER:
+            self.skipTest("aiter library is not available in the environment.")
+
+        # Disabling flash_attn and aiter to get SDPA results
+        usp.HAS_FLASH_ATTN = False
+        usp.HAS_AITER = False
+        fsdpa_results = usp.USP(self.query, self.key, self.value, dropout_p=0.0, is_causal=False)
+
+        usp.HAS_AITER = True
+        aiter_attn_results = usp.USP(self.query, self.key, self.value, dropout_p=0.0, is_causal=False)
+
+        result_diff = (fsdpa_results - aiter_attn_results).abs().max()
+        self.assertNotEqual(result_diff, 0) # Different implementations won't produce same output
+        self.assertAlmostEqual(result_diff.item(), 0, places=1) # Difference can be 0.15ish
+
+    def test_ring_attn_aiter(self):
+        """
+        Verifies ring_attn results with aiter are close to F.SDPA results
+        Calling ring_attn directly and not through USP due to not using real parallelization,
+        which doesn't then call ring_attn at all
+        """
+        if not self.HAS_AITER:
+            self.skipTest("aiter library is not available in the environment.")
+
+        # Disabling flash_attn and aiter to get SDPA results
+        usp.HAS_FLASH_ATTN = False
+        usp.HAS_AITER = False
+        fsdpa_results = usp.ring_attn(self.query, self.key, self.value, dropout_p=0.0, is_causal=False)
+
+        usp.HAS_AITER = True
+        aiter_attn_results = usp.ring_attn(self.query, self.key, self.value, dropout_p=0.0, is_causal=False)
+
+        result_diff = (fsdpa_results - aiter_attn_results).abs().max()
+        self.assertNotEqual(result_diff, 0) # Different implementations won't produce same output
+        self.assertAlmostEqual(result_diff.item(), 0, places=1) # Difference can be 0.15ish

--- a/xfuser/envs.py
+++ b/xfuser/envs.py
@@ -153,10 +153,28 @@ class PackagesEnvChecker:
 
     def initialize(self):
         self.packages_info = {
+            "has_aiter": self.check_aiter(),
             "has_flash_attn": self.check_flash_attn(),
             "has_long_ctx_attn": self.check_long_ctx_attn(),
             "diffusers_version": self.check_diffusers_version(),
         }
+
+    def check_aiter(self):
+        """
+        Checks whether ROCm AITER library is installed
+        """
+        try:
+            import aiter
+            logger.info("Using AITER as the attention library")
+            return True
+        except:
+            if _is_hip():
+                logger.warning(
+                    f'Using AMD GPUs, but library "aiter" is not installed, '
+                    'defaulting to other attention mechanisms'
+                )
+            return False
+
 
     def check_flash_attn(self):
         if _is_musa():

--- a/xfuser/model_executor/layers/usp.py
+++ b/xfuser/model_executor/layers/usp.py
@@ -14,7 +14,7 @@ from xfuser.core.distributed import (
     get_ring_parallel_world_size,
 )
 
-from packaging.veresion import parse
+from packaging.version import parse
 from xfuser.envs import PACKAGES_CHECKER
 env_info = PACKAGES_CHECKER.get_packages_info()
 HAS_FLASH_ATTN = env_info["has_flash_attn"]

--- a/xfuser/model_executor/layers/usp.py
+++ b/xfuser/model_executor/layers/usp.py
@@ -14,26 +14,38 @@ from xfuser.core.distributed import (
     get_ring_parallel_world_size,
 )
 
+from packaging.veresion import parse
 from xfuser.envs import PACKAGES_CHECKER
 env_info = PACKAGES_CHECKER.get_packages_info()
 HAS_FLASH_ATTN = env_info["has_flash_attn"]
+HAS_AITER = env_info["has_aiter"]
 
 aten = torch.ops.aten
 
-    
+
 def ring_attn(query, key, value, dropout_p=0.0, is_causal=False):
-    if torch.__version__ >= "2.6.0":
+    if parse(torch.__version__).release >= parse("2.6.0").release:
         from torch.distributed.tensor.experimental._attention import _cp_options
         _cp_options.enable_load_balance = False
         kwargs = {
             "dropout_p": dropout_p,
             "is_causal": is_causal,
         }
-        if HAS_FLASH_ATTN:
+        if HAS_AITER:
             out, *_ = _templated_ring_attention(
                 PROCESS_GROUP.RING_PG,
                 1,
-                aten._scaled_dot_product_flash_attention,
+                _aiter_attn_call,
+                query,
+                key,
+                value,
+                **kwargs,
+            )
+        elif HAS_FLASH_ATTN:
+            out, *_ = _templated_ring_attention(
+                PROCESS_GROUP.RING_PG,
+                1,
+                _flash_attn_call,
                 query,
                 key,
                 value,
@@ -59,10 +71,20 @@ def ring_attn(query, key, value, dropout_p=0.0, is_causal=False):
             "dropout_p": dropout_p,
             "is_causal": is_causal,
         }
-        if HAS_FLASH_ATTN:
+        if HAS_AITER:
             out, *_ = _templated_ring_attention(
                 PROCESS_GROUP.RING_PG,
-                aten._scaled_dot_product_flash_attention,
+                1,
+                _aiter_attn_call,
+                query,
+                key,
+                value,
+                **kwargs,
+            )
+        elif HAS_FLASH_ATTN:
+            out, *_ = _templated_ring_attention(
+                PROCESS_GROUP.RING_PG,
+                _flash_attn_call,
                 query,
                 key,
                 value,
@@ -133,6 +155,61 @@ def _ft_c_output_all_to_all(x):
     x = x.reshape(world_size, s // world_size, b, -1, d).permute(2, 0, 3, 1, 4).reshape(b, -1, s // world_size, d)
     return x
 
+def _aiter_attn_call(query, key, value, dropout_p, is_causal):
+    """
+    Performs the necessary tensor permutes and
+    then calls attention through AITER
+    """
+    import aiter
+    query = torch.permute(query, [0, 2, 1, 3]).contiguous()
+    key = torch.permute(key, [0, 2, 1, 3]).contiguous()
+    value = torch.permute(value, [0, 2, 1, 3]).contiguous()
+    output, softmax_lse = aiter.flash_attn_func(
+        query,
+        key,
+        value,
+        dropout_p=dropout_p,
+        causal=is_causal,
+        return_attn_probs=False,
+        return_lse=True
+    )
+    output = torch.permute(output, [0, 2, 1, 3])
+    return output, softmax_lse
+
+def _flash_attn_call(query, key, value, dropout_p, is_causal):
+    """
+    Performs the necessary tensor permutes and
+    then calls attention through flash_attn
+    """
+    import flash_attn
+    query = torch.permute(query, [0, 2, 1, 3])
+    key = torch.permute(key, [0, 2, 1, 3])
+    value = torch.permute(value, [0, 2, 1, 3])
+    output, softmax_lse = flash_attn.flash_attn_func(
+        query,
+        key,
+        value,
+        dropout_p=dropout_p,
+        causal=is_causal,
+        return_attn_probs=True,
+    )
+    output = torch.permute(output, [0, 2, 1, 3])
+    return output, softmax_lse
+
+def _attention(query, key, value, dropout_p, is_causal):
+    """
+    Calls the correct attention mechanism based on the available libraries
+    """
+    if HAS_AITER:
+        output, _ = _aiter_attn_call(query, key, value, dropout_p, is_causal)
+        return output
+    elif HAS_FLASH_ATTN:
+        output, _ = _flash_attn_call(query, key, value, dropout_p, is_causal)
+        return output
+    else:
+        return F.scaled_dot_product_attention(
+            query, key, value, dropout_p=dropout_p, is_causal=is_causal
+        )
 
 def USP(query, key, value, dropout_p=0.0, is_causal=False):
     if get_sequence_parallel_world_size() == 1:
@@ -154,5 +231,5 @@ def USP(query, key, value, dropout_p=0.0, is_causal=False):
             out = ring_attn(query, key, value, dropout_p=dropout_p, is_causal=is_causal)
 
         out = _ft_c_output_all_to_all(out)
-        
+
     return out

--- a/xfuser/model_executor/layers/usp.py
+++ b/xfuser/model_executor/layers/usp.py
@@ -18,7 +18,12 @@ from packaging.version import parse
 from xfuser.envs import PACKAGES_CHECKER
 env_info = PACKAGES_CHECKER.get_packages_info()
 HAS_FLASH_ATTN = env_info["has_flash_attn"]
+if HAS_FLASH_ATTN:
+    import flash_attn
+
 HAS_AITER = env_info["has_aiter"]
+if HAS_AITER:
+    import aiter
 
 aten = torch.ops.aten
 
@@ -160,7 +165,6 @@ def _aiter_attn_call(query, key, value, dropout_p, is_causal):
     Performs the necessary tensor permutes and
     then calls attention through AITER
     """
-    import aiter
     query = torch.permute(query, [0, 2, 1, 3]).contiguous()
     key = torch.permute(key, [0, 2, 1, 3]).contiguous()
     value = torch.permute(value, [0, 2, 1, 3]).contiguous()
@@ -181,7 +185,6 @@ def _flash_attn_call(query, key, value, dropout_p, is_causal):
     Performs the necessary tensor permutes and
     then calls attention through flash_attn
     """
-    import flash_attn
     query = torch.permute(query, [0, 2, 1, 3])
     key = torch.permute(key, [0, 2, 1, 3])
     value = torch.permute(value, [0, 2, 1, 3])


### PR DESCRIPTION
## What?
This PR enables AITER flash attention (https://github.com/ROCm/aiter) usage in USP code path as well as implements an attention mechanism decision tree for AITER, flash_attn and SDPA. 

## Why?
The best and fastest attention kernels available for AMD GPUs are nowadays pushed through the AITER library. Enabling the usage of this allows people with AMD GPUs to fully utilize them. Currently, FA through AITER is approximately 10-15% faster than through `flash_attn` library.

## Testing
This PR also contains new unit tests for the attention decision tree. They run one set of QKV values through the other attention mechanisms (aiter, flash_attn) and compares them against SDPA to make sure there's no degradation in quality.

Running `pytest tests/layers/usp_test.py` we get:
```
0.38s call     tests/layers/usp_test.py::TestUSP::test_ring_attn_aiter
0.11s call     tests/layers/usp_test.py::TestUSP::test_usp_aiter
0.10s call     tests/layers/usp_test.py::TestUSP::test_usp_flash_attn
0.10s call     tests/layers/usp_test.py::TestUSP::test_ring_attn_flash_attn

(8 durations < 0.005s hidden.  Use -vv to show these durations.)
===== 4 passed in 17.92s ===========
```

## Extra
Also changed the flash attention called in `ring_attn` function to use `flash_attn`, not `scaled_dot_product_flash_attention`, which is a slower implementation.