### PR TITLE
Mxfp4 aiter gemms

### DIFF
--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -369,11 +369,6 @@ class xFuserArgs:
             action="store_true",
             help="Quantize the transformer linear layers (selected models only).",
         )
-        runtime_group.add_argument(
-            "--use_fp4_gemms",
-            action="store_true",
-            help="Quantize the transformer linear layers (selected models only).",
-        )
 
         # DiTFastAttn arguments
         fast_attn_group = parser.add_argument_group("DiTFastAttn Options")

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -121,6 +121,7 @@ class xFuserArgs:
     shard_t5_encoder: bool = False
     attention_backend: Optional[str] = None
     use_fp8_gemms: bool = False
+    use_fp4_gemms: bool = False
     # Model runner specific
     num_iterations: int = 1
     profile: bool = False
@@ -368,6 +369,11 @@ class xFuserArgs:
             action="store_true",
             help="Quantize the transformer linear layers (selected models only).",
         )
+        runtime_group.add_argument(
+            "--use_fp4_gemms",
+            action="store_true",
+            help="Quantize the transformer linear layers (selected models only).",
+        )
 
         # DiTFastAttn arguments
         fast_attn_group = parser.add_argument_group("DiTFastAttn Options")
@@ -546,6 +552,11 @@ class xFuserArgs:
         )
         parser.add_argument(
             "--use_fp8_gemms",
+            action="store_true",
+            help="Quantize the transformer linear layers (selected models only).",
+        )
+        parser.add_argument(
+            "--use_fp4_gemms",
             action="store_true",
             help="Quantize the transformer linear layers (selected models only).",
         )

--- a/xfuser/model_executor/layers/__init__.py
+++ b/xfuser/model_executor/layers/__init__.py
@@ -5,6 +5,7 @@ from .attention_processor import xFuserAttentionBaseWrapper
 from .conv import xFuserConv2dWrapper
 from .embeddings import xFuserPatchEmbedWrapper
 from .feedforward import xFuserFeedForwardWrapper
