### PR TITLE
Fix envs to recognize AMD devices again

### DIFF
--- a/xfuser/envs.py
+++ b/xfuser/envs.py
@@ -76,7 +76,7 @@ def _is_npu():
 
 
 def get_device(local_rank: int) -> torch.device:
-    if _is_cuda():
+    if _is_cuda() or _is_hip():
         return torch.device("cuda", local_rank)
     elif _is_musa():
         return torch.device("musa", local_rank)
@@ -89,7 +89,7 @@ def get_device(local_rank: int) -> torch.device:
 
 
 def get_device_name() -> str:
-    if _is_cuda():
+    if _is_cuda() or _is_hip():
         return "cuda"
     elif _is_musa():
         return "musa"
@@ -121,7 +121,7 @@ def get_device_version():
 
 
 def get_torch_distributed_backend() -> str:
-    if _is_cuda():
+    if _is_cuda() or _is_hip():
         return "nccl"
     elif _is_musa():
         return "mccl"


### PR DESCRIPTION
# What?
Adds a fix to `envs.py` to recognize AMD devices again.

# Why?
PR #566 broke support for AMD devices due to changing the way `envs.py` checks the devices. This PR adds checks for HIP devices.


@feifeibear 