### PR TITLE
Profiling: use .json.gz format

### DIFF
--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -365,7 +365,7 @@ class xFuserModel(abc.ABC):
         log(f"Timings saved to {self.config.output_directory}/timings.json")
 
     def save_profile(self, profile: torch.profiler.profiler.profile) -> None:
-        profile_file = f"{self.config.output_directory}/profile_trace_rank_{get_world_group().rank}.json"
+        profile_file = f"{self.config.output_directory}/profile_trace_rank_{get_world_group().rank}.json.gz"
         profile.export_chrome_trace(profile_file)
         log(f"Profile trace saved to {profile_file}")
 


### PR DESCRIPTION
Profiles for diffusion models can be quite large, we can save some disk space by saving in `.json.gz` format that is supported `profile.export_chrome_trace`.

Before this PR:
```
> ls -lh
total 631M
-rw-r--r-- 1 root root 631M Feb 20 01:29 profile_trace_rank_7.json
```

This PR:
```
> ls -lh
total 33M
-rw-r--r-- 1 root root 33M Feb 20 01:46 profile_trace_rank_7.json.gz
```