+from .mxfp4_linear import xFuserMXFP4Linear
 
 __all__ = [
     "xFuserLayerWrappersRegister",
@@ -14,4 +15,5 @@ __all__ = [
     "xFuserConv2dWrapper",
     "xFuserPatchEmbedWrapper",
     "xFuserFeedForwardWrapper",
+    "xFuserMXFP4Linear"
 ]

--- a/xfuser/model_executor/layers/mxfp4_linear.py
+++ b/xfuser/model_executor/layers/mxfp4_linear.py
@@ -122,7 +122,7 @@ class xFuserMXFP4Linear(nn.Module):
         Forward pass using MXFP4 GEMM
         """
 
-        if self.weight_shuffle is None:
+        if not hasattr(self, "weight_shuffle"):
             self._quantize_weights()
 
         # Save original shape

--- a/xfuser/model_executor/layers/mxfp4_linear.py
+++ b/xfuser/model_executor/layers/mxfp4_linear.py
@@ -1,0 +1,114 @@
+import torch
+import torch.nn as nn
+import math
+import aiter
+from aiter.ops.shuffle import shuffle_weight
+from typing import Optional
+
+
+@torch.library.custom_op("mylib::mxfp4_gemm", mutates_args=())
+def _mxfp4_gemm(a: torch.Tensor, w_quant: torch.Tensor, w_scale: torch.Tensor, bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+    quant_func = aiter.get_hip_quant(aiter.QuantType.per_1x32)
+    a_quant, a_scale = quant_func(a, shuffle=True)
+    output = aiter.gemm_a4w4(a_quant, w_quant, a_scale, w_scale, bpreshuffle=True, bias=bias)
+    return output
+
+@_mxfp4_gemm.register_fake
+def _(a: torch.Tensor, w_quant: torch.Tensor, w_scale: torch.Tensor, bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+    """
+    Fake implementation for torch. compile shape inference
+    """
+    M, _ = a.shape
+    N, _ = w_quant.shape
+    
+    # Return fake tensor with correct shape
+    return torch.empty(M, N, dtype=a.dtype, device=a.device)
+
+class xFuserMXFP4Linear(nn.Module):
+    """
+    Custom Linear layer using MXFP4 GEMM operation
+    
+    Drop-in replacement for nn.Linear.
+    """
+    def __init__(self, in_features, out_features, bias=True, device=None, dtype=None):
+        factory_kwargs = {'device': device, 'dtype': dtype}
+        super().__init__()
+        
+        self.in_features = in_features
+        self.out_features = out_features
+
+        self.weight_shuffle = None
+        self.weight_scale = None
+        
+        self.weight = nn.Parameter(
+            torch.empty((out_features, in_features), **factory_kwargs)
+        )
+        
+        if bias:
+            self.bias = nn.Parameter(
+                torch.empty(out_features, **factory_kwargs)
+            )
+        else:
+            self.register_parameter('bias', None)
+        
+        self.reset_parameters()
+        self.mm = self._run_mxfp4_gemm
+    
+    def reset_parameters(self) -> None:
+        """Initialize weights using Kaiming uniform (same as nn.Linear)"""
+        nn.init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+        if self.bias is not None:
+            fan_in, _ = nn.init._calculate_fan_in_and_fan_out(self.weight)
+            bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
+            nn.init.uniform_(self.bias, -bound, bound)
+    
+    def load_and_quantize_weights(self, weights: torch.Tensor, bias: Optional[torch.Tensor] = None) -> None:
+        with torch.no_grad():
+            self.weight.data.copy_(weights.data)
+            if bias is not None:
+                self.bias.data.copy_(bias.data)
+        self._quantize_weights()
+
+    def _quantize_weights(self) -> None:
+        quant_func = aiter.get_hip_quant(aiter.QuantType.per_1x32)
+        weight_quant, self.weight_scale = quant_func(self.weight, shuffle=True)
+        self.weight_shuffle = shuffle_weight(weight_quant, layout=(16, 16))
+
+        del self.weight
+        self.weight = None
+
+    def _run_mxfp4_gemm(self, a: torch.Tensor, w_quant: torch.Tensor, w_scale: torch.Tensor, bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+        return torch.ops.mylib.mxfp4_gemm(a, w_quant, w_scale, bias)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass using MXFP4 GEMM
+        """
+
+        if self.weight_shuffle is None:
+            self._quantize_weights()
+
+        # Save original shape
+        original_shape = input.shape
+        
+        # Flatten all batch dimensions: [..., in_features] -> [M, in_features]
+        input_2d = input.view(-1, self.in_features)
+        
+        output = self.mm(
+            input_2d,
+            self.weight_shuffle,
+            self.weight_scale,
+            None
+        )
+        if self.bias is not None:
+            output = output + self.bias
+        
+        # Reshape back to original batch dimensions
+        # [M, N] -> [..., out_features]
+        output = output.view(*original_shape[:-1], self.out_features)
+        
+        return output
+    
+    def extra_repr(self):
+        """String representation (for print(model))"""
+        return f'in_features={self.in_features}, out_features={self.out_features}, bias={self.bias is not None}'

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -414,7 +414,7 @@ class xFuserModel(abc.ABC):
                 module = rgetattr(self.pipe, module_name)
                 quantize_linear_layers_to_fp4(module, fp8_layers=self.settings.fp8_precision_overrides)
             # Any module specified in fp8 gemms modules list and not specified in fp4 gemms module list,
-            # will be quantized to fp8, this is specially benefitial for MoE models like Wan2.2, 
+            # will be quantized to fp8, this is specially beneficial for MoE models like Wan2.2, 
             # where the low-noise transformer should use FP8 quantization.
             # This transformer generates fine details and requires higher precision to maintain quality.
             for module_name in self.settings.fp8_gemm_module_list:

--- a/xfuser/model_executor/models/runner_models/flux.py
+++ b/xfuser/model_executor/models/runner_models/flux.py
@@ -173,6 +173,7 @@ class xFuserFlux2Model(xFuserModel):
         ulysses_degree=True,
         ring_degree=True,
         use_fp8_gemms=True,
+        use_fp4_gemms=True,
         fully_shard_degree=True,
     )
     default_input_values = DefaultInputValues(
@@ -188,6 +189,7 @@ class xFuserFlux2Model(xFuserModel):
         model_output_type="image",
         mod_value=16,
         fp8_gemm_module_list=["transformer.transformer_blocks", "transformer.single_transformer_blocks"],
+        fp4_gemm_module_list=["transformer.transformer_blocks", "transformer.single_transformer_blocks"],
         fsdp_strategy={
             "transformer": {
                 "wrap_attrs": ["transformer_blocks", "single_transformer_blocks"],

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -72,7 +72,10 @@ class xFuserWan21I2VModel(xFuserModel):
         fps = 16,
         fp8_gemm_module_list=["transformer.blocks"],
         fp4_gemm_module_list=["transformer.blocks"],
-        fp8_precision_overrides=("0.", "1.", "2.", "3.", "4.","35.", "36.", "37.", "38.", "39."),
+        fp8_precision_overrides=("0.", "1.", "2.", "3.", "4.",
+                                 "5.", "6.", "7.", "8.", "9.",
+                                 "30.", "31.", "32.", "33.", "34.",
+                                 "35.", "36.", "37.", "38.", "39."),
         fsdp_strategy=COMMON_FSDP_STRATEGY,
         flow_shift=5,
     )
@@ -215,7 +218,10 @@ class xFuserWan21T2VModel(xFuserModel):
         output_name="wan2.1_t2v",
         fp8_gemm_module_list=["transformer.blocks"],
         fp4_gemm_module_list=["transformer.blocks"],
-        fp8_precision_overrides=("0.", "1.", "2.", "3.", "4.","35.", "36.", "37.", "38.", "39."),
+        fp8_precision_overrides=("0.", "1.", "2.", "3.", "4.",
+                                 "5.", "6.", "7.", "8.", "9.",
+                                 "30.", "31.", "32.", "33.", "34.",
+                                 "35.", "36.", "37.", "38.", "39."),
         fsdp_strategy=COMMON_FSDP_STRATEGY,
         flow_shift=12,
     )

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -1,5 +1,6 @@
 import copy
 import torch
+from typing import List
 from PIL import Image
 from diffusers import WanPipeline
 from diffusers.pipelines.pipeline_utils import DiffusionPipeline
@@ -52,6 +53,7 @@ class xFuserWan21I2VModel(xFuserModel):
         use_fp8_gemms=True,
         use_cfg_parallel=True,
         use_hybrid_fp8_attn=True,
+        use_fp4_gemms=True
     )
     default_input_values = DefaultInputValues(
         height=720,
@@ -69,6 +71,8 @@ class xFuserWan21I2VModel(xFuserModel):
         mod_value = 16, # vae_scale_factor_spatial * patch_size[1] = 8
         fps = 16,
         fp8_gemm_module_list=["transformer.blocks"],
+        fp4_gemm_module_list=["transformer.blocks"],
+        fp8_precision_overrides=("0.", "1.", "2.", "3.", "4.","35.", "36.", "37.", "38.", "39."),
         fsdp_strategy=COMMON_FSDP_STRATEGY,
     )
 
