### PR TITLE
Change FLUX.1-dev compile mode

### DIFF
--- a/xfuser/model_executor/models/runner_models/flux.py
+++ b/xfuser/model_executor/models/runner_models/flux.py
@@ -72,6 +72,14 @@ class xFuserFluxModel(xFuserModel):
         if self.config.use_parallel_vae:
             _setup_parallel_vae(self.pipe.vae)
 
+    def _compile_model(self, input_args: dict) -> None:
+        """ Compile the model using torch.compile."""
+        torch._inductor.config.reorder_for_compute_comm_overlap = True
+        self.pipe.transformer = torch.compile(self.pipe.transformer, mode="reduce-overhead") # Better perf for FLUX.1
+        # two steps to warmup the torch compiler
+        input_args["num_inference_steps"] = 2
+        self._run_timed_pipe(input_args)
+
     def _load_model(self) -> DiffusionPipeline:
         if self.config.pipefusion_parallel_degree > 1:
             pipe = xFuserFluxPipeline.from_pretrained(

--- a/xfuser/runner.py
+++ b/xfuser/runner.py
@@ -89,6 +89,8 @@ class xFuserModelRunner:
 
     def cleanup(self) -> None:
         """ Cleanup resources after model execution """
+        torch.compiler.reset()
+        torch.cuda.synchronize()
         del self.model.pipe
         gc.collect()
         torch.cuda.empty_cache()


### PR DESCRIPTION
# What?
Changes the FLUX.1-dev compile mode from `default` to `reduce-overhead`.

# Why?
FLUX.1-dev is CPU bound at times, so `reduce-overhead` reduces this, improving the e2e performance.

# Extra
Also adds compiler reset to the cleanup code, otherwise we end up in deadlock with this change.
`reduce-overhead` enables CUDA graph capturing, so `torch.compile` records async NCCL ops directly into the graph. When we call `destroy_distributed_env()` on all ranks, we can end up in deadlock situation, as some ranks might still wait for some NCCL ops while as others want to destroy the environment (which requires a sync).
