### PR TITLE
Add NPU support for one model in single card

### DIFF
--- a/xfuser/core/distributed/group_coordinator.py
+++ b/xfuser/core/distributed/group_coordinator.py
@@ -19,6 +19,11 @@ except ModuleNotFoundError:
     pass
 
 import xfuser.envs as envs
+if envs._is_npu():
+    print("torch.npu synchronize")
+    from torch.npu import synchronize
+
+import xfuser.envs as envs
 from xfuser.logger import init_logger
 
 logger = init_logger(__name__)

--- a/xfuser/core/distributed/parallel_state.py
+++ b/xfuser/core/distributed/parallel_state.py
@@ -22,6 +22,11 @@ try:
 except ModuleNotFoundError:
     pass
 
+try:
+    from torch.npu import set_device, device_count
+except ModuleNotFoundError:
+    pass
+
 from .utils import RankGenerator
 
 env_info = envs.PACKAGES_CHECKER.get_packages_info()
@@ -395,6 +400,11 @@ def initialize_model_parallel(
         raise ValueError(
             f"sequence_parallel_degree is not equal to ring_degree * ulysses_degree, {sequence_parallel_degree} != {ring_degree} * {ulysses_degree}"
         )
+
+    # FIXME: Since the async p2p communication operation of NPU is not same as cuda in torch,
+    # the pipefusion is not ready for npu yet
+    if envs._is_npu():
+        assert pipeline_parallel_degree == 1, "Current pipefusion is not ready for NPU"
 
     dit_parallel_size = (
         data_parallel_degree

--- a/xfuser/core/distributed/runtime_state.py
+++ b/xfuser/core/distributed/runtime_state.py
@@ -17,6 +17,10 @@ try:
 except ModuleNotFoundError:
     pass
 
+import xfuser.envs as envs
+if envs._is_npu():
+    from torch.npu import manual_seed as device_manual_seed
+    from torch.npu import manual_seed_all as device_manual_seed_all
 from xfuser.config.config import (
     ParallelConfig,
     RuntimeConfig,

--- a/xfuser/core/utils/timer.py
+++ b/xfuser/core/utils/timer.py
@@ -9,6 +9,10 @@ try:
 except ModuleNotFoundError:
     pass
 
+import xfuser.envs as envs
+if envs._is_npu():
+    from torch.npu import synchronize
+
 def gpu_timer_decorator(func):
     def wrapper(*args, **kwargs):
         synchronize()

--- a/xfuser/envs.py
+++ b/xfuser/envs.py
@@ -67,24 +67,36 @@ def _is_mps():
     return torch.backends.mps.is_available()
 
 
+def _is_npu():
+    try:
+        if hasattr(torch, "npu") and torch.npu.is_available():
+            return True
+    except ModuleNotFoundError:
+        return False
+
+
 def get_device(local_rank: int) -> torch.device:
-    if torch.cuda.is_available():
+    if _is_cuda():
         return torch.device("cuda", local_rank)
     elif _is_musa():
         return torch.device("musa", local_rank)
     elif _is_mps():
         return torch.device("mps")
+    elif _is_npu():
+        return torch.device("npu", local_rank)
     else:
         return torch.device("cpu")
 
 
 def get_device_name() -> str:
-    if torch.cuda.is_available():
+    if _is_cuda():
         return "cuda"
     elif _is_musa():
         return "musa"
     elif _is_mps():
         return "mps"
+    elif _is_npu():
+        return "npu"
     else:
         return "cpu"
 
@@ -100,6 +112,8 @@ def get_device_version():
         return torch.version.musa
     elif _is_mps():
         return None
+    elif _is_npu():
+        return None
     else:
         raise NotImplementedError(
             "No Accelerators(AMD/NV/MTT GPU, AMD MI instinct accelerators) available"
@@ -107,12 +121,14 @@ def get_device_version():
 
 
 def get_torch_distributed_backend() -> str:
-    if torch.cuda.is_available():
+    if _is_cuda():
         return "nccl"
     elif _is_musa():
         return "mccl"
     elif _is_mps():
         return "gloo"
+    elif _is_npu():
+        return "hccl"
     else:
         raise NotImplementedError(
             "No Accelerators(AMD/NV/MTT GPU, AMD MI instinct accelerators) available"
@@ -191,6 +207,12 @@ class PackagesEnvChecker:
     def check_flash_attn(self):
         if not torch.cuda.is_available():
             return False
+
+        # Check if torch_npu is available
+        if _is_npu():
+            logger.info("falsh_attn is not ready on torch_npu for now")
+            return False
+
         if _is_musa():
             logger.info(
                 "Flash Attention library is not supported on MUSA for the moment."

--- a/xfuser/model_executor/layers/feedforward.py
+++ b/xfuser/model_executor/layers/feedforward.py
@@ -11,6 +11,10 @@ try:
 except ModuleNotFoundError:
     pass
 
+import xfuser.envs as envs
+if envs._is_npu():
+    from torch.npu import empty_cache
+
 from xfuser.core.distributed.parallel_state import (
     get_tensor_model_parallel_world_size,
     get_tensor_model_parallel_rank,

--- a/xfuser/model_executor/pipelines/pipeline_flux.py
+++ b/xfuser/model_executor/pipelines/pipeline_flux.py
@@ -40,6 +40,7 @@ from xfuser.core.distributed import (
 from xfuser.core.distributed.group_coordinator import GroupCoordinator
 from .base_pipeline import xFuserPipelineBaseWrapper
 from .register import xFuserPipelineWrapperRegister
+from ...envs import _is_npu
 
 if is_torch_xla_available():
     import torch_xla.core.xla_model as xm
@@ -75,13 +76,14 @@ class xFuserFluxPipeline(xFuserPipelineBaseWrapper):
         prompt = [""] * input_config.batch_size if input_config.batch_size > 1 else ""
         warmup_steps = get_runtime_state().runtime_config.warmup_steps
         get_runtime_state().runtime_config.warmup_steps = sync_steps
+        device = "npu" if _is_npu() else "cuda"
         self.__call__(
             height=input_config.height,
             width=input_config.width,
             prompt=prompt,
             num_inference_steps=steps,
             max_sequence_length=input_config.max_sequence_length,
-            generator=torch.Generator(device="cuda").manual_seed(42),
+            generator=torch.Generator(device=device).manual_seed(42),
             output_type=input_config.output_type,
         )
         get_runtime_state().runtime_config.warmup_steps = warmup_steps

--- a/xfuser/model_executor/pipelines/pipeline_stable_diffusion_3.py
+++ b/xfuser/model_executor/pipelines/pipeline_stable_diffusion_3.py
@@ -41,6 +41,7 @@ from xfuser.core.distributed import (
 )
 from .base_pipeline import xFuserPipelineBaseWrapper
 from .register import xFuserPipelineWrapperRegister
+from ...envs import _is_npu
 
 if is_torch_xla_available():
     import torch_xla.core.xla_model as xm
@@ -74,12 +75,15 @@ class xFuserStableDiffusion3Pipeline(xFuserPipelineBaseWrapper):
         prompt = [""] * input_config.batch_size if input_config.batch_size > 1 else ""
         warmup_steps = get_runtime_state().runtime_config.warmup_steps
         get_runtime_state().runtime_config.warmup_steps = sync_steps
+        device = "cuda"
+        if _is_npu():
+            device = "npu"
         self.__call__(
             height=input_config.height,
             width=input_config.width,
             prompt=prompt,
             num_inference_steps=steps,
-            generator=torch.Generator(device="cuda").manual_seed(42),
+            generator=torch.Generator(device=device).manual_seed(42),
             output_type=input_config.output_type,
         )
         get_runtime_state().runtime_config.warmup_steps = warmup_steps


### PR DESCRIPTION
Refer to the issue: #567

This is the first PR for support Ascend NPU platform, we implement the `flux` model in a single NPU run. Here is the main change illustration:
1. Add NPU env info in `xfuser/envs.py`
2. use NPU specific method in `xfuser/core/distributed/parallel_state.py` and `xfuser/model_executor/pipelines/pipeline_flux.py`

The additional environment needed:
```
torch==2.7.1
torch_npu==2.7.1.dev20250724
```

This PR confirm the usage of `tp` and `dp` in npu xDiT. The following file and command can be verify the correction:
1. `/root/Workplace/xDiT_example/launch.sh`
```bash
set -xe

torchrun --nproc_per_node=4 --start_method=spawn /root/Workplace/xDiT_example/sd3.py \
--model /root/.cache/modelscope/hub/models/stabilityai/stable-diffusion-3-medium-diffusers \
--height 1024 --width 1024 --no_use_resolution_binning --guidance_scale 3.5 \
--num_inference_steps 50 \
--warmup_steps 1 \
--prompt "brown dog laying on the ground with a metal bowl in front of him." "A small cat." "A good man" \
--tensor_parallel_degree 2 \
--data_parallel_degree 2
```
2. `/root/Workplace/xDiT_example/sd3.py` :
```python
import time
import os
import torch
import torch.distributed
from transformers import T5EncoderModel
from xfuser import xFuserStableDiffusion3Pipeline, xFuserArgs
from xfuser.config import FlexibleArgumentParser
from xfuser.core.distributed import (
    get_world_group,
    is_dp_last_group,
    get_data_parallel_rank,
    get_runtime_state,
)
from xfuser.core.distributed.parallel_state import get_data_parallel_world_size

def main():
    
    parser = FlexibleArgumentParser(description="xFuser Arguments")
    args = xFuserArgs.add_cli_args(parser).parse_args()
    engine_args = xFuserArgs.from_cli_args(args)
    engine_config, input_config = engine_args.create_config()
    local_rank = get_world_group().local_rank
    text_encoder_3 = T5EncoderModel.from_pretrained(engine_config.model_config.model, subfolder="text_encoder_3", torch_dtype=torch.float16)
    if args.use_fp8_t5_encoder:
        from optimum.quanto import freeze, qfloat8, quantize
        print(f"rank {local_rank} quantizing text encoder 2")
        quantize(text_encoder_3, weights=qfloat8)
        freeze(text_encoder_3)

    pipe = xFuserStableDiffusion3Pipeline.from_pretrained(
        pretrained_model_name_or_path=engine_config.model_config.model,
        engine_config=engine_config,
        torch_dtype=torch.float16,
        text_encoder_3=text_encoder_3,
    ).to(f"npu:{local_rank}")

    parameter_peak_memory = torch.npu.max_memory_allocated(device=f"npu:{local_rank}")

    pipe.prepare_run(input_config)
    
    torch.npu.reset_peak_memory_stats()
    start_time = time.time()
    output = pipe(
        height=input_config.height,
        width=input_config.width,
        prompt=input_config.prompt,
        num_inference_steps=input_config.num_inference_steps,
        output_type=input_config.output_type,
        guidance_scale=input_config.guidance_scale,
        generator=torch.Generator(device="npu").manual_seed(input_config.seed),
    )
    end_time = time.time()
    elapsed_time = end_time - start_time
    peak_memory = torch.npu.max_memory_allocated(device=f"npu:{local_rank}")

    parallel_info = (
        f"dp{engine_args.data_parallel_degree}_cfg{engine_config.parallel_config.cfg_degree}_"
        f"ulysses{engine_args.ulysses_degree}_ring{engine_args.ring_degree}_"
        f"pp{engine_args.pipefusion_parallel_degree}_patch{engine_args.num_pipeline_patch}"
    )
    if input_config.output_type == "pil":
        dp_group_index = get_data_parallel_rank()
        num_dp_groups = get_data_parallel_world_size()
        dp_batch_size = (input_config.batch_size + num_dp_groups - 1) // num_dp_groups
        if pipe.is_dp_last_group():
            if not os.path.exists("results"):
                os.mkdir("results")
            for i, image in enumerate(output.images):
                image_rank = dp_group_index * dp_batch_size + i
                image.save(
                    f"./results/stable_diffusion_3_result_{parallel_info}_{image_rank}.png"
                )
                print(
                    f"image {i} saved to ./results/stable_diffusion_3_result_{parallel_info}_{image_rank}.png"
                )

    if get_world_group().rank == get_world_group().world_size - 1:
        print(
            f"epoch time: {elapsed_time:.2f} sec, parameter memory: {parameter_peak_memory/1e9:.2f} GB, peak memory: {peak_memory/1e9:.2f} GB"
        )

    get_runtime_state().destroy_distributed_env()


if __name__ == "__main__":
    main()

```

And run the command:
```
chmod +x /root/Workplace/xDiT_example/launch.sh
/root/Workplace/xDiT_example/launch.sh
```

