### PR TITLE
Fix Wan model after yunchang deprecation

### DIFF
--- a/xfuser/model_executor/models/transformers/transformer_wan.py
+++ b/xfuser/model_executor/models/transformers/transformer_wan.py
@@ -7,7 +7,6 @@ from diffusers.models.transformers.transformer_wan import WanAttention
 from xfuser.model_executor.layers.usp import USP
 from xfuser.core.distributed import get_sequence_parallel_world_size
 from xfuser.model_executor.layers.attention_processor import (
-    set_hybrid_seq_parallel_attn,
     xFuserAttentionProcessorRegister
 )
 from xfuser.envs import PACKAGES_CHECKER
@@ -26,7 +25,6 @@ class xFuserWanAttnProcessor(WanAttnProcessor):
             and use_long_ctx_attn_kvcache
             and get_sequence_parallel_world_size() > 1
         )
-        set_hybrid_seq_parallel_attn(self, self.use_long_ctx_attn_kvcache)
 
     def _get_qkv_projections(self, attn: "WanAttention", hidden_states: torch.Tensor, encoder_hidden_states: torch.Tensor):
         # encoder_hidden_states is only passed for cross-attention


### PR DESCRIPTION
# What?
A small addition to #607 , removes the import/call to `set_hybrid_seq_parallel_attn`, which was removed. I forgot to remove these calls alongside when submitting the previous PR.

# Why?
This currently throws an error, as it cannot import this. The import/call in this function were already unnecessary, as the transformer calls USP, not hybrid_seq_parallel_attn, so these can be removed without worry.