@@ -143,6 +147,7 @@ class xFuserWan22I2VModel(xFuserWan21I2VModel):
                 "dtype": torch.bfloat16,
         }
         self.settings.fp8_gemm_module_list=["transformer.blocks", "transformer_2.blocks"]
+        self.settings.fp8_precision_overrides=None
 
 
     def _load_model(self) -> DiffusionPipeline:
@@ -187,6 +192,7 @@ class xFuserWan21T2VModel(xFuserModel):
         ring_degree=True,
         fully_shard_degree=True,
         use_fp8_gemms=True,
+        use_fp4_gemms=True,
         use_hybrid_fp8_attn=True,
     )
     default_input_values = DefaultInputValues(
@@ -205,6 +211,8 @@ class xFuserWan21T2VModel(xFuserModel):
         model_name="Wan-AI/Wan2.1-T2V-14B-Diffusers",
         output_name="wan2.1_t2v",
         fp8_gemm_module_list=["transformer.blocks"],
+        fp4_gemm_module_list=["transformer.blocks"],
+        fp8_precision_overrides=("0.", "1.", "2.", "3.", "4.","35.", "36.", "37.", "38.", "39."),
         fsdp_strategy=COMMON_FSDP_STRATEGY,
     )
 
@@ -258,6 +266,7 @@ class xFuserWan22T2VModel(xFuserWan21T2VModel):
                 "dtype": torch.bfloat16,
         }
         self.settings.fp8_gemm_module_list=["transformer.blocks", "transformer_2.blocks"]
