### PR TITLE
Transformer engine fp8 attention

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,13 +264,14 @@ Several different attention backends are supported:
 | [FAv2](https://github.com/Dao-AILab/flash-attention) | flash |
 | [FAv3](https://github.com/Dao-AILab/flash-attention/tree/main/hopper) | flash_3 |
 | [FAv3 FP8](https://github.com/Dao-AILab/flash-attention/tree/main/hopper) | flash_3_fp8 |
+| [Transformer Engine FP8](https://github.com/NVIDIA/TransformerEngine) | nvte_fp8 |
 | [FAv4](https://github.com/Dao-AILab/flash-attention/tree/main/flash_attn/cute) | flash_4 |
 | [SAGE](https://github.com/thu-ml/SageAttention) | sage |
 | [AITER](https://github.com/rocm/aiter) | aiter |
 | [AITER FP8](https://github.com/rocm/aiter) | aiter_fp8 |
 
 xDiT comes with `flash_attn` as an optional install requirement, as it currently supports the largest variety of different GPU architectures.
-However, newer implementations generally offer better performance. If available for you, we highly recommend using `cuDNN`, `FAv3` (on _hopper_ GPUs) or `FAv4` (on _blackwell_ GPUs).
+However, newer implementations generally offer better performance. If available for you, we highly recommend using `cuDNN`, `FAv3`, `FAv3 FP8` (on _hopper_ GPUs) or `FAv4`, `Transformer engine FP8` (on _blackwell_ GPUs).
 On recent AMD GPUs (MI300X or newer) it is generally recommended to use `AITER` in all cases to get the best possible performance. Note that when using `AITER FP8` as the attention backend with `torch.compile`, it is important to use a version of `AITER` from Jan 16, 2026 or later. Older versions may trigger a bug related to the fake tensors, resulting in a runtime error.
 
 

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -104,6 +104,8 @@ class xFuserArgs:
     seed: int = 42
     output_type: str = "pil"
     guidance_scale: float = 3.5
+    guidance_scale_2: Optional[float] = None
+    flow_shift: Optional[float] = None
     enable_model_cpu_offload: bool = False
     enable_sequential_cpu_offload: bool = False
     enable_tiling: bool = False
@@ -532,6 +534,16 @@ class xFuserArgs:
             "--guidance_scale",
             type=float,
             help="Guidance scale for classifier free guidance.",
+        )
+        parser.add_argument(
+            "--guidance_scale_2",
+            type=float,
+            help="Guidance scale for classifier free guidance (second scale).",
+        )
+        parser.add_argument(
+            "--flow_shift",
+            type=float,
+            help="Flow shift for the scheduler.",
         )
         parser.add_argument(
             "--enable_sequential_cpu_offload",

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -113,7 +113,7 @@ class AttentionBackendType(Enum):
     CUDNN =  "cuDNN"
     FLASH_3 = "Flash Attention V3"
     FLASH_3_FP8 = "Flash Attention v3 FP8"
-    TE_FP8_FLASH_ATTN = "TE FP8 Flash Attention"
+    TE_FP8 = "TE FP8"
     FLASH_4 = "Flash Attention V4"
     SAGE = "Sage Attention"
     AITER = "AITER"
@@ -458,7 +458,7 @@ def _get_cached_te_fp8_dot_product_attention(
         attention_dropout=0.0,
     ).to(torch.device("cuda", device_index)).eval()
 
-@register_attention_function(AttentionBackendType.TE_FP8_FLASH_ATTN)
+@register_attention_function(AttentionBackendType.TE_FP8)
 def _te_fp8_flash_attn_call(query, key, value, dropout_p, is_causal):
     query = query.permute(0, 2, 1, 3).contiguous()
     key = key.permute(0, 2, 1, 3).contiguous()

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -97,9 +97,7 @@ if env_info["has_transformer_engine"]:
     from transformer_engine.common import recipe
 
     TE_FP8_SCALING = recipe.DelayedScaling(
-        fp8_format=recipe.Format.HYBRID, # E4M3 during forward pass, E5M2 during backward pass
-        amax_history_len=16,
-        amax_compute_algo="max",
+        fp8_dpa=True,
     )
 if env_info["has_sage"]:
     from sageattention import sageattn

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -113,7 +113,7 @@ class AttentionBackendType(Enum):
     CUDNN =  "cuDNN"
     FLASH_3 = "Flash Attention V3"
     FLASH_3_FP8 = "Flash Attention v3 FP8"
-    TE_FP8 = "TE FP8"
+    NVTE_FP8 = "NVTE FP8"
     FLASH_4 = "Flash Attention V4"
     SAGE = "Sage Attention"
     AITER = "AITER"
@@ -458,8 +458,8 @@ def _get_cached_te_fp8_dot_product_attention(
         attention_dropout=0.0,
     ).to(torch.device("cuda", device_index)).eval()
 
-@register_attention_function(AttentionBackendType.TE_FP8)
-def _te_fp8_flash_attn_call(query, key, value, dropout_p, is_causal):
+@register_attention_function(AttentionBackendType.NVTE_FP8)
+def _nvte_fp8_flash_attn_call(query, key, value, dropout_p, is_causal):
     query = query.permute(0, 2, 1, 3).contiguous()
     key = key.permute(0, 2, 1, 3).contiguous()
     value = value.permute(0, 2, 1, 3).contiguous()

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -92,6 +92,15 @@ if env_info["has_flash_attn_3"]:
     from flash_attn_interface import flash_attn_func as flash_attn_func_3
 if env_info["has_flash_attn_4"]:
     from flash_attn.cute.interface import flash_attn_func as flash_attn_func_4
+if env_info["has_transformer_engine"]:
+    from transformer_engine.pytorch import DotProductAttention, fp8_autocast
+    from transformer_engine.common import recipe
+
+    TE_FP8_SCALING = recipe.DelayedScaling(
+        fp8_format=recipe.Format.HYBRID, # E4M3 during forward pass, E5M2 during backward pass
+        amax_history_len=16,
+        amax_compute_algo="max",
+    )
 if env_info["has_sage"]:
     from sageattention import sageattn
 if env_info["has_npu_flash_attn"]:
@@ -106,6 +115,7 @@ class AttentionBackendType(Enum):
     CUDNN =  "cuDNN"
     FLASH_3 = "Flash Attention V3"
     FLASH_3_FP8 = "Flash Attention v3 FP8"
+    TE_FP8_FLASH_ATTN = "TE FP8 Flash Attention"
     FLASH_4 = "Flash Attention V4"
     SAGE = "Sage Attention"
     AITER = "AITER"
@@ -434,3 +444,37 @@ def _sage_attn_call(query, key, value, dropout_p, is_causal):
         return_lse=True
     )
     return output, softmax_lse
+
+@functools.lru_cache(maxsize=32)
+def _get_cached_te_fp8_dot_product_attention(
+    num_attention_heads: int,
+    kv_channels: int,
+    attn_mask_type: str,
+    device_index: int,
+):
+    return DotProductAttention(
+        num_attention_heads=num_attention_heads,
+        kv_channels=kv_channels,
+        qkv_format="bshd",
+        attn_mask_type=attn_mask_type,
+        attention_dropout=0.0,
+    ).to(torch.device("cuda", device_index)).eval()
+
+@register_attention_function(AttentionBackendType.TE_FP8_FLASH_ATTN)
+def _te_fp8_flash_attn_call(query, key, value, dropout_p, is_causal):
+    query = query.permute(0, 2, 1, 3).contiguous()
+    key = key.permute(0, 2, 1, 3).contiguous()
+    value = value.permute(0, 2, 1, 3).contiguous()
+    batch, seqlen, num_heads, head_dim = query.shape
+    attn_mask_type = "causal" if is_causal else "no_mask"
+    device_index = query.device.index if query.device.index is not None else 0
+    dpa = _get_cached_te_fp8_dot_product_attention(
+        num_heads,
+        head_dim,
+        attn_mask_type,
+        device_index,
+    )
+    with fp8_autocast(enabled=True, fp8_recipe=TE_FP8_SCALING):
+        out = dpa(query, key, value, attn_mask_type=attn_mask_type)
+    out = out.view(batch, seqlen, num_heads, head_dim).permute(0, 2, 1, 3)
+    return out, None

--- a/xfuser/core/distributed/runtime_state.py
+++ b/xfuser/core/distributed/runtime_state.py
@@ -124,7 +124,7 @@ class RuntimeState(metaclass=ABCMeta):
         self._check_if_backend_compatible_with_current_configuration(attention_backend)
         self.attention_backend = attention_backend
         logger.warning("Using {} as attention backend.".format(self.attention_backend.name))
-        if attention_backend in [AttentionBackendType.FLASH_3_FP8, AttentionBackendType.AITER_FP8, AttentionBackendType.TE_FP8_FLASH_ATTN]:
+        if attention_backend in [AttentionBackendType.FLASH_3_FP8, AttentionBackendType.AITER_FP8, AttentionBackendType.TE_FP8]:
             logger.warning("FP8 attention backend is enabled. This may cause poor quality outputs, consider using hybrid attention if possible.")
 
 
@@ -214,7 +214,7 @@ class RuntimeState(metaclass=ABCMeta):
                 from aiter import flash_attn_fp8_pertensor_func
             except ImportError:
                 raise RuntimeError("AITER fp8 flash attention is not available, please update AITER")
-        if attention_backend == AttentionBackendType.TE_FP8_FLASH_ATTN:
+        if attention_backend == AttentionBackendType.TE_FP8:
             if not env_info.get("has_transformer_engine"):
                 raise RuntimeError(
                     "Transformer Engine FP8 attention requires transformer-engine"

--- a/xfuser/core/distributed/runtime_state.py
+++ b/xfuser/core/distributed/runtime_state.py
@@ -124,7 +124,7 @@ class RuntimeState(metaclass=ABCMeta):
         self._check_if_backend_compatible_with_current_configuration(attention_backend)
         self.attention_backend = attention_backend
         logger.warning("Using {} as attention backend.".format(self.attention_backend.name))
-        if attention_backend in [AttentionBackendType.FLASH_3_FP8, AttentionBackendType.AITER_FP8, AttentionBackendType.TE_FP8]:
+        if attention_backend in [AttentionBackendType.FLASH_3_FP8, AttentionBackendType.AITER_FP8, AttentionBackendType.NVTE_FP8]:
             logger.warning("FP8 attention backend is enabled. This may cause poor quality outputs, consider using hybrid attention if possible.")
 
 
@@ -214,7 +214,7 @@ class RuntimeState(metaclass=ABCMeta):
                 from aiter import flash_attn_fp8_pertensor_func
             except ImportError:
                 raise RuntimeError("AITER fp8 flash attention is not available, please update AITER")
-        if attention_backend == AttentionBackendType.TE_FP8:
+        elif attention_backend == AttentionBackendType.NVTE_FP8:
             if not env_info.get("has_transformer_engine"):
                 raise RuntimeError(
                     "Transformer Engine FP8 attention requires transformer-engine"

--- a/xfuser/core/distributed/runtime_state.py
+++ b/xfuser/core/distributed/runtime_state.py
@@ -124,7 +124,7 @@ class RuntimeState(metaclass=ABCMeta):
         self._check_if_backend_compatible_with_current_configuration(attention_backend)
         self.attention_backend = attention_backend
         logger.warning("Using {} as attention backend.".format(self.attention_backend.name))
-        if attention_backend in [AttentionBackendType.FLASH_3_FP8, AttentionBackendType.AITER_FP8]:
+        if attention_backend in [AttentionBackendType.FLASH_3_FP8, AttentionBackendType.AITER_FP8, AttentionBackendType.TE_FP8_FLASH_ATTN]:
             logger.warning("FP8 attention backend is enabled. This may cause poor quality outputs, consider using hybrid attention if possible.")
 
 
@@ -214,6 +214,11 @@ class RuntimeState(metaclass=ABCMeta):
                 from aiter import flash_attn_fp8_pertensor_func
             except ImportError:
                 raise RuntimeError("AITER fp8 flash attention is not available, please update AITER")
+        if attention_backend == AttentionBackendType.TE_FP8_FLASH_ATTN:
+            if not env_info.get("has_transformer_engine"):
+                raise RuntimeError(
+                    "Transformer Engine FP8 attention requires transformer-engine"
+                )
         elif attention_backend == AttentionBackendType.AITER_SAGE:
             try:
                 import aiter.ops.triton.attention

--- a/xfuser/envs.py
+++ b/xfuser/envs.py
@@ -204,6 +204,7 @@ class PackagesEnvChecker:
         packages_info["has_flash_attn"] = self.check_flash_attn()
         packages_info["has_flash_attn_3"] = self._check_flash_attn_3()
         packages_info["has_flash_attn_4"] = self._check_flash_attn_4()
+        packages_info["has_transformer_engine"] = self.check_transformer_engine()
         packages_info["has_sage"] = self._check_sage()
         packages_info["has_long_ctx_attn"] = self.check_long_ctx_attn()
         packages_info["diffusers_version"] = self.check_diffusers_version()
@@ -273,6 +274,36 @@ class PackagesEnvChecker:
             from flash_attn.cute import interface as flash_cute
             return True
         except:
+            return False
+    
+    @staticmethod
+    def _install_flash_attn_3_shim_for_transformer_engine() -> None:
+        """TE imports ``flash_attn_3.flash_attn_interface``; wheels often expose only ``flash_attn_interface``."""
+        import sys
+        import types
+
+        if "flash_attn_3.flash_attn_interface" in sys.modules:
+            return
+        try:
+            import flash_attn_interface as _fai
+        except ImportError:
+            return
+        if "flash_attn_3" not in sys.modules:
+            sys.modules["flash_attn_3"] = types.ModuleType("flash_attn_3")
+        sys.modules["flash_attn_3.flash_attn_interface"] = _fai
+
+    def check_transformer_engine(self):
+        import sys
+        if not torch.cuda.is_available() or _is_hip():
+            return False
+        self._install_flash_attn_3_shim_for_transformer_engine()
+        if "flash_attn_3.flash_attn_interface" not in sys.modules:
+            return False
+        try:
+            from transformer_engine.pytorch import DotProductAttention, fp8_autocast  # noqa: F401
+            from transformer_engine.common import recipe # noqa: F401
+            return True
+        except ImportError:
             return False
 
     def _check_sage(self):

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -81,6 +81,8 @@ class DefaultInputValues:
     negative_prompt: Optional[str] = None
     num_inference_steps: Optional[int] = None
     guidance_scale: Optional[float] = None
+    guidance_scale_2: Optional[float] = None
+    flow_shift: Optional[float] = None
     max_sequence_length: Optional[int] = None
     num_hybrid_attn_high_precision_steps: Optional[int] = None
     num_hybrid_gemm_high_precision_steps: Optional[int] = None
@@ -110,7 +112,6 @@ class ModelSettings:
     })
     valid_tasks: List[str] = field(default_factory=list)
     resolution_divisor: Optional[int] = None
-    flow_shift: Optional[int] = None
 
 class DiffusionOutput:
     """ Class to encapsulate diffusion model outputs """

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -89,6 +89,8 @@ class xFuserWan21I2VModel(xFuserModel):
         num_frames=81,
         negative_prompt="bright colors, overexposed, static, blurred details, subtitles, style, artwork, painting, picture, still, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, malformed limbs, fused fingers, still picture, cluttered background, three legs, many people in the background, walking backwards",
         guidance_scale=3.5,
+        guidance_scale_2=None,
+        flow_shift=5,
         num_hybrid_attn_high_precision_steps = 5,
     )
     settings = ModelSettings(
@@ -104,13 +106,13 @@ class xFuserWan21I2VModel(xFuserModel):
                                  "30.", "31.", "32.", "33.", "34.",
                                  "35.", "36.", "37.", "38.", "39."),
         fsdp_strategy=COMMON_FSDP_STRATEGY,
-        flow_shift=5,
     )
 
     def _post_load_and_state_initialization(self, input_args: dict) -> None:
         super()._post_load_and_state_initialization(input_args)
         if self.config.use_parallel_vae:
             _setup_parallel_vae(self.pipe.vae)
+        self.pipe.scheduler.config.flow_shift = input_args["flow_shift"]
 
     def _load_model(self) -> DiffusionPipeline:
         transformer = xFuserWanTransformer3DWrapper.from_pretrained(
@@ -123,7 +125,6 @@ class xFuserWan21I2VModel(xFuserModel):
                 torch_dtype=torch.bfloat16,
                 transformer=transformer,
         )
-        pipe.scheduler.config.flow_shift = self.settings.flow_shift
         return pipe
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
@@ -136,6 +137,7 @@ class xFuserWan21I2VModel(xFuserModel):
             num_inference_steps=input_args["num_inference_steps"],
             num_frames=input_args["num_frames"],
             guidance_scale=input_args["guidance_scale"],
+            guidance_scale_2=input_args["guidance_scale_2"],
             generator=torch.Generator(device="cuda").manual_seed(input_args["seed"]),
         )
         return DiffusionOutput(videos=output.frames, pipe_args=input_args)
@@ -203,7 +205,6 @@ class xFuserWan22I2VModel(xFuserWan21I2VModel):
                 transformer=transformer,
                 transformer_2=transformer_2,
         )
-        pipe.scheduler.config.flow_shift = self.settings.flow_shift
         return pipe
 
     def _compile_model(self, input_args):
@@ -241,6 +242,8 @@ class xFuserWan21T2VModel(xFuserModel):
         num_frames=81,
         negative_prompt="bright colors, overexposed, static, blurred details, subtitles, style, artwork, painting, picture, still, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, malformed limbs, fused fingers, still picture, cluttered background, three legs, many people in the background, walking backwards",
         guidance_scale=3.5,
+        guidance_scale_2=None,
+        flow_shift=12,
         num_hybrid_attn_high_precision_steps = 5,
     )
     settings = ModelSettings(
@@ -256,13 +259,13 @@ class xFuserWan21T2VModel(xFuserModel):
                                  "30.", "31.", "32.", "33.", "34.",
                                  "35.", "36.", "37.", "38.", "39."),
         fsdp_strategy=COMMON_FSDP_STRATEGY,
-        flow_shift=12,
     )
 
     def _post_load_and_state_initialization(self, input_args: dict) -> None:
         super()._post_load_and_state_initialization(input_args)
         if self.config.use_parallel_vae:
             _setup_parallel_vae(self.pipe.vae)
+        self.pipe.scheduler.config.flow_shift = input_args["flow_shift"]
 
     def _load_model(self) -> DiffusionPipeline:
         transformer = xFuserWanTransformer3DWrapper.from_pretrained(
@@ -275,7 +278,6 @@ class xFuserWan21T2VModel(xFuserModel):
             torch_dtype=torch.bfloat16,
             transformer=transformer,
         )
-        pipe.scheduler.config.flow_shift = self.settings.flow_shift
         return pipe
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
@@ -287,6 +289,7 @@ class xFuserWan21T2VModel(xFuserModel):
             num_inference_steps=input_args["num_inference_steps"],
             num_frames=input_args["num_frames"],
             guidance_scale=input_args["guidance_scale"],
+            guidance_scale_2=input_args["guidance_scale_2"],
             generator=torch.Generator(device="cuda").manual_seed(input_args["seed"]),
         )
         return DiffusionOutput(videos=output.frames, pipe_args=input_args)
