### PR TITLE
Enable hybrid attn scheduling capability for Wan2.2-5B

### DIFF
--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -316,6 +316,7 @@ class xFuserWan22TI2VModel(xFuserWan21T2VModel):
         ring_degree=True,
         fully_shard_degree=True,
         use_fp8_gemms=True,
+        use_hybrid_attn_schedule=True,
     )
     default_input_values = DefaultInputValues(
         height=736,


### PR DESCRIPTION
This PR enables [hybrid attn. scheduling capability](https://github.com/xdit-project/xDiT/pull/645) for `Wan-AI/Wan2.2-TI2V-5B-Diffusers` model. 

## Tests

Verified that custom scheduling works, perf. is expected and output video is ok with:
```bash
xdit \
    --model Wan-AI/Wan2.2-TI2V-5B-Diffusers \
    --ulysses_degree 8 \
    --prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside." \
    --input_images https://huggingface.co/Wan-AI/Wan2.2-I2V-A14B/resolve/main/examples/i2v_input.JPG \
    --width 1280 \
    --height 736 \
    --use_torch_compile \
    --num_inference_steps 50 \
    --num_frames 121 \
    --guidance_scale 5.0 \
    --task i2v \
    --num_iterations 3 \
    --use_fp8_gemms \
    --resize_input_images \
    --use_hybrid_attn_schedule \
    --hybrid_attn_low_precision_backend aiter_sage \
    --hybrid_attn_high_precision_backend aiter \
    --num_hybrid_attn_high_precision_steps 5
```