### PR TITLE
disbale AITER on AMD Radeon GPU for the time being

### DIFF
--- a/xfuser/envs.py
+++ b/xfuser/envs.py
@@ -199,20 +199,24 @@ class PackagesEnvChecker:
         Checks whether ROCm AITER library is installed
         Because AITER hasn't been enabled on AMD Radeon GPU officially, it returns False directly.
         """
-        gpu_name = torch.cuda.get_device_name().strip()
-        if "Radeon" in gpu_name or "RX" in gpu_name:
+        if torch.cuda.is_available():
+            gpu_name = torch.cuda.get_device_name().strip()
+            if "Radeon" in gpu_name :
+                return False
+        
+            try:
+                import aiter
+                return True
+            except:
+                if _is_hip():
+                    logger.warning(
+                        f'Using AMD GPUs, but library "aiter" is not installed, '
+                        'defaulting to other attention mechanisms'
+                    )
+                return False
+        else:
             return False
         
-        try:
-            import aiter
-            return True
-        except:
-            if _is_hip():
-                logger.warning(
-                    f'Using AMD GPUs, but library "aiter" is not installed, '
-                    'defaulting to other attention mechanisms'
-                )
-            return False
 
 
     def check_flash_attn(self):


### PR DESCRIPTION
because AITER library hasn't been supported fully on AMD Radeon GPU, we disable it for the time being, otherwiese xDit will fail to run on Radeon GPU.

with this patch, I can run PixArt-XL-2-1024-MS model successfully on 4 AMD R9700 GPU.