@@ -333,7 +336,6 @@ class xFuserWan22T2VModel(xFuserWan21T2VModel):
             transformer=transformer,
             transformer_2=transformer_2,
         )
-        pipe.scheduler.config.flow_shift = self.settings.flow_shift
         return pipe
 
     def _compile_model(self, input_args):
@@ -366,6 +368,8 @@ class xFuserWan22TI2VModel(xFuserWan21T2VModel):
         num_frames=121,
         negative_prompt="bright colors, overexposed, static, blurred details, subtitles, style, artwork, painting, picture, still, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, malformed limbs, fused fingers, still picture, cluttered background, three legs, many people in the background, walking backwards",
         guidance_scale=5.0,
+        guidance_scale_2=None,
+        flow_shift=5,
         num_hybrid_attn_high_precision_steps=5,
         num_hybrid_gemm_high_precision_steps=5,
     )
@@ -380,7 +384,6 @@ class xFuserWan22TI2VModel(xFuserWan21T2VModel):
         fp8_precision_overrides=("0.", "1.", "28.", "29."),
         fsdp_strategy=COMMON_FSDP_STRATEGY,
         valid_tasks=["i2v", "t2v"],
-        flow_shift=5,
     )
 
     def _load_model(self) -> DiffusionPipeline:
@@ -396,7 +399,6 @@ class xFuserWan22TI2VModel(xFuserWan21T2VModel):
                 torch_dtype=torch.bfloat16,
                 transformer=transformer,
         )
