### PR TITLE
Add fix for ring attention with rear joint tensors

### DIFF
--- a/xfuser/model_executor/layers/usp.py
+++ b/xfuser/model_executor/layers/usp.py
@@ -206,7 +206,7 @@ def concat_joint_tensors_decorator(func):
         query, key, value = args[0:3]
         is_causal = kwargs.get("is_causal")
         dropout_p = kwargs.get("dropout_p")
-        joint_attn_kwargs = kwargs.get("joint_attn_kwargs", {})
+        joint_attn_kwargs = kwargs.get("joint_attn_kwargs", None)
 
         if joint_attn_kwargs is not None:
             joint_strategy = joint_attn_kwargs.get("joint_strategy", None)
@@ -245,7 +245,7 @@ def USP(
     attention_function = _get_attention_function()
 
 
-    joint_attn_kwargs = {}
+    joint_attn_kwargs = None
     if joint_strategy:
         query = _concat_joint_tensor(query, joint_query, joint_strategy, dim=2)
         joint_key, joint_value = _preprocess_joint_tensors(joint_key, joint_value)


### PR DESCRIPTION
# What?
Fixes bug in ring attention when using it alongside joint tensors and joint strategy of `rear`.

# Why?
This bug causes some quality artifacts if all the requirements are met for it. Example of where this can happen is SD3.5 when running u2r4.
The bug was caused by a faulty logic as to when to concatenate joint values to QKV values. 
Basically: we have QKV and the tensors that are separated from the QKV (rear or front). These are joint tensors that are the concatenated back to QKV at specific times. If strategy is front, these should be concatenated prior to attn on step 0 (step being an "iteration" of ring) and to the front of QKV. With rear, they are concatenated to the rear of QKV at step `len(steps) -1`, i.e. just before the last attention step.

Currently all concats happened at step 0, so if one had ring > 1, used joint_tensors and the joint_strategy was rear, the concat happened way too early, causing some visual artifacts.

# How?
As we use torch's templated ring attention in USP, we can't really access the individual iterations of ring. Therefore this PR adds a decorator for the attention calls that checks whether the QKV concatenation would need to be done. It basically does the concat under-the-hood without changing any logic or complicating the attention mechanisms. Now joint tensors with `front` strategy are concatenated on step 0 and `rear` tensors on step `len(steps) -1`, as expected.

# Tests

Before fix with SD3.5, `ulysses 2, ring 4`:
<img width="976" height="980" alt="image (8)" src="https://github.com/user-attachments/assets/3d796550-c3ee-4a61-b4c6-2a51fbc6c941" />

After fix:
<img width="1024" height="1024" alt="SD_3_5_result_tp1_dp1_cfg1_ulysses2_ring4_pp1_patchNone_0" src="https://github.com/user-attachments/assets/c9317c1c-cd55-4046-8867-045729f9473e" />

Tested performance with Flux and Hunyuanvideo with USP, no performance degradations.