### PR TITLE
move torchao imports to function bodies

### DIFF
--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -6,10 +6,6 @@ import functools
 import numpy as np
 from PIL.Image import Image
 from typing import Callable, Optional
-from torchao.quantization.granularity import PerTensor
-from torchao.quantization.quant_api import Float8DynamicActivationFloat8WeightConfig, quantize_, _is_linear
-from torchao.quantization.quantize_.common import KernelPreference
-from xfuser.model_executor.layers.mxfp4_linear import xFuserMXFP4Linear, xFuserHybridMXFP4Linear
 
 logger = logging.getLogger(__name__)
 
@@ -79,9 +75,15 @@ def resize_and_crop_image(image: Image, target_height: int, target_width: int, m
         return image
 
 def quantize_linear_layers_to_fp8(module_or_module_list_to_quantize: torch.nn.Module | torch.nn.ModuleList,
-    filter_fn: Callable[[torch.nn.Module, str], bool] = _is_linear,
+    filter_fn: Optional[Callable[[torch.nn.Module, str], bool]] = None,
     device: Optional[torch.device] = None) -> None:
     """Quantize all linear layers in the given module or module list to FP8."""
+    from torchao.quantization.granularity import PerTensor
+    from torchao.quantization.quant_api import Float8DynamicActivationFloat8WeightConfig, quantize_, _is_linear
+    from torchao.quantization.quantize_.common import KernelPreference
+
+    if filter_fn is None:
+        filter_fn = _is_linear
     config = Float8DynamicActivationFloat8WeightConfig(
                 granularity=PerTensor(),
                 set_inductor_config=False,
@@ -118,6 +120,11 @@ def rgetattr(obj: object, attr: str) -> object:
     return functools.reduce(getattr, [obj] + attr.split("."))
 
 def quantize_linear_layers_to_fp4(model, parent_name='', fp8_layers=None, use_hybrid_schedule: bool = False, device: Optional[torch.device] = None):
+    from torchao.quantization.granularity import PerTensor
+    from torchao.quantization.quant_api import Float8DynamicActivationFloat8WeightConfig, quantize_
+    from torchao.quantization.quantize_.common import KernelPreference
+    from xfuser.model_executor.layers.mxfp4_linear import xFuserMXFP4Linear, xFuserHybridMXFP4Linear
+
     for name, module in list(model.named_children()):
         full_name = f"{parent_name}.{name}" if parent_name else name
 
@@ -133,7 +140,6 @@ def quantize_linear_layers_to_fp4(model, parent_name='', fp8_layers=None, use_hy
                     device=device,
                 )
             else:
-                # Create low-precision MXFP4 replacement
                 low_precision_layer = xFuserMXFP4Linear(
                     module.in_features,
                     module.out_features,
@@ -142,7 +148,6 @@ def quantize_linear_layers_to_fp4(model, parent_name='', fp8_layers=None, use_hy
                     dtype=module.weight.dtype
                 )
 
-                # Copy weights
                 with torch.no_grad():
                     low_precision_layer.load_and_quantize_weights(module.weight, module.bias)
 
@@ -174,11 +179,9 @@ def quantize_linear_layers_to_fp4(model, parent_name='', fp8_layers=None, use_hy
                 else:
                     new_layer = low_precision_layer
 
-                # Replace
                 setattr(model, name, new_layer)
 
         elif len(list(module.children())) > 0:
-            # Recurse into submodules
             quantize_linear_layers_to_fp4(module, full_name, fp8_layers=fp8_layers, use_hybrid_schedule=use_hybrid_schedule, device=device)
 
 


### PR DESCRIPTION
`torchao` is an optional dependency for the project, but currently in `xfuser/core/utils/runner_utils.py` there are unconditional imports from `torchao`. Using the runner without `torchao` installed leads to an `ImportError` and a crash.

This PR fixes the imports by moving all `torchao` imports to the function bodies of `quantize_linear_layers_to_fp8` and `quantize_linear_layers_to_fp4`. As these functions are called once at start of inference, there is no extra overhead introduced by moving the imports. Also changes the `filter_fn` default on `quantize_linear_layers_to_fp8()` from `_is_linear` (a torchao symbol) to `None`, resolved internally at call time without changing the current default behavior.

I tested that after moving the imports, I can run inference without `torchao` installed.