### PR TITLE
Add possibility to call AttnType.Aiter

### DIFF
--- a/xfuser/envs.py
+++ b/xfuser/envs.py
@@ -153,10 +153,27 @@ class PackagesEnvChecker:
 
     def initialize(self):
         self.packages_info = {
+            "has_aiter": self.check_aiter(),
             "has_flash_attn": self.check_flash_attn(),
             "has_long_ctx_attn": self.check_long_ctx_attn(),
             "diffusers_version": self.check_diffusers_version(),
         }
+
+    def check_aiter(self):
+        """
+        Checks whether ROCm AITER library is installed
+        """
+        try:
+            import aiter
+            logger.info("Using AITER as the attention library")
+            return True
+        except:
+            if _is_hip():
+                logger.warning(
+                    f'Using AMD GPUs, but library "aiter" is not installed, '
+                    'defaulting to other attention mechanisms'
+                )
+            return False
 
     def check_flash_attn(self):
         if _is_musa():

--- a/xfuser/model_executor/layers/attention_processor.py
+++ b/xfuser/model_executor/layers/attention_processor.py
@@ -1398,7 +1398,8 @@ if HunyuanVideoAttnProcessor2_0 is not None:
                 )
                 from yunchang.kernels import AttnType
                 
-                if HAS_AITER and 'AITER' in AttnType.__members__:
+                if HAS_AITER:
+                    assert 'AITER' in AttnType.__members__, f"AttnType.AITER not implemented in existing yunchang version {yunchang.__version__}, consider upgrading."
                     self.hybrid_seq_parallel_attn = xFuserLongContextAttention(
                         use_kv_cache=self.use_long_ctx_attn_kvcache,
                         attn_type=AttnType.AITER,

--- a/xfuser/model_executor/layers/attention_processor.py
+++ b/xfuser/model_executor/layers/attention_processor.py
@@ -51,6 +51,7 @@ else:
 logger = init_logger(__name__)
 
 env_info = PACKAGES_CHECKER.get_packages_info()
+HAS_AITER = env_info["has_aiter"]
 HAS_LONG_CTX_ATTN = env_info["has_long_ctx_attn"]
 HAS_FLASH_ATTN = env_info["has_flash_attn"]
 
@@ -1395,14 +1396,18 @@ if HunyuanVideoAttnProcessor2_0 is not None:
                 from xfuser.core.long_ctx_attention import (
                     xFuserLongContextAttention,
                 )
-
-                if HAS_FLASH_ATTN:
+                from yunchang.kernels import AttnType
+                
+                if HAS_AITER and 'AITER' in AttnType.__members__:
+                    self.hybrid_seq_parallel_attn = xFuserLongContextAttention(
+                        use_kv_cache=self.use_long_ctx_attn_kvcache,
+                        attn_type=AttnType.AITER,
+                    )
+                elif HAS_FLASH_ATTN:
                     self.hybrid_seq_parallel_attn = xFuserLongContextAttention(
                         use_kv_cache=self.use_long_ctx_attn_kvcache
                     )
                 else:
-                    from yunchang.kernels import AttnType
-
                     self.hybrid_seq_parallel_attn = xFuserLongContextAttention(
                         use_kv_cache=self.use_long_ctx_attn_kvcache,
                         attn_type=AttnType.TORCH,

--- a/xfuser/model_executor/layers/attention_processor.py
+++ b/xfuser/model_executor/layers/attention_processor.py
@@ -73,6 +73,9 @@ def torch_compile_disable_if_v100(func):
 
 
 def set_hybrid_seq_parallel_attn(self, use_long_ctx_attn_kvcache):
+    """
+    Initialize hybrid sequence-parallel attention based on available backend.
+    """
     if HAS_LONG_CTX_ATTN and get_sequence_parallel_world_size() > 1:
         from xfuser.core.long_ctx_attention import (
             xFuserLongContextAttention,
@@ -80,7 +83,7 @@ def set_hybrid_seq_parallel_attn(self, use_long_ctx_attn_kvcache):
         from yunchang.kernels import AttnType
 
         if HAS_AITER:
-            assert 'AITER' in AttnType.__members__, f"AttnType.AITER not implemented in existing yunchang version: {yunchang.__version__}, consider upgrading."
+            assert 'AITER' in AttnType.__members__, f"AttnType.AITER not implemented in yunchang version: {yunchang.__version__}. Upgrade to latest version from source."
             self.hybrid_seq_parallel_attn = xFuserLongContextAttention(
                     use_kv_cache=self.use_long_ctx_attn_kvcache,
                     attn_type=AttnType.AITER,


### PR DESCRIPTION
## Purpose
This PR implements a new AttnType `AttnType.AITER` which together with [this PR](https://github.com/feifeibear/long-context-attention/pull/159) would enable the use of [AITER](https://github.com/ROCm/aiter) flash forward kernels when calling xFuserLongContextAttention.

## Motivation
The fastest attention kernels for AMD GPUs are nowadays provided through Aiter. For people with supporting hardware, choosing this implementation improves flash-attention inference times by roughly 10-15% compared to the standard flash_attn library.

## Testing
Updated and ran existing unit test-file `/tests/core/test_xfuser_attn.py` to run with different backends and dtypes.

## Additional updates
Refactored selection of hybrid_seq_parallel_attention into it's own function.