-        pipe.scheduler.config.flow_shift = self.settings.flow_shift
         return pipe
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
@@ -408,6 +410,7 @@ class xFuserWan22TI2VModel(xFuserWan21T2VModel):
             "num_inference_steps": input_args["num_inference_steps"],
             "num_frames": input_args["num_frames"],
             "guidance_scale": input_args["guidance_scale"],
+            "guidance_scale_2": input_args["guidance_scale_2"],
             "generator": torch.Generator(device="cuda").manual_seed(input_args["seed"]),
         }
         if self.config.task == "i2v":


### PR DESCRIPTION
Added Transformer Engine (TE) FP8 Attention as a new attention backend, enabling FP8 support for B200. Note that TE FP8 alone may exhibit the same artifacts observed with other supported FP8 attention backends. For the best balance between performance and quality, we recommend using a hybrid FAv4 + TE FP8 attention schedule.

Tested with:
`xdit --model Wan-AI/Wan2.2-T2V-A14B-Diffusers     --ulysses_degree 8     --prompt "a motorcycle cruising along a coastal highway"     --negative_prompt "vivid colors, overexposed, static, blurry details, subtitles, style, work of art, painting, picture, still, overall grayish, worst quality, low quality, JPEG artifacts, ugly, deformed, extra fingers, poorly drawn hands, poorly drawn face, deformed, disfigured, deformed limbs, fused fingers, static image, cluttered background, three legs, many people in the background, walking backwards"     --height 720     --width 1280     --num_frames 81     --num_iterations 1     --num_inference_steps 20     --guidance-scale 4.0 --use_torch_compile --attention_backend nvte_fp8`

Output video:

https://github.com/user-attachments/assets/73d8b9b6-c351-47bf-8571-0b98da0f7576

Using 50/50 split between FAv4 and TE FP8 results in:

https://github.com/user-attachments/assets/54f44c01-c4b2-4617-b76e-5e482f220ecb



It has also been observed that adjusting `guidance_scale_2` and `flow_shift` for the Wan models can reduce FP8-induced artifacts in output videos. This PR adds support for user-configurable values for both parameters.

Adjusting these parameters would give the following video with pure TE FP8:

https://github.com/user-attachments/assets/41c12d5f-2af1-49c6-8a0f-1335656b59b9

