### PR TITLE
Add workaround for default attn_type

### DIFF
--- a/xfuser/core/long_ctx_attention/hybrid/attn_layer.py
+++ b/xfuser/core/long_ctx_attention/hybrid/attn_layer.py
@@ -55,6 +55,12 @@ class xFuserLongContextAttention(LongContextAttention):
             attn_type: AttnType = AttnType.FA, the attention type supported inside long context attention, including "TORCH", "FA", "FA3", "SAGE_FP16", "SAGE_FP8"
             attn_processor: nn.Module = None, the attention processor can be passed in to replace the attention processor if attn_type is do not support it.
         """
+
+        # A workaround to allow running xDiT without having yunchang installed
+        # while still supporting AttnType.FA as the default value for legacy reasons
+        if attn_type is None:
+            attn_type = AttnType.FA
+
         super().__init__(
             scatter_idx=scatter_idx,
             gather_idx=gather_idx,


### PR DESCRIPTION
## What?
Adds a workaround for allowing the default `attn_type` to be `AttnType.FA` for legacy reasons while still being able to run xDiT  without `yunchang` installed.

## Why?
As discussed in the issue #576 ,  for example Wan2.1 repo no longer works out-of-the-box with the xDiT, as it assumes the default value for `attn_type` to be `AttnType.FA`, which has been set to `None` by PR #559 . 

## How?
We set the default `attn_type` within init call itself, not as the default value. This keeps the support for Apple Silicon without interfering with legacy default values.

@feifeibear 