### PR TITLE
Add FP8 GEMM support for Flux in model runner

### DIFF
--- a/xfuser/model_executor/models/runner_models/flux.py
+++ b/xfuser/model_executor/models/runner_models/flux.py
@@ -28,6 +28,7 @@ class xFuserFluxModel(xFuserModel):
     capabilities = ModelCapabilities(
         ulysses_degree=True,
         ring_degree=True,
+        use_fp8_gemms=True,
     )
     default_input_values = DefaultInputValues(
         height=1024,
@@ -93,6 +94,7 @@ class xFuserFluxKontextModel(xFuserModel):
     capabilities = ModelCapabilities(
         ulysses_degree=True,
         ring_degree=True,
+        use_fp8_gemms=True,
     )
     default_input_values = DefaultInputValues(
         height=1024,
@@ -170,6 +172,7 @@ class xFuserFlux2Model(xFuserModel):
     capabilities = ModelCapabilities(
         ulysses_degree=True,
         ring_degree=True,
+        use_fp8_gemms=True,
     )
     default_input_values = DefaultInputValues(
         height=1024,


### PR DESCRIPTION
# What?
Adds the missing FP8 GEMM support for all Flux models. 

# Why?
This was already present in examples, but was left out from the model runner.