### PR TITLE
Add support for WanI2V CFG parallel

### DIFF
--- a/xfuser/core/distributed/runtime_state.py
+++ b/xfuser/core/distributed/runtime_state.py
@@ -203,6 +203,13 @@ class DiTRuntimeState(RuntimeState):
         self._check_model_and_parallel_config(
             pipeline=pipeline, parallel_config=config.parallel_config
         )
+        try:
+            self._check_pipeline_class_name(pipeline, config)
+        except Exception:
+            # Keeps backward compatatability with existing pipeline classes.
+            pass
+
+    def _check_pipeline_class_name(self, pipeline: DiffusionPipeline, config: EngineConfig):
         self.cogvideox = False
         self.consisid = False
         self.hunyuan_video = False
@@ -781,6 +788,7 @@ class DiTRuntimeState(RuntimeState):
             patches_shape_list=patches_shape,
             feature_map_shape=feature_map_shape,
         )
+
 
 
 class ExternalRuntimeState(RuntimeState):

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -1,9 +1,12 @@
 import copy
 import torch
-from diffusers import WanImageToVideoPipeline, WanPipeline
+from diffusers import WanPipeline
 from diffusers.pipelines.pipeline_utils import DiffusionPipeline
 from xfuser import xFuserArgs
 from xfuser.model_executor.models.transformers.transformer_wan import xFuserWanTransformer3DWrapper
+from xfuser.model_executor.pipelines.pipeline_wan_i2v import (
+    xFuserWanImageToVideoPipeline,
+)
 from xfuser.model_executor.models.runner_models.base_model import (
     ModelSettings,
     xFuserModel,
@@ -58,6 +61,7 @@ class xFuserWan21I2VModel(xFuserModel):
         ring_degree=True,
         use_fp8_gemms=True,
         use_fsdp=True,
+        use_cfg_parallel=True,
         use_hybrid_fp8_attn=True,
     )
     default_input_values = DefaultInputValues(
@@ -85,7 +89,7 @@ class xFuserWan21I2VModel(xFuserModel):
             torch_dtype=torch.bfloat16,
             subfolder="transformer",
         )
