### PR TITLE
Add NVFP4 GEMM quantization for Blackwell GPUs

### DIFF
--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -185,6 +185,95 @@ def quantize_linear_layers_to_fp4(model, parent_name='', fp8_layers=None, use_hy
             quantize_linear_layers_to_fp4(module, full_name, fp8_layers=fp8_layers, use_hybrid_schedule=use_hybrid_schedule, device=device)
 
 
+def quantize_linear_layers_to_nvfp4(
+    module_or_module_list_to_quantize: torch.nn.Module | torch.nn.ModuleList,
+    fp8_layers: tuple[str] = None,
+    device: Optional[torch.device] = None,
+    min_layer_size: int = 0,
+    use_triton_kernel: bool = False,
+) -> None:
+    """Quantize linear layers to NVFP4 using torchao on NVIDIA Blackwell GPUs.
+
+    Args:
+        module_or_module_list_to_quantize: Module(s) whose linear layers will be quantized.
+        fp8_layers: FQN prefixes of layers that should use FP8 instead of NVFP4
+            for quality-sensitive blocks.
+        device: Target device.
+        min_layer_size: Skip NVFP4 for layers where min(out_features, in_features)
+            is below this threshold (quantization overhead may exceed the speedup).
+        use_triton_kernel: Whether to use the Triton-based NVFP4 kernel.
+    """
+    from torchao.prototype.mx_formats.inference_workflow import (
+        NVFP4DynamicActivationNVFP4WeightConfig,
+    )
+    from torchao.quantization.quant_api import quantize_, _is_linear
+
+    nvfp4_config = NVFP4DynamicActivationNVFP4WeightConfig(
+        use_dynamic_per_tensor_scale=True,
+        use_triton_kernel=use_triton_kernel,
+    )
+
+    if isinstance(module_or_module_list_to_quantize, torch.nn.Module):
+        module_or_module_list_to_quantize = [module_or_module_list_to_quantize]
+
+    quantized_count = 0
+    skipped_fp8_count = 0
+    skipped_small_count = 0
+
+    for module in module_or_module_list_to_quantize:
+        for fqn, submodule in module.named_modules():
+            if not isinstance(submodule, torch.nn.Linear):
+                continue
+
+            if fp8_layers and fqn.startswith(fp8_layers):
+                log(f"  [NVFP4] SKIP (fp8 override) {fqn}: shape=({submodule.out_features}, {submodule.in_features})")
+                skipped_fp8_count += 1
+                continue
+
+            layer_min = min(submodule.out_features, submodule.in_features)
+            if min_layer_size > 0 and layer_min < min_layer_size:
+                log(f"  [NVFP4] SKIP (too small, min_dim={layer_min} < {min_layer_size}) {fqn}: shape=({submodule.out_features}, {submodule.in_features})")
+                skipped_small_count += 1
+                continue
+
+            log(f"  [NVFP4] QUANTIZE {fqn}: shape=({submodule.out_features}, {submodule.in_features})")
+            quantized_count += 1
+
+        def nvfp4_filter_fn(mod, fqn):
+            if not _is_linear(mod, fqn):
+                return False
+            if fp8_layers and fqn.startswith(fp8_layers):
+                return False
+            if min_layer_size > 0:
+                layer_min = min(mod.out_features, mod.in_features)
+                if layer_min < min_layer_size:
+                    return False
+            return True
+
+        quantize_(module, config=nvfp4_config, filter_fn=nvfp4_filter_fn, device=device)
+
+        if fp8_layers:
+            from torchao.quantization.granularity import PerTensor
+            from torchao.quantization.quant_api import Float8DynamicActivationFloat8WeightConfig
+            from torchao.quantization.quantize_.common import KernelPreference
+
+            fp8_config = Float8DynamicActivationFloat8WeightConfig(
+                granularity=PerTensor(),
+                set_inductor_config=False,
+                kernel_preference=KernelPreference.AUTO,
+            )
+
+            def fp8_filter_fn(mod, fqn):
+                if not _is_linear(mod, fqn):
+                    return False
+                return fqn.startswith(fp8_layers)
+
+            quantize_(module, config=fp8_config, filter_fn=fp8_filter_fn, device=device)
+
+    log(f"  [NVFP4] Summary: {quantized_count} layers quantized to NVFP4, "
+        f"{skipped_fp8_count} overridden to FP8, {skipped_small_count} skipped (too small)")
+
+
 def convert_model_convs_to_channels_last(model: torch.nn.Module) -> None:
     """
     Manually convert 2D and 3D convolutional layer weights to channels_last format.

--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -74,20 +74,31 @@ def resize_and_crop_image(image: Image, target_height: int, target_width: int, m
         log(f"Cropped from center to: {target_height_aligned}x{target_width_aligned}")
         return image
 
+def _get_fp8_kernel_preference():
+    """Select FP8 kernel preference based on GPU architecture.
+
+    AUTO selects CUTLASS sm90a kernels which crash on Blackwell (sm100a)
+    under torch.compile, so we force TORCH (_scaled_mm) on Blackwell+.
+    """
+    from torchao.quantization.quantize_.common import KernelPreference
+    if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 10:
+        return KernelPreference.TORCH
+    return KernelPreference.AUTO
+
+
 def quantize_linear_layers_to_fp8(module_or_module_list_to_quantize: torch.nn.Module | torch.nn.ModuleList,
     filter_fn: Optional[Callable[[torch.nn.Module, str], bool]] = None,
     device: Optional[torch.device] = None) -> None:
     """Quantize all linear layers in the given module or module list to FP8."""
     from torchao.quantization.granularity import PerTensor
     from torchao.quantization.quant_api import Float8DynamicActivationFloat8WeightConfig, quantize_, _is_linear
-    from torchao.quantization.quantize_.common import KernelPreference
 
     if filter_fn is None:
         filter_fn = _is_linear
     config = Float8DynamicActivationFloat8WeightConfig(
                 granularity=PerTensor(),
                 set_inductor_config=False,
-                kernel_preference=KernelPreference.AUTO
+                kernel_preference=_get_fp8_kernel_preference(),
         )
     if isinstance(module_or_module_list_to_quantize, torch.nn.Module):
         module_or_module_list_to_quantize = [module_or_module_list_to_quantize]
@@ -122,7 +133,6 @@ def rgetattr(obj: object, attr: str) -> object:
 def quantize_linear_layers_to_fp4(model, parent_name='', fp8_layers=None, use_hybrid_schedule: bool = False, device: Optional[torch.device] = None):
     from torchao.quantization.granularity import PerTensor
     from torchao.quantization.quant_api import Float8DynamicActivationFloat8WeightConfig, quantize_
-    from torchao.quantization.quantize_.common import KernelPreference
     from xfuser.model_executor.layers.mxfp4_linear import xFuserMXFP4Linear, xFuserHybridMXFP4Linear
 
     for name, module in list(model.named_children()):
@@ -135,7 +145,7 @@ def quantize_linear_layers_to_fp4(model, parent_name='', fp8_layers=None, use_hy
                       config=Float8DynamicActivationFloat8WeightConfig(
                           granularity=PerTensor(),
                           set_inductor_config=False,
-                          kernel_preference=KernelPreference.AUTO
+                          kernel_preference=_get_fp8_kernel_preference(),
                     ),
                     device=device,
                 )
@@ -168,7 +178,7 @@ def quantize_linear_layers_to_fp4(model, parent_name='', fp8_layers=None, use_hy
                         config=Float8DynamicActivationFloat8WeightConfig(
                             granularity=PerTensor(),
                             set_inductor_config=False,
-                            kernel_preference=KernelPreference.AUTO,
+                            kernel_preference=_get_fp8_kernel_preference(),
                         ),
                         device=device,
                     )
@@ -190,7 +200,7 @@ def quantize_linear_layers_to_nvfp4(
     fp8_layers: tuple[str] = None,
     device: Optional[torch.device] = None,
     min_layer_size: int = 0,
-    use_triton_kernel: bool = False,
+    use_triton_kernel: bool = True,
 ) -> None:
     """Quantize linear layers to NVFP4 using torchao on NVIDIA Blackwell GPUs.
 
@@ -226,17 +236,14 @@ def quantize_linear_layers_to_nvfp4(
                 continue
 
             if fp8_layers and fqn.startswith(fp8_layers):
-                log(f"  [NVFP4] SKIP (fp8 override) {fqn}: shape=({submodule.out_features}, {submodule.in_features})")
                 skipped_fp8_count += 1
                 continue
 
             layer_min = min(submodule.out_features, submodule.in_features)
             if min_layer_size > 0 and layer_min < min_layer_size:
-                log(f"  [NVFP4] SKIP (too small, min_dim={layer_min} < {min_layer_size}) {fqn}: shape=({submodule.out_features}, {submodule.in_features})")
                 skipped_small_count += 1
                 continue
 
-            log(f"  [NVFP4] QUANTIZE {fqn}: shape=({submodule.out_features}, {submodule.in_features})")
             quantized_count += 1
 
         def nvfp4_filter_fn(mod, fqn):
@@ -255,12 +262,11 @@ def quantize_linear_layers_to_nvfp4(
         if fp8_layers:
             from torchao.quantization.granularity import PerTensor
             from torchao.quantization.quant_api import Float8DynamicActivationFloat8WeightConfig
-            from torchao.quantization.quantize_.common import KernelPreference
 
             fp8_config = Float8DynamicActivationFloat8WeightConfig(
                 granularity=PerTensor(),
                 set_inductor_config=False,
-                kernel_preference=KernelPreference.AUTO,
+                kernel_preference=_get_fp8_kernel_preference(),
             )
 
             def fp8_filter_fn(mod, fqn):

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -19,6 +19,7 @@ from xfuser.core.utils.runner_utils import (
     load_dataset_prompts,
     quantize_linear_layers_to_fp8,
     quantize_linear_layers_to_fp4,
+    quantize_linear_layers_to_nvfp4,
     convert_model_convs_to_channels_last,
     rgetattr,
 )
@@ -240,8 +241,16 @@ class xFuserModel(abc.ABC):
             raise ValueError(f"Model {self.settings.model_name} produces video output but fps is not set.")
 
         if config.use_fp4_gemms:
-            if not packages_info.get("has_aiter", False):
-                raise ValueError("FP4 Gemms only supported with AITER.")
+            from xfuser.envs import _is_hip, _is_cuda
+            if _is_hip() and not packages_info.get("has_aiter", False):
+                raise ValueError("FP4 GEMMs on ROCm require AITER.")
+            if _is_cuda():
+                major, _ = torch.cuda.get_device_capability()
+                if major < 10:
+                    raise ValueError(
+                        f"NVFP4 GEMMs require CUDA capability >= 10.0 (Blackwell). "
+                        f"Detected: {torch.cuda.get_device_capability()}"
+                    )
         if config.use_parallel_vae:
             if not packages_info.get("has_distvae", False):
                 raise ValueError("DistVAE is not installed. Please install it before using parallel VAE.")
@@ -459,7 +468,11 @@ class xFuserModel(abc.ABC):
             self.pipe = self.pipe.to(f"cuda:{local_rank}")
 
         if self.config.use_fp4_gemms:
-            self._setup_mxfp4_gemms(local_rank=local_rank)
+            from xfuser.envs import _is_cuda
+            if _is_cuda():
+                self._setup_nvfp4_gemms(local_rank=local_rank)
+            else:
+                self._setup_mxfp4_gemms(local_rank=local_rank)
         elif self.config.use_fp8_gemms:
             for module_name in self.settings.fp8_gemm_module_list:
                 log(f"Quantizing linear layers in {module_name} to FP8...")
@@ -516,6 +529,24 @@ class xFuserModel(abc.ABC):
         # will be quantized to fp8, this is specially beneficial for MoE models like Wan2.2,
         # where the low-noise transformer should use FP8 quantization.
         # This transformer generates fine details and requires higher precision to maintain quality.
+        for module_name in self.settings.fp8_gemm_module_list:
+            if module_name in self.settings.fp4_gemm_module_list:
+                continue
+            log(f"Quantizing linear layers in {module_name} to FP8...")
+            module = rgetattr(self.pipe, module_name)
+            quantize_linear_layers_to_fp8(module, device=f"cuda:{local_rank}")
+
+    def _setup_nvfp4_gemms(self, local_rank):
+        for module_name in self.settings.fp4_gemm_module_list:
+            log(f"Quantizing linear layers in {module_name} to NVFP4 (torchao)...")
+            if self.settings.fp8_precision_overrides:
+                log(f"The following blocks will use FP8 instead, to maintain output quality: {self.settings.fp8_precision_overrides}")
+            module = rgetattr(self.pipe, module_name)
+            quantize_linear_layers_to_nvfp4(
+                module,
+                fp8_layers=self.settings.fp8_precision_overrides,
+                device=f"cuda:{local_rank}",
+            )
         for module_name in self.settings.fp8_gemm_module_list:
             if module_name in self.settings.fp4_gemm_module_list:
                 continue

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -12,7 +12,13 @@ from diffusers.pipelines.pipeline_utils import DiffusionPipeline
 from diffusers.utils import load_image, export_to_video
 import numpy as np
 from xfuser.config import args, xFuserArgs
-from xfuser.envs import PACKAGES_CHECKER, get_platform, _TORCH_GROUPNORM
+from xfuser.envs import (
+    PACKAGES_CHECKER,
+    _TORCH_GROUPNORM,
+    get_platform,
+    _is_hip,
+    _is_cuda,
+)
 from xfuser.core.distributed.parallel_state import get_fs_group
 from xfuser.core.utils.runner_utils import (
     log,
@@ -241,7 +247,6 @@ class xFuserModel(abc.ABC):
             raise ValueError(f"Model {self.settings.model_name} produces video output but fps is not set.")
 
         if config.use_fp4_gemms:
-            from xfuser.envs import _is_hip, _is_cuda
             if _is_hip() and not packages_info.get("has_aiter", False):
                 raise ValueError("FP4 GEMMs on ROCm require AITER.")
             if _is_cuda():
@@ -468,7 +473,6 @@ class xFuserModel(abc.ABC):
             self.pipe = self.pipe.to(f"cuda:{local_rank}")
 
         if self.config.use_fp4_gemms:
-            from xfuser.envs import _is_cuda
             if _is_cuda():
                 self._setup_nvfp4_gemms(local_rank=local_rank)
             else:


### PR DESCRIPTION
### Summary

Add NVFP4 (4-bit floating point) GEMM quantization support for NVIDIA Blackwell GPUs (SM >= 10.0) using torchao's `NVFP4DynamicActivationNVFP4WeightConfig`. This is the CUDA-side counterpart to the existing MXFP4 GEMM support on ROCm (via AITER).

- **Platform-based dispatch**: `--use_fp4_gemms` routes to NVFP4 on CUDA (Blackwell) and MXFP4 on ROCm
- **torchao integration**: Uses `quantize_()` with `NVFP4DynamicActivationNVFP4WeightConfig` for weight-and-activation FP4 quantization with dynamic per-tensor scaling
- **Hybrid FP8/NVFP4**: Supports `--fp8_layers` to keep quality-sensitive layers (e.g., norm projections) in FP8 while quantizing the rest to NVFP4
- **`min_layer_size` threshold**: Skip NVFP4 for small linear layers where quantization overhead exceeds speedup
- **Blackwell torch.compile fix**: Use `KernelPreference.TORCH` instead of `AUTO` on SM 10.0 to prevent torch.compile from generating CUTLASS sm90a FP8 kernels that crash on Blackwell
- **Triton kernel default**: Default `use_triton_kernel=True` for better NVFP4 performance

### Files changed

| File | Description |
|------|-------------|
| `xfuser/core/utils/runner_utils.py` | New `quantize_linear_layers_to_nvfp4()` function with torchao integration; FP8 kernel preference fix |
| `xfuser/core/models/runner_models/base_model.py` | Platform dispatch: NVFP4 on CUDA Blackwell, MXFP4 on ROCm |

### Test plan

- [x] Flux2 on 8xB200: 6 task/resolution combos x 3 configs (BF16, FP8, NVFP4), 24 runs each
- [x] Wan2.2 I2V 720x1280 81f on 8xB200: BF16 baseline, FP8, NVFP4

### Results (8xB200, torch.compile enabled, Ulysses=8)

**Flux2 t2i (text-to-image), 50 steps:**

| Config | 1024x1024 (s) | Speedup | 2048x2048 (s) | Speedup |
|--------|--------------|---------|--------------|---------|
| BF16 baseline | 2.146 | 1.00x | 8.512 | 1.00x |
| FP8 | 1.615 | 1.33x | 6.902 | 1.23x |
| NVFP4 | 2.092 | 1.03x | 5.528 | **1.54x** |

**Flux2 ti2i (text+image-to-image), 50 steps:**

| Config | 1024x1024 (s) | Speedup | 2048x2048 (s) | Speedup |
|--------|--------------|---------|--------------|---------|
| BF16 baseline | 3.470 | 1.00x | 10.013 | 1.00x |
| FP8 | 2.752 | 1.26x | 8.243 | 1.21x |
| NVFP4 | 2.264 | **1.53x** | 6.831 | **1.47x** |

**Flux2 t_multi_i2i (text+multi-image-to-image), 50 steps:**

| Config | 1024x1024 (s) | Speedup | 2048x2048 (s) | Speedup |
|--------|--------------|---------|--------------|---------|
| BF16 baseline | 4.514 | 1.00x | 11.591 | 1.00x |
| FP8 | 3.574 | 1.26x | 9.760 | 1.19x |
| NVFP4 | 2.802 | **1.61x** | 7.743 | **1.50x** |

**Wan2.2 I2V 720x1280 81 frames, 40 steps:**

| Config | Time (s) | Speedup vs BF16 |
|--------|----------|-----------------|
| BF16 baseline | 58.88 | 1.00x |
| FP8 | 54.64 | 1.08x |
| NVFP4 | 53.90 | 1.09x |

### Qualitative assessment

**Flux2 ti2i (text+image-to-image), 50 steps, 2048x2048:**

bf16
<img width="2048" height="2048" alt="flux_2_dev_u8r1_tc_True_2048x2048_0" src="https://github.com/user-attachments/assets/b2b7d40d-d159-456b-a541-34b8131627c5" />

fp4
<img width="2048" height="2048" alt="flux_2_dev_u8r1_tc_True_2048x2048_0_fp4gemm" src="https://github.com/user-attachments/assets/1a88b6b6-ccdc-4999-a0f0-d7a5898f3715" />


**Key observations:**
- NVFP4 speedup scales with sequence length: minimal at 1024 t2i (short sequences) but up to **1.61x** for multi-image tasks where the joint attention sequence is much longer.
- NVFP4 consistently outperforms FP8 on image-conditioned tasks (ti2i, t_multi_i2i) across both resolutions.
- At 2048x2048, NVFP4 outperforms FP8 even for pure t2i (1.54x vs 1.23x).
- For Wan2.2 video, NVFP4 and FP8 provide similar ~1.09x speedup over BF16.
- Visual changes/artefacts seen when running all layers in nvfp4 gemm, but finetuning selection left out of scope of PR
