### PR TITLE
Fix SyntaxWarning on Python 3.12

### DIFF
--- a/xfuser/core/distributed/utils.py
+++ b/xfuser/core/distributed/utils.py
@@ -4,7 +4,7 @@ from typing import List
 def generate_masked_orthogonal_rank_groups(
     world_size: int, parallel_size: List[int], mask: List[bool]
 ) -> List[List[int]]:
-    """Generate orthogonal parallel groups based on the parallel size and mask.
+    r"""Generate orthogonal parallel groups based on the parallel size and mask.
 
     Arguments:
         world_size (int): world size


### PR DESCRIPTION
## Background
Since Python 3.12, a [`SyntaxWarning` is emitted if a string contains an invalid escape sequence](https://docs.python.org/3/whatsnew/3.12.html#other-language-changes). In future versions, this may raise an error instead, crashing the program.

In [`xfuser/core/distributed/utilts.py`](xfuser/core/distributed/utilts.py), there are LaTeX symbols `\in` in the docstring of `generate_masked_orthogonal_rank_groups`, which cause the warning to be emitted.

## Changes

This PR fixes the issue by making the docstring an r-string according to recommendations from [PEP 257](https://peps.python.org/pep-0257/#what-is-a-docstring).

## Test
On Python 3.12.3.

Before this PR:
```python
>>> import xfuser.core.distributed

/app/external/xDiT/xfuser/core/distributed/utils.py:7: SyntaxWarning: invalid escape sequence '\i'
  """Generate orthogonal parallel groups based on the parallel size and mask.
```

After this PR:
```python
>>> import xfuser.core.distributed
```