### PR TITLE
Fix broken hybrid attention code path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ if __name__ == "__main__":
         author_email="fangjiarui123@gmail.com",
         packages=find_packages(),
         install_requires=[
-            "torch==2.4.1",
+            "torch>=2.4.1",
             "accelerate>=0.33.0",
             "transformers>=4.39.1",
             "sentencepiece>=0.1.99",

--- a/xfuser/core/long_ctx_attention/hybrid/attn_layer.py
+++ b/xfuser/core/long_ctx_attention/hybrid/attn_layer.py
@@ -63,10 +63,6 @@ class xFuserLongContextAttention(LongContextAttention):
             use_sync=use_sync,
             attn_type = attn_type,
         )
-        if attn_type is None:
-            if torch.cuda.is_available():
-                from yunchang.kernels import AttnType
-                attn_type = AttnType.FA
         self.use_kv_cache = use_kv_cache
         self.q_descale = q_descale
         self.k_descale = k_descale
@@ -231,25 +227,21 @@ class xFuserLongContextAttention(LongContextAttention):
         return output
 
 class xFuserSanaLinearLongContextAttention(xFuserLongContextAttention):
-    def __init__(self, 
-                 scatter_idx: int = 2, 
-                 gather_idx: int = 1, 
-                 ring_impl_type: str = "basic", 
-                 use_pack_qkv: bool = False, 
-                 use_kv_cache: bool = False, 
+    def __init__(self,
+                 scatter_idx: int = 2,
+                 gather_idx: int = 1,
+                 ring_impl_type: str = "basic",
+                 use_pack_qkv: bool = False,
+                 use_kv_cache: bool = False,
                  attn_type: AttnType = None,
                  attn_processor: torch.nn.Module = None):
-        if attn_type is None:
-            if torch.cuda.is_available():
-                from yunchang.kernels import AttnType
-                attn_type = AttnType.FA
         super().__init__(scatter_idx, gather_idx, ring_impl_type, use_pack_qkv, use_kv_cache, attn_type, attn_processor)
         # TODO need to check the attn_type
         from xfuser.core.long_ctx_attention.ring import xdit_sana_ring_flash_attn_func
         self.ring_attn_fn = xdit_sana_ring_flash_attn_func
         # self.ring_attn_fn = xdit_sana_linear_ring_flash_attn_func
         self.ring_world_size = get_ring_parallel_world_size()
-    
+
     def forward(
         self,
         attn,

--- a/xfuser/core/long_ctx_attention/ring/ring_flash_attn.py
+++ b/xfuser/core/long_ctx_attention/ring/ring_flash_attn.py
@@ -21,10 +21,6 @@ try:
 except ImportError:
     flash_attn = None
     _flash_attn_forward = None
-    if torch.cuda.is_available():
-        from yunchang.kernels.attention import pytorch_attn_forward
-    else:
-        pytorch_attn_forward = None
 
 def xdit_ring_flash_attn_forward(
     process_group,

--- a/xfuser/model_executor/layers/attention_processor.py
+++ b/xfuser/model_executor/layers/attention_processor.py
@@ -54,6 +54,9 @@ env_info = PACKAGES_CHECKER.get_packages_info()
 HAS_LONG_CTX_ATTN = env_info["has_long_ctx_attn"]
 HAS_FLASH_ATTN = env_info["has_flash_attn"]
 
+if HAS_LONG_CTX_ATTN:
+    from yunchang.kernels import AttnType
+
 
 def is_v100():
     if not torch.cuda.is_available():
@@ -195,15 +198,11 @@ class xFuserAttnProcessor2_0(AttnProcessor2_0):
             )
 
             if HAS_FLASH_ATTN:
-                # self.hybrid_seq_parallel_attn = LongContextAttention()
                 self.hybrid_seq_parallel_attn = xFuserLongContextAttention(
-                    use_kv_cache=self.use_long_ctx_attn_kvcache
+                    use_kv_cache=self.use_long_ctx_attn_kvcache,
+                    attn_type=AttnType.FA,
                 )
             else:
-                import yunchang
-                from yunchang.kernels import AttnType
-
-                assert yunchang.__version__ >= "0.6.0"
                 self.hybrid_seq_parallel_attn = xFuserLongContextAttention(
                     use_kv_cache=self.use_long_ctx_attn_kvcache,
                     attn_type=AttnType.TORCH,
@@ -407,11 +406,10 @@ class xFuserJointAttnProcessor2_0(JointAttnProcessor2_0):
 
             if HAS_FLASH_ATTN:
                 self.hybrid_seq_parallel_attn = xFuserLongContextAttention(
-                    use_kv_cache=self.use_long_ctx_attn_kvcache
+                    use_kv_cache=self.use_long_ctx_attn_kvcache,
+                    attn_type=AttnType.FA,
                 )
             else:
-                from yunchang.kernels import AttnType
-
                 self.hybrid_seq_parallel_attn = xFuserLongContextAttention(
                     use_kv_cache=self.use_long_ctx_attn_kvcache,
                     attn_type=AttnType.TORCH,
@@ -640,11 +638,10 @@ class xFuserFluxAttnProcessor2_0(FluxAttnProcessor2_0):
 
             if HAS_FLASH_ATTN:
                 self.hybrid_seq_parallel_attn = xFuserLongContextAttention(
-                    use_kv_cache=self.use_long_ctx_attn_kvcache
+                    use_kv_cache=self.use_long_ctx_attn_kvcache,
+                    attn_type=AttnType.FA,
                 )
             else:
-                from yunchang.kernels import AttnType
-
                 self.hybrid_seq_parallel_attn = xFuserLongContextAttention(
                     use_kv_cache=self.use_long_ctx_attn_kvcache,
                     attn_type=AttnType.TORCH,
@@ -846,11 +843,10 @@ class xFuserHunyuanAttnProcessor2_0(HunyuanAttnProcessor2_0):
 
             if HAS_FLASH_ATTN:
                 self.hybrid_seq_parallel_attn = xFuserLongContextAttention(
-                    use_kv_cache=self.use_long_ctx_attn_kvcache
+                    use_kv_cache=self.use_long_ctx_attn_kvcache,
+                    attn_type=AttnType.FA,
                 )
             else:
-                from yunchang.kernels import AttnType
-
                 self.hybrid_seq_parallel_attn = xFuserLongContextAttention(
                     use_kv_cache=self.use_long_ctx_attn_kvcache,
                     attn_type=AttnType.TORCH,
@@ -1049,11 +1045,10 @@ class xFuserCogVideoXAttnProcessor2_0(CogVideoXAttnProcessor2_0):
 
             if HAS_FLASH_ATTN:
                 self.hybrid_seq_parallel_attn = xFuserLongContextAttention(
-                    use_kv_cache=self.use_long_ctx_attn_kvcache
+                    use_kv_cache=self.use_long_ctx_attn_kvcache,
+                    attn_type=AttnType.FA,
                 )
             else:
-                from yunchang.kernels import AttnType
-
                 self.hybrid_seq_parallel_attn = xFuserLongContextAttention(
                     use_kv_cache=self.use_long_ctx_attn_kvcache,
                     attn_type=AttnType.TORCH,
@@ -1225,11 +1220,10 @@ class xFuserConsisIDAttnProcessor2_0(CogVideoXAttnProcessor2_0):
 
             if HAS_FLASH_ATTN:
                 self.hybrid_seq_parallel_attn = xFuserLongContextAttention(
-                    use_kv_cache=self.use_long_ctx_attn_kvcache
+                    use_kv_cache=self.use_long_ctx_attn_kvcache,
+                    attn_type=AttnType.FA,
                 )
             else:
-                from yunchang.kernels import AttnType
-
                 self.hybrid_seq_parallel_attn = xFuserLongContextAttention(
                     use_kv_cache=self.use_long_ctx_attn_kvcache,
                     attn_type=AttnType.TORCH,
@@ -1398,11 +1392,10 @@ if HunyuanVideoAttnProcessor2_0 is not None:
 
                 if HAS_FLASH_ATTN:
                     self.hybrid_seq_parallel_attn = xFuserLongContextAttention(
-                        use_kv_cache=self.use_long_ctx_attn_kvcache
+                        use_kv_cache=self.use_long_ctx_attn_kvcache,
+                        attn_type=AttnType.FA,
                     )
                 else:
-                    from yunchang.kernels import AttnType
-
                     self.hybrid_seq_parallel_attn = xFuserLongContextAttention(
                         use_kv_cache=self.use_long_ctx_attn_kvcache,
                         attn_type=AttnType.TORCH,
@@ -1686,11 +1679,10 @@ class xFuserSanaLinearAttnProcessor2_0(SanaLinearAttnProcessor2_0):
 
             if HAS_FLASH_ATTN:
                 self.hybrid_seq_parallel_attn = xFuserSanaLinearLongContextAttention(
-                    use_kv_cache=self.use_long_ctx_attn_kvcache
+                    use_kv_cache=self.use_long_ctx_attn_kvcache,
+                    attn_type=AttnType.FA,
                 )
             else:
-                from yunchang.kernels import AttnType
-
                 self.hybrid_seq_parallel_attn = xFuserSanaLinearLongContextAttention(
                     use_kv_cache=self.use_long_ctx_attn_kvcache,
                     attn_type=AttnType.TORCH,


### PR DESCRIPTION
# What?
PR #559 broke the hybrid attention path for all models. This PR adds fixes to alleviate that and allow models to be ran again.

# How?
Previously running any models that used the hybrid code (i.e., used long context attention) path resulted in:
```
[rank3]: ValueError: Unknown flash attention implementation: None
```

This was caused by PR #559 changing the default behaviour, so the default attention type wasn't `AttnType.FA` anymore, instead it was `None`.
This fix explicitly adds the `AttnType.FA` when necessary to all models rather than relying on the default value. This allows the changed default value to stay as `None`, so all devices can run xDiT.
# Extra
Relaxed torch version requirement to be higher than 2.4.1.

@feifeibear 