### PR TITLE
Refactor packages info to remove conflicting logging

### DIFF
--- a/xfuser/envs.py
+++ b/xfuser/envs.py
@@ -164,12 +164,12 @@ class PackagesEnvChecker:
         return cls._instance
 
     def initialize(self):
-        self.packages_info = {
-            "has_aiter": self.check_aiter(),
-            "has_flash_attn": self.check_flash_attn(),
-            "has_long_ctx_attn": self.check_long_ctx_attn(),
-            "diffusers_version": self.check_diffusers_version(),
-        }
+        packages_info = {}
+        packages_info["has_aiter"] = self.check_aiter()
+        packages_info["has_flash_attn"] = self.check_flash_attn(packages_info)
+        packages_info["has_long_ctx_attn"] = self.check_long_ctx_attn()
+        packages_info["diffusers_version"] = self.check_diffusers_version()
+        self.packages_info = packages_info
 
     def check_aiter(self):
         """
@@ -188,7 +188,7 @@ class PackagesEnvChecker:
             return False
 
 
-    def check_flash_attn(self):
+    def check_flash_attn(self, packages_info):
         if not torch.cuda.is_available():
             return False
         if _is_musa():
@@ -209,10 +209,11 @@ class PackagesEnvChecker:
                     raise ImportError(f"install flash_attn >= 2.6.0")
                 return True
         except ImportError:
-            logger.warning(
-                f'Flash Attention library "flash_attn" not found, '
-                f"using pytorch attention implementation"
-            )
+            if not packages_info.get("has_aiter", False):
+                logger.warning(
+                    f'Flash Attention library "flash_attn" not found, '
+                    f"using pytorch attention implementation"
+                )
             return False
 
     def check_long_ctx_attn(self):


### PR DESCRIPTION
# What
Small refactoring to gate missing `flash_attn` warning logs behind not having `AITER` installed.

# Why
Currently when running xDiT on AMD devices, one can use AITER instead of `flash_attn`, which means `flash_attn` doesn't even have to be installed. 
Having AITER installed, xDiT correctly logs that AITER is installed and will be used as the attention library, but missing `flash_attn` then triggers another warning log:
```
Flash Attention library "flash_attn" not found, using pytorch attention implementation
```
SDPA will not be used if AITER is present, so this PR gates this warning, so only if AITER is not installed will this be logged.
