### PR TITLE
Fix Wan 2.1 sharding

### DIFF
--- a/examples/wan_example.py
+++ b/examples/wan_example.py
@@ -240,6 +240,8 @@ def shard_model_wan(
         pipe.text_encoder = shard_t5_encoder(pipe.text_encoder, local_rank, get_world_group().device_group)
     else:
         pipe.text_encoder.to(f"cuda:{local_rank}")
+    if pipe.image_encoder is not None:
+        pipe.image_encoder.to(f"cuda:{local_rank}")
     pipe.vae.to(f"cuda:{local_rank}")
 
 


### PR DESCRIPTION
Fixes Wan 2.1 sharding logic.

#### Observation

Running `examples/wan_example.py` for Wan 2.1 model with `--shard_dit` and/or `--shard_t5_encoder` errors because some tensors lie on CPU. For Wan 2.2 model this does not happen and the workload runs successfully with sharding.

#### Fix

Wan 2.1 has `pipe.image_encoder` component which Wan 2.2 does not have. The solution is to move the image encoder to GPU when running Wan sharding function.

#### Tests

Tested successfully by running Wan workloads.  