### PR TITLE
Use correct I2V pipeline with Wan2.2-TI2V

### DIFF
--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -341,7 +341,7 @@ class xFuserWan22TI2VModel(xFuserWan21T2VModel):
             torch_dtype=torch.bfloat16,
             subfolder="transformer",
         )
-        pipe_class = WanImageToVideoPipeline if self.config.task == "i2v" else WanPipeline
+        pipe_class = xFuserWanImageToVideoPipeline if self.config.task == "i2v" else WanPipeline
         pipe = pipe_class.from_pretrained(
                 pretrained_model_name_or_path=self.settings.model_name,
                 torch_dtype=torch.bfloat16,


### PR DESCRIPTION
# What?
Changes the pipeline to be used in Wan2.2-TI2V to be `xFuserWanImageToVideoPipeline` instead of `WanImageToVideoPipeline`.

# Why?
PR #632 wrapped the I2V pipeline and the original is no longer imported. This caused an error with the TI2V model with i2v task. Now it uses the correct pipeline.