+        self.settings.fp8_precision_overrides=None
 
     def _load_model(self) -> DiffusionPipeline:
         transformer = xFuserWanTransformer3DWrapper.from_pretrained(

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -237,7 +237,7 @@ class xFuserWan21T2VModel(xFuserModel):
             pretrained_model_name_or_path=self.settings.model_name,
             torch_dtype=torch.bfloat16,
             transformer=transformer,
-        )
+        pipe.scheduler.config.flow_shift = self.settings.flow_shift
         pipe.scheduler.config.flow_shit = self.settings.flow_shift
         return pipe
 
@@ -296,7 +296,7 @@ class xFuserWan22T2VModel(xFuserWan21T2VModel):
             transformer=transformer,
             transformer_2=transformer_2,
         )
-        pipe.scheduler.config.flow_shit = self.settings.flow_shift
+        pipe.scheduler.config.flow_shift = self.settings.flow_shift
         return pipe
 
     def _compile_model(self, input_args):
@@ -351,7 +351,7 @@ class xFuserWan22TI2VModel(xFuserWan21T2VModel):
                 torch_dtype=torch.bfloat16,
                 transformer=transformer,
         )
-        pipe.scheduler.config.flow_shit = self.settings.flow_shift
+        pipe.scheduler.config.flow_shift = self.settings.flow_shift
         return pipe
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -54,7 +54,7 @@ class xFuserWan21I2VModel(xFuserModel):
         fully_shard_degree=True,
         use_fp8_gemms=True,
         use_cfg_parallel=True,
-        use_fp4_gemms=True
+        use_fp4_gemms=True,
         use_hybrid_attn_schedule=True,
     )
     default_input_values = DefaultInputValues(
@@ -237,8 +237,8 @@ class xFuserWan21T2VModel(xFuserModel):
             pretrained_model_name_or_path=self.settings.model_name,
             torch_dtype=torch.bfloat16,
             transformer=transformer,
+        )
         pipe.scheduler.config.flow_shift = self.settings.flow_shift
-        pipe.scheduler.config.flow_shit = self.settings.flow_shift
         return pipe
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -74,6 +74,7 @@ class xFuserWan21I2VModel(xFuserModel):
         fp4_gemm_module_list=["transformer.blocks"],
         fp8_precision_overrides=("0.", "1.", "2.", "3.", "4.","35.", "36.", "37.", "38.", "39."),
         fsdp_strategy=COMMON_FSDP_STRATEGY,
+        flow_shift=5,
     )
 
     def _load_model(self) -> DiffusionPipeline:
@@ -87,6 +88,7 @@ class xFuserWan21I2VModel(xFuserModel):
                 torch_dtype=torch.bfloat16,
                 transformer=transformer,
         )
+        pipe.scheduler.config.flow_shift = self.settings.flow_shift
         return pipe
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
@@ -167,6 +169,7 @@ class xFuserWan22I2VModel(xFuserWan21I2VModel):
                 transformer=transformer,
                 transformer_2=transformer_2,
         )
+        pipe.scheduler.config.flow_shift = self.settings.flow_shift
         return pipe
 
     def _compile_model(self, input_args):
@@ -214,6 +217,7 @@ class xFuserWan21T2VModel(xFuserModel):
         fp4_gemm_module_list=["transformer.blocks"],
         fp8_precision_overrides=("0.", "1.", "2.", "3.", "4.","35.", "36.", "37.", "38.", "39."),
         fsdp_strategy=COMMON_FSDP_STRATEGY,