-        pipe = WanImageToVideoPipeline.from_pretrained(
+        pipe = xFuserWanImageToVideoPipeline.from_pretrained(
                 pretrained_model_name_or_path=self.settings.model_name,
                 torch_dtype=torch.bfloat16,
                 transformer=transformer,
@@ -142,9 +146,9 @@ class xFuserWan21I2VModel(xFuserModel):
 class xFuserWan22I2VModel(xFuserWan21I2VModel):
 
     def __init__(self, config: xFuserArgs) -> None:
-        super().__init__(config)
         self.settings.model_name = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
         self.settings.output_name = "wan2.2_i2v"
+        super().__init__(config)
         self.settings.fsdp_strategy["transformer_2"] = {
                 "block_attr": "blocks",
                 "dtype": torch.bfloat16,
@@ -167,7 +171,7 @@ class xFuserWan22I2VModel(xFuserWan21I2VModel):
             torch_dtype=torch.bfloat16,
             subfolder="transformer_2",
         )
-        pipe = WanImageToVideoPipeline.from_pretrained(
+        pipe = xFuserWanImageToVideoPipeline.from_pretrained(
                 pretrained_model_name_or_path=self.settings.model_name,
                 torch_dtype=torch.bfloat16,
                 transformer=transformer,

--- a/xfuser/model_executor/pipelines/pipeline_wan_i2v.py
+++ b/xfuser/model_executor/pipelines/pipeline_wan_i2v.py
@@ -1,0 +1,294 @@
+from typing import Any, Callable, Dict, List, Optional, Union
+import os
+
+from diffusers import WanImageToVideoPipeline
+from diffusers.callbacks import MultiPipelineCallbacks, PipelineCallback
+from diffusers.image_processor import PipelineImageInput
+from diffusers.pipelines.wan.pipeline_output import WanPipelineOutput
+from diffusers.utils import is_torch_xla_available, logging
+import torch
+
+from xfuser.config import EngineConfig
+from xfuser.core.distributed import (
+    get_classifier_free_guidance_rank,
+    get_classifier_free_guidance_world_size,
+    get_cfg_group,
+)
+
+if is_torch_xla_available():
+    import torch_xla.core.xla_model as xm
+
+    XLA_AVAILABLE = True
+else:
+    XLA_AVAILABLE = False
+
+logger = logging.get_logger(__name__)
+
+class xFuserWanImageToVideoPipeline(WanImageToVideoPipeline):
+    """Direct subclass of the diffusers pipeline."""
+
+    @torch.no_grad()
+    def __call__(
+        self,
+        image: PipelineImageInput,
+        prompt: Union[str, List[str]] = None,
+        negative_prompt: Union[str, List[str]] = None,
+        height: int = 480,
+        width: int = 832,
+        num_frames: int = 81,
+        num_inference_steps: int = 50,
+        guidance_scale: float = 5.0,
+        guidance_scale_2: Optional[float] = None,
+        num_videos_per_prompt: Optional[int] = 1,
+        generator: Optional[Union[torch.Generator, List[torch.Generator]]] = None,
+        latents: Optional[torch.Tensor] = None,
+        prompt_embeds: Optional[torch.Tensor] = None,
+        negative_prompt_embeds: Optional[torch.Tensor] = None,
+        image_embeds: Optional[torch.Tensor] = None,
+        last_image: Optional[torch.Tensor] = None,
+        output_type: Optional[str] = "np",
+        return_dict: bool = True,
+        attention_kwargs: Optional[Dict[str, Any]] = None,
+        callback_on_step_end: Optional[
+            Union[Callable[[int, int, Dict], None], PipelineCallback, MultiPipelineCallbacks]
+        ] = None,
+        callback_on_step_end_tensor_inputs: List[str] = ["latents"],
+        max_sequence_length: int = 512,
+    ):
+        if isinstance(callback_on_step_end, (PipelineCallback, MultiPipelineCallbacks)):
+            callback_on_step_end_tensor_inputs = callback_on_step_end.tensor_inputs
+
+        # 1. Check inputs. Raise error if not correct
+        self.check_inputs(
+            prompt,
+            negative_prompt,
+            image,
+            height,
+            width,
+            prompt_embeds,
+            negative_prompt_embeds,
+            image_embeds,
+            callback_on_step_end_tensor_inputs,
+            guidance_scale_2,
+        )
+
+        if num_frames % self.vae_scale_factor_temporal != 1:
+            logger.warning(
+                f"`num_frames - 1` has to be divisible by {self.vae_scale_factor_temporal}. Rounding to the nearest number."
+            )
+            num_frames = num_frames // self.vae_scale_factor_temporal * self.vae_scale_factor_temporal + 1
+        num_frames = max(num_frames, 1)
+
+        if self.config.boundary_ratio is not None and guidance_scale_2 is None:
+            guidance_scale_2 = guidance_scale
+
+        self._guidance_scale = guidance_scale
+        self._guidance_scale_2 = guidance_scale_2
+        self._attention_kwargs = attention_kwargs
+        self._current_timestep = None
+        self._interrupt = False
+
+        device = self._execution_device
+
+        # 2. Define call parameters
+        if prompt is not None and isinstance(prompt, str):
+            batch_size = 1
+        elif prompt is not None and isinstance(prompt, list):
+            batch_size = len(prompt)
+        else:
+            batch_size = prompt_embeds.shape[0]
+
+        # 3. Encode input prompt
+        prompt_embeds, negative_prompt_embeds = self.encode_prompt(
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            do_classifier_free_guidance=self.do_classifier_free_guidance,
+            num_videos_per_prompt=num_videos_per_prompt,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            max_sequence_length=max_sequence_length,
+            device=device,
+        )
+
+        # Encode image embedding
+        transformer_dtype = self.transformer.dtype if self.transformer is not None else self.transformer_2.dtype
+        prompt_embeds = prompt_embeds.to(transformer_dtype)
+        if negative_prompt_embeds is not None:
+            negative_prompt_embeds = negative_prompt_embeds.to(transformer_dtype)
+
+        # only wan 2.1 i2v transformer accepts image_embeds
+        if self.transformer is not None and self.transformer.config.image_dim is not None:
+            if image_embeds is None:
+                if last_image is None:
+                    image_embeds = self.encode_image(image, device)
+                else:
+                    image_embeds = self.encode_image([image, last_image], device)
+            image_embeds = image_embeds.repeat(batch_size, 1, 1)
+            image_embeds = image_embeds.to(transformer_dtype)
+
+        cfg_rank = get_classifier_free_guidance_rank()
+        do_cfg_parallel = self.do_classifier_free_guidance and get_classifier_free_guidance_world_size() == 2
+        if do_cfg_parallel:
+            prompt_embeds_local = negative_prompt_embeds if cfg_rank == 0 else prompt_embeds
+            cache_key = "uncond" if cfg_rank == 0 else "cond"
+        else:
+            prompt_embeds_local = prompt_embeds
+            cache_key = "cond"
+
+        # 4. Prepare timesteps
+        self.scheduler.set_timesteps(num_inference_steps, device=device)
+        timesteps = self.scheduler.timesteps
+
+        # 5. Prepare latent variables
+        num_channels_latents = self.vae.config.z_dim
+        image = self.video_processor.preprocess(image, height=height, width=width).to(device, dtype=torch.float32)
+        if last_image is not None:
+            last_image = self.video_processor.preprocess(last_image, height=height, width=width).to(
+                device, dtype=torch.float32
+            )
+
+        latents_outputs = self.prepare_latents(
+            image,
+            batch_size * num_videos_per_prompt,
+            num_channels_latents,
+            height,
+            width,
+            num_frames,
+            torch.float32,
+            device,
+            generator,
+            latents,
+            last_image,
+        )
+        if self.config.expand_timesteps:
+            # wan 2.2 5b i2v use firt_frame_mask to mask timesteps
+            latents, condition, first_frame_mask = latents_outputs
+        else:
+            latents, condition = latents_outputs
+
+        # 6. Denoising loop
+        num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order
+        self._num_timesteps = len(timesteps)
+
+        if self.config.boundary_ratio is not None:
+            boundary_timestep = self.config.boundary_ratio * self.scheduler.config.num_train_timesteps
+        else:
+            boundary_timestep = None
+
+        with self.progress_bar(total=num_inference_steps) as progress_bar:
+            for i, t in enumerate(timesteps):
+                if self.interrupt:
+                    continue
+
+                self._current_timestep = t
+
+                if boundary_timestep is None or t >= boundary_timestep:
+                    # wan2.1 or high-noise stage in wan2.2
+                    current_model = self.transformer
+                    current_guidance_scale = guidance_scale
+                else:
+                    # low-noise stage in wan2.2
+                    current_model = self.transformer_2
+                    current_guidance_scale = guidance_scale_2
+
+                if self.config.expand_timesteps:
+                    latent_model_input = (1 - first_frame_mask) * condition + first_frame_mask * latents
+                    latent_model_input = latent_model_input.to(transformer_dtype)
+
+                    # seq_len: num_latent_frames * (latent_height // patch_size) * (latent_width // patch_size)
+                    temp_ts = (first_frame_mask[0][0][:, ::2, ::2] * t).flatten()
+                    # batch_size, seq_len
+                    timestep = temp_ts.unsqueeze(0).expand(latents.shape[0], -1)
+                else:
+                    latent_model_input = torch.cat([latents, condition], dim=1).to(transformer_dtype)
+                    timestep = t.expand(latents.shape[0])
+
+                with current_model.cache_context(cache_key):
+                    noise_pred = current_model(
+                        hidden_states=latent_model_input,
+                        timestep=timestep,
+                        encoder_hidden_states=prompt_embeds_local,
+                        encoder_hidden_states_image=image_embeds,
+                        attention_kwargs=attention_kwargs,
+                        return_dict=False,
+                    )[0]
+
+                if self.do_classifier_free_guidance:
+                    if do_cfg_parallel:
+                        noise_pred_uncond, noise_pred_text = get_cfg_group().all_gather(
+                            noise_pred, separate_tensors=True
+                        )
+                        noise_pred = noise_pred_uncond + current_guidance_scale * (
+                            noise_pred_text - noise_pred_uncond
+                        )
+                    else:
+                        with current_model.cache_context("uncond"):
+                            noise_uncond = current_model(
+                                hidden_states=latent_model_input,
+                                timestep=timestep,
+                                encoder_hidden_states=negative_prompt_embeds,
+                                encoder_hidden_states_image=image_embeds,
+                                attention_kwargs=attention_kwargs,
+                                return_dict=False,
+                            )[0]
+                            noise_pred = noise_uncond + current_guidance_scale * (noise_pred - noise_uncond)
+
+                # compute the previous noisy sample x_t -> x_t-1
+                latents = self.scheduler.step(noise_pred, t, latents, return_dict=False)[0]
+
+                if callback_on_step_end is not None:
+                    callback_kwargs = {}
+                    for k in callback_on_step_end_tensor_inputs:
+                        callback_kwargs[k] = locals()[k]
+                    callback_outputs = callback_on_step_end(self, i, t, callback_kwargs)
+
+                    latents = callback_outputs.pop("latents", latents)
+                    prompt_embeds = callback_outputs.pop("prompt_embeds", prompt_embeds)
+                    negative_prompt_embeds = callback_outputs.pop("negative_prompt_embeds", negative_prompt_embeds)
+
+                # call the callback, if provided
+                if i == len(timesteps) - 1 or ((i + 1) > num_warmup_steps and (i + 1) % self.scheduler.order == 0):
+                    progress_bar.update()
+
+                if XLA_AVAILABLE:
+                    xm.mark_step()
+
+        self._current_timestep = None
+
+        if self.config.expand_timesteps:
+            latents = (1 - first_frame_mask) * condition + first_frame_mask * latents
+
+        if not output_type == "latent":
+            latents = latents.to(self.vae.dtype)
+            latents_mean = (
+                torch.tensor(self.vae.config.latents_mean)
+                .view(1, self.vae.config.z_dim, 1, 1, 1)
+                .to(latents.device, latents.dtype)
+            )
+            latents_std = 1.0 / torch.tensor(self.vae.config.latents_std).view(1, self.vae.config.z_dim, 1, 1, 1).to(
+                latents.device, latents.dtype
+            )
+            latents = latents / latents_std + latents_mean
+            video = self.vae.decode(latents, return_dict=False)[0]
+            video = self.video_processor.postprocess_video(video, output_type=output_type)
+        else:
+            video = latents
+
+        # Offload all models
+        self.maybe_free_model_hooks()
+
+        if not return_dict:
+            return (video,)
+
+        return WanPipelineOutput(frames=video)
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: Optional[Union[str, os.PathLike]],
+        engine_config: Optional[EngineConfig] = None,
+        **kwargs,
+    ):
+        pipeline = super().from_pretrained(pretrained_model_name_or_path, **kwargs)
+        pipeline.engine_config = engine_config
+        return pipeline


### PR DESCRIPTION
# What

Adds support for Wan2.x I2V CFG parallel

# How

Implements CFG-parallel by splitting cond/uncond transformer calls across CFG ranks, adding minimal changes to the original diffusers implementation.

# Tests


https://github.com/user-attachments/assets/f6ff34fa-3a58-4f94-b3cd-ddb382326b52
```
torchrun --nproc_per_node=8 /app/external/xDiT/xfuser/runner.py \
  --model Wan-AI/Wan2.2-I2V-A14B-Diffusers \
  --prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside." \
  --height 720 \
  --width 1280 \
  --input_images /app/Wan/i2v_input.JPG \
  --num_frames 81 \
  --ulysses_degree 8 \
  --seed 42 \
  --num_iterations 3 \
  --num_inference_steps 40 \
  --use_torch_compile \
  --attention_backend aiter
```




https://github.com/user-attachments/assets/50443a3c-1ffc-4f88-9404-879d5ada831b
```
torchrun --nproc_per_node=8 /app/external/xDiT/xfuser/runner.py \
  --model Wan-AI/Wan2.2-I2V-A14B-Diffusers \
  --prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside." \
  --height 720 \
  --width 1280 \
  --input_images /app/Wan/i2v_input.JPG \
  --num_frames 81 \
  --ulysses_degree 4 \
  --seed 42 \
  --num_iterations 3 \
  --num_inference_steps 40 \
  --use_torch_compile \
  --attention_backend aiter \
  --use_cfg_parallel
```


https://github.com/user-attachments/assets/04a0eac8-2ba7-4fcd-b6e9-fd258f42d744
```
torchrun --nproc_per_node=8 /app/external/xDiT/xfuser/runner.py \
  --model Wan-AI/Wan2.1-I2V-14B-720P-Diffusers \
  --prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside." \
  --height 720 \
  --width 1280 \
  --input_images /app/Wan/i2v_input.JPG \
  --num_frames 81 \
  --ulysses_degree 8 \
  --seed 42 \
  --num_iterations 3 \
  --num_inference_steps 40 \
  --use_torch_compile \
  --attention_backend aiter
```



https://github.com/user-attachments/assets/8d5b4473-66b0-488f-8767-60a7afef79db
```
torchrun --nproc_per_node=8 /app/external/xDiT/xfuser/runner.py \
  --model Wan-AI/Wan2.1-I2V-14B-720P-Diffusers \
  --prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside." \
  --height 720 \
  --width 1280 \
  --input_images /app/Wan/i2v_input.JPG \
  --num_frames 81 \
  --ulysses_degree 4 \
  --seed 42 \
  --num_iterations 3 \
  --num_inference_steps 40 \
  --use_torch_compile \
  --attention_backend aiter \
  --use_cfg_parallel
```