### PR TITLE
Aiter round mode control

### DIFF
--- a/xfuser/model_executor/layers/usp.py
+++ b/xfuser/model_executor/layers/usp.py
@@ -192,11 +192,11 @@ def _aiter_attn_call(query, key, value, dropout_p, is_causal):
     if HAS_ROUND_MODE:
         attn_kwargs["how_v3_bf16_cvt"] = HOW_V3_BF16_CVT
     output, softmax_lse = aiter.flash_attn_func(
-            query,
-            key,
-            value,
-            **attn_kwargs
-        )
+        query,
+        key,
+        value,
+        **attn_kwargs
+    )
     output = torch.permute(output, [0, 2, 1, 3])
     return output, softmax_lse
 


### PR DESCRIPTION
AITER has in later commits exposed multiple rounding modes. By changing mode from 1 (rtna = Round to Nearest Away from Zero) to 2 (rtz = Round Toward Zero) MI300X sees an uplift of 6% E2E for Wan2.2 without any visual changes to the outputs.

Tested with command:
`torchrun --nproc_per_node=8 examples/wan_i2v_example.py --height 720 --width 1280 --num_frames 81 --model Wan-AI/Wan2.2-I2V-A14B-Diffusers --ulysses_degree 8 --prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside." --num_inference_steps 40 --use_torch_compile --seed 42 --img_file_path https://huggingface.co/datasets/YiYiXu/testing-images/resolve/main/wan_i2v_input.JPG`

Output from current main:

https://github.com/user-attachments/assets/0c9b1e36-6f3a-440b-8cb6-092a810c3136

Output with this PR

https://github.com/user-attachments/assets/671457a6-df11-405e-acce-3d31bee105d6