+        flow_shift=12,
     )
 
     def _load_model(self) -> DiffusionPipeline:
@@ -227,6 +231,7 @@ class xFuserWan21T2VModel(xFuserModel):
             torch_dtype=torch.bfloat16,
             transformer=transformer,
         )
+        pipe.scheduler.config.flow_shit = self.settings.flow_shift
         return pipe
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
@@ -285,6 +290,7 @@ class xFuserWan22T2VModel(xFuserWan21T2VModel):
             transformer=transformer,
             transformer_2=transformer_2,
         )
+        pipe.scheduler.config.flow_shit = self.settings.flow_shift
         return pipe
 
     def _compile_model(self, input_args):
@@ -323,6 +329,7 @@ class xFuserWan22TI2VModel(xFuserWan21T2VModel):
         fp8_gemm_module_list=["transformer.blocks"],
         fsdp_strategy=COMMON_FSDP_STRATEGY,
         valid_tasks=["i2v", "t2v"],
+        flow_shift=5,
     )
 
     def _load_model(self) -> DiffusionPipeline:
@@ -338,6 +345,7 @@ class xFuserWan22TI2VModel(xFuserWan21T2VModel):
                 torch_dtype=torch.bfloat16,
                 transformer=transformer,
         )
+        pipe.scheduler.config.flow_shit = self.settings.flow_shift
         return pipe
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:


### PR DESCRIPTION
Enable MXFP4 Gemms via AITER. To do this, a custom linear layer class is used to quantize the weights and call AITER gemm op instead of torch.nn.functional.linear. MXFP4 Gemms are enabled for Wan2.X I2V and T2V models, as well as Flux.2-dev. Diffusion models have proven complicated to quantize down to FP4, causing output quality regressions. Due to this, special strategies have been deployed for the Wan models. 

For all models, only the linear layers in the transformer blocks are quantized.

- Wan2.1 I2V and T2V: The first and last 10 transformer blocks are quantized to FP8, the rest to FP4.
- Wan2.2 I2V and T2V: The first transformer is quantized to FP4, the second to FP8.

This will give ~1.5% For Wan2.2 and ~2% perf gain for Wan2.1, while Flux.2 improves by 14%, on MI355X

To enable the MXFP4 Gemms, simply pass --use_fp4_gemms in the run command. Only supported with AITER currently.

**Results:**
Wan2.1 I2V: 
Baseline video:

https://github.com/user-attachments/assets/de84aacd-c32a-4b5f-ba3f-1da25a2e4180

MXFP4 Gemms:

https://github.com/user-attachments/assets/61fb8564-c590-461e-9eef-c977004d5f93


Wan2.2 I2V: 

Baseline video:

https://github.com/user-attachments/assets/94b2b4a1-ad72-4c50-a613-4d2b591b96bf


MXFP4 Gemms:

https://github.com/user-attachments/assets/6002845c-a5ee-4d67-9da8-5e6196fc25c0


Wan2.1 T2V: 
Baseline video:

https://github.com/user-attachments/assets/1c293a9c-93a8-489c-9809-6cb91b6cbb6f


MXFP4 Gemms:

https://github.com/user-attachments/assets/8f3ceb83-8c3c-4b4d-8793-97d3fa9250e6


Wan2.2 T2V: 
Baseline video:

https://github.com/user-attachments/assets/f47a0ca2-8b56-466a-be0e-b6929768035b


MXFP4 Gemms:

https://github.com/user-attachments/assets/be4c75c4-a1ba-41be-8802-c39ef38a1596


Flux.2:

Baseline:
<img width="1024" height="1024" alt="flux_2_fp8" src="https://github.com/user-attachments/assets/1d3e6e15-13f6-46f2-9506-8cd1e56aa01a" />

MXFP4 Gemms:
<img width="1024" height="1024" alt="flux_2_fp4" src="https://github.com/user-attachments/assets/7deab081-ff8d-49a6-b5b0-78f252087e33" />
