### PR TITLE
Add FP4 CuTe Flash Attention v4 backend for Blackwell

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Several different attention backends are supported:
 | [FAv3 FP8](https://github.com/Dao-AILab/flash-attention/tree/main/hopper) | flash_3_fp8 |
 | [Transformer Engine FP8](https://github.com/NVIDIA/TransformerEngine) | nvte_fp8 |
 | [FAv4](https://github.com/Dao-AILab/flash-attention/tree/main/flash_attn/cute) | flash_4 |
+| [FAv4 FP4](https://github.com/hao-ai-lab/flash-attention-fp4) | flash_4_fp4 |
 | [SAGE](https://github.com/thu-ml/SageAttention) | sage |
 | [AITER](https://github.com/rocm/aiter) | aiter |
 | [AITER FP8](https://github.com/rocm/aiter) | aiter_fp8 |

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -301,8 +301,7 @@ def _flash_attn_4_fp4_call(query, key, value, dropout_p, is_causal):
 
     Input tensors arrive in (batch, nheads, seqlen, headdim) from the USP layer.
     The FAv4 kernel expects (batch, seqlen, nheads, headdim).
-    Q and K are quantized to NVFP4 (float4_e2m1fn_x2) via flashinfer's
-    nvfp4_quantize; V stays in BF16.
+    Q and K are quantized to NVFP4 via flashinfer's nvfp4_quantize; V stays in BF16.
     """
     query = torch.permute(query, [0, 2, 1, 3]).contiguous()
     key = torch.permute(key, [0, 2, 1, 3]).contiguous()

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -92,6 +92,9 @@ if env_info["has_flash_attn_3"]:
     from flash_attn_interface import flash_attn_func as flash_attn_func_3
 if env_info["has_flash_attn_4"]:
     from flash_attn.cute.interface import flash_attn_func as flash_attn_func_4
+if env_info["has_flash_attn_4_fp4"]:
+    from flash_attn.cute.interface import flash_attn_func as flash_attn_func_4_fp4
+    from xfuser.core.distributed.fp4_quantize import quantize_qk_to_fp4
 if env_info["has_transformer_engine"]:
     from transformer_engine.pytorch import DotProductAttention, fp8_autocast
     from transformer_engine.common import recipe
@@ -115,6 +118,7 @@ class AttentionBackendType(Enum):
     FLASH_3_FP8 = "Flash Attention v3 FP8"
     NVTE_FP8 = "NVTE FP8"
     FLASH_4 = "Flash Attention V4"
+    FLASH_4_FP4 = "Flash Attention V4 FP4"
     SAGE = "Sage Attention"
     AITER = "AITER"
     AITER_FP8 = "AITER FP8"
@@ -285,6 +289,35 @@ def _flash_attn_4_call(query, key, value, dropout_p, is_causal):
         key,
         value,
         causal=is_causal,
+    )
+    output = torch.permute(output, [0, 2, 1, 3])
+    return output, softmax_lse
+
+@register_attention_function(AttentionBackendType.FLASH_4_FP4)
+@torch.compiler.disable
+def _flash_attn_4_fp4_call(query, key, value, dropout_p, is_causal):
+    """
+    Flash Attention V4 with runtime FP4 quantization of Q and K.
+
+    Input tensors arrive in (batch, nheads, seqlen, headdim) from the USP layer.
+    The FAv4 kernel expects (batch, seqlen, nheads, headdim).
+    Q and K are quantized to NVFP4 (float4_e2m1fn_x2) via flashinfer's
+    nvfp4_quantize; V stays in BF16.
+    """
+    query = torch.permute(query, [0, 2, 1, 3]).contiguous()
+    key = torch.permute(key, [0, 2, 1, 3]).contiguous()
+    value = torch.permute(value, [0, 2, 1, 3]).contiguous()
+
+    q_fp4, mSFQ = quantize_qk_to_fp4(query)
+    k_fp4, mSFK = quantize_qk_to_fp4(key)
+
+    output, softmax_lse = flash_attn_func_4_fp4(
+        q_fp4,
+        k_fp4,
+        value,
+        causal=is_causal,
+        mSFQ=mSFQ,
+        mSFK=mSFK,
     )
     output = torch.permute(output, [0, 2, 1, 3])
     return output, softmax_lse

--- a/xfuser/core/distributed/fp4_quantize.py
+++ b/xfuser/core/distributed/fp4_quantize.py
@@ -4,6 +4,13 @@ Uses flashinfer's nvfp4_quantize to convert BF16/FP16 Q/K tensors to NVFP4
 (Float4E2M1FN) with block-scaled scale factors in the MMA tile layout
 expected by the hao-ai-lab/flash-attention-fp4 kernel.
 
+NOTE: cutlass-dsl's cute_tensor_like + convert_cute_tensor also works for
+quantization and produces slightly faster kernel execution (~1-2%), but it
+relies on @cute.jit which JIT-compiles a new CUDA kernel for every distinct
+tensor shape. This makes it unsuitable for E2E inference where attention is
+called hundreds of times during warmup/compilation. flashinfer's nvfp4_quantize
+is a pre-compiled kernel with no JIT overhead.
+
 Requires: flashinfer-python (pip install flashinfer-python)
 Requires: CUTE_DSL_ENABLE_TVM_FFI=1 (set automatically in envs.py)
 """

--- a/xfuser/core/distributed/fp4_quantize.py
+++ b/xfuser/core/distributed/fp4_quantize.py
@@ -1,0 +1,70 @@
+"""Runtime FP4 quantization helpers for the FLASH_4_FP4 attention backend.
+
+Uses flashinfer's nvfp4_quantize to convert BF16/FP16 Q/K tensors to NVFP4
+(Float4E2M1FN) with block-scaled scale factors in the MMA tile layout
+expected by the hao-ai-lab/flash-attention-fp4 kernel.
+
+Requires: flashinfer-python (pip install flashinfer-python)
+Requires: CUTE_DSL_ENABLE_TVM_FFI=1 (set automatically in envs.py)
+"""
+
+import math
+
+import torch
+from flashinfer.quantization import nvfp4_quantize, SfLayout
+
+
+def quantize_qk_to_fp4(
+    tensor: torch.Tensor,
+    sf_vec_size: int = 16,
+):
+    """Quantize a BF16/FP16 Q or K tensor to NVFP4 for the Flash Attention FP4 kernel.
+
+    Uses flashinfer's nvfp4_quantize with layout_128x4 scale factor layout,
+    then reshapes the packed FP4 data and permutes scale factors into the
+    (32, 4, rest_m, 4, rest_k, nheads, batch) MMA tile layout expected by
+    the FlashAttentionForwardSm100FP4 kernel.
+
+    Args:
+        tensor: Input tensor of shape (batch, seqlen, nheads, headdim) in BF16/FP16.
+        sf_vec_size: Number of elements per scale factor block (default 16).
+
+    Returns:
+        (fp4_tensor, sf_tensor) -- fp4_tensor is torch.float4_e2m1fn_x2
+        with shape (batch, seqlen, nheads, headdim//2), and sf_tensor is
+        the scale factors in MMA tile layout.
+    """
+    batch, seqlen, nheads, headdim = tensor.shape
+
+    global_sf = torch.ones(1, device=tensor.device, dtype=torch.float32)
+    fp4_data, sf_data = nvfp4_quantize(
+        tensor.reshape(batch * seqlen, nheads * headdim),
+        global_sf,
+        sfLayout=SfLayout.layout_128x4,
+        do_shuffle=False,
+    )
+
+    fp4 = (
+        fp4_data
+        .reshape(batch, seqlen, nheads, headdim // 2)
+        .view(torch.int8)
+        .view(torch.float4_e2m1fn_x2)
+    )
+
+    # nvfp4_quantize pads M to next multiple of 128 internally
+    rest_m = math.ceil(seqlen / 128)
+    sf_kph = headdim // sf_vec_size
+    rest_k = sf_kph // 4
+    total_m = batch * rest_m
+    total_k = (nheads * sf_kph) // 4
+
+    sf = (
+        sf_data
+        .reshape(total_m, total_k, 32, 4, 4)
+        .reshape(batch, rest_m, nheads, rest_k, 32, 4, 4)
+        .permute(0, 2, 1, 3, 4, 5, 6)
+        .contiguous()
+        .permute(4, 5, 2, 6, 3, 1, 0)
+    )
+
+    return fp4, sf

--- a/xfuser/core/distributed/fp4_quantize.py
+++ b/xfuser/core/distributed/fp4_quantize.py
@@ -43,9 +43,14 @@ def quantize_qk_to_fp4(
     """
     batch, seqlen, nheads, headdim = tensor.shape
 
+    # Pad seqlen so each batch element aligns independently
+    padded_seqlen = math.ceil(seqlen / 128) * 128
+    if padded_seqlen > seqlen:
+        tensor = torch.nn.functional.pad(tensor, (0, 0, 0, 0, 0, padded_seqlen - seqlen))
+
     global_sf = torch.ones(1, device=tensor.device, dtype=torch.float32)
     fp4_data, sf_data = nvfp4_quantize(
-        tensor.reshape(batch * seqlen, nheads * headdim),
+        tensor.reshape(batch * padded_seqlen, nheads * headdim),
         global_sf,
         sfLayout=SfLayout.layout_128x4,
         do_shuffle=False,
@@ -53,13 +58,16 @@ def quantize_qk_to_fp4(
 
     fp4 = (
         fp4_data
-        .reshape(batch, seqlen, nheads, headdim // 2)
+        .reshape(batch, padded_seqlen, nheads, headdim // 2)
         .view(torch.int8)
         .view(torch.float4_e2m1fn_x2)
     )
+    # Slice back to original seqlen for the kernel
+    if padded_seqlen > seqlen:
+        fp4 = fp4[:, :seqlen, ...].contiguous()
 
-    # nvfp4_quantize pads M to next multiple of 128 internally
-    rest_m = math.ceil(seqlen / 128)
+    # sf uses padded dimensions - rest_m is now exact division
+    rest_m = padded_seqlen // 128
     sf_kph = headdim // sf_vec_size
     rest_k = sf_kph // 4
     total_m = batch * rest_m

--- a/xfuser/core/distributed/runtime_state.py
+++ b/xfuser/core/distributed/runtime_state.py
@@ -124,8 +124,8 @@ class RuntimeState(metaclass=ABCMeta):
         self._check_if_backend_compatible_with_current_configuration(attention_backend)
         self.attention_backend = attention_backend
         logger.warning("Using {} as attention backend.".format(self.attention_backend.name))
-        if attention_backend in [AttentionBackendType.FLASH_3_FP8, AttentionBackendType.AITER_FP8, AttentionBackendType.NVTE_FP8]:
-            logger.warning("FP8 attention backend is enabled. This may cause poor quality outputs, consider using hybrid attention if possible.")
+        if attention_backend in [AttentionBackendType.FLASH_3_FP8, AttentionBackendType.AITER_FP8, AttentionBackendType.NVTE_FP8, AttentionBackendType.FLASH_4_FP4]:
+            logger.warning("Low-precision attention backend is enabled. This may cause poor quality outputs, consider using hybrid attention if possible.")
 
 
     def set_cross_attention_backend(self, cross_attention_backend: Optional[str | AttentionBackendType]):
@@ -204,6 +204,7 @@ class RuntimeState(metaclass=ABCMeta):
         if attention_backend in [AttentionBackendType.SDPA,
                                  AttentionBackendType.SDPA_MATH,
                                  AttentionBackendType.FLASH_4,
+                                 AttentionBackendType.FLASH_4_FP4,
                                  AttentionBackendType.AITER_FP8,
                                  AttentionBackendType.AITER_SAGE,
                                  AttentionBackendType.AITER_SAGE_V2]:
@@ -230,6 +231,12 @@ class RuntimeState(metaclass=ABCMeta):
                 from aiter.ops.triton.attention.fav3_sage_attention_mxfp4_wrapper import fav3_sage_mxfp4_wrapper
             except ImportError:
                 raise RuntimeError("AITER Sage V2 attention is not available, please update AITER") from None
+        elif attention_backend == AttentionBackendType.FLASH_4_FP4:
+            if not env_info.get("has_flash_attn_4_fp4"):
+                raise RuntimeError(
+                    "Flash Attention V4 FP4 is not available. Requires Blackwell GPU (SM >= 10.0) "
+                    "and the hao-ai-lab/flash-attention-fp4 fork with nvidia-cutlass-dsl."
+                )
         elif attention_backend == AttentionBackendType.SAGE:
             if not env_info["has_sage"]:
                 raise RuntimeError("SageAttention is not available, please install SageAttention.")

--- a/xfuser/envs.py
+++ b/xfuser/envs.py
@@ -204,6 +204,7 @@ class PackagesEnvChecker:
         packages_info["has_flash_attn"] = self.check_flash_attn()
         packages_info["has_flash_attn_3"] = self._check_flash_attn_3()
         packages_info["has_flash_attn_4"] = self._check_flash_attn_4()
+        packages_info["has_flash_attn_4_fp4"] = self._check_flash_attn_4_fp4()
         packages_info["has_transformer_engine"] = self.check_transformer_engine()
         packages_info["has_sage"] = self._check_sage()
         packages_info["has_long_ctx_attn"] = self.check_long_ctx_attn()
@@ -275,7 +276,22 @@ class PackagesEnvChecker:
             return True
         except:
             return False
-    
+
+    def _check_flash_attn_4_fp4(self):
+        if not torch.cuda.is_available() or _is_hip():
+            return False
+        try:
+            major, _ = torch.cuda.get_device_capability()
+            if major < 10:
+                return False
+            from flash_attn.cute.flash_fwd_sm100_fp4 import FlashAttentionForwardSm100  # noqa: F401
+            # TVM-FFI must be enabled for CUTE tensors (FP4 quantized Q/K)
+            # to be passed through the cutlass-dsl compiled kernel.
+            os.environ.setdefault("CUTE_DSL_ENABLE_TVM_FFI", "1")
+            return True
+        except:
+            return False
+
     @staticmethod
     def _install_flash_attn_3_shim_for_transformer_engine() -> None:
         """TE imports ``flash_attn_3.flash_attn_interface``; wheels often expose only ``flash_attn_interface``."""


### PR DESCRIPTION
### Summary

Integrate the FP4 CUTE Flash Attention v4 kernel from [hao-ai-lab/flash-attention-fp4](https://github.com/hao-ai-lab/flash-attention-fp4) as a new attention backend (`FLASH_4_FP4`) for NVIDIA Blackwell GPUs (SM >= 10.0). This is the CUDA counterpart to the MXFP4 attention support on ROCm (`AITER_SAGE_V2`).

**Key design decisions:**
- **Runtime FP4 quantization via flashinfer**: Q and K are quantized to `Float4E2M1FN` at runtime using `flashinfer.quantization.nvfp4_quantize` with MMA-layout scale factors. V stays in BF16.
- **Why flashinfer over cutlass-dsl for quantization**: cutlass-dsl's `cute_tensor_like` + `convert_cute_tensor` also works and produces slightly faster kernel execution (~1-2%), but `convert_cute_tensor` calls `cute.testing.convert` -- a `@cute.jit` function that JIT-compiles a new CUDA kernel for every distinct tensor shape. During E2E inference with `torch.compile`, this triggers repeated JIT compilations (tens of seconds per step), making it unusable. flashinfer's `nvfp4_quantize` is a pre-compiled kernel with zero JIT overhead.
- **Important: cute-only install for the FP4 fork**: Only install `flash_attn/cute/` from the FP4 fork (`pip install -e .` in the cute subdirectory). Do NOT run the top-level `python setup.py install` or build the `hopper/` extension -- those compile CUDA extensions that cause SIGILL on Blackwell due to architecture mismatches with the fork's build configuration.
- **Hybrid attention schedule support**: Works with `AttentionSchedule` to use FP4 as the low-precision backend alongside cuDNN or FAv4 BF16 as the high-precision backend during early denoising steps.
- **`torch.compiler.disable`**: The FAv4 CUTE kernel uses `cutlass-dsl`'s `cute.compile()` to JIT-compile CUDA kernels at runtime, launching them via TVM FFI with raw pointer manipulation and a compile cache. None of this is traceable by `torch.compile`/Dynamo, so the attention call is wrapped with `@torch.compiler.disable`. This means the FP4 attention path runs outside the compiled graph -- the rest of the model (GEMMs, norms, etc.) is still compiled normally.

### Changes

| File | Description |
|------|-------------|
| `xfuser/core/distributed/attention_backend.py` | New `FLASH_4_FP4` enum value and registered `_flash_attn_4_fp4_call` handler. Conditional import of `flash_attn.cute.interface` and `fp4_quantize`. Handles permutation from xDiT's `(B,H,S,D)` to FAv4's `(B,S,H,D)` layout. |
| `xfuser/core/distributed/fp4_quantize.py` | New file. `quantize_qk_to_fp4()` uses `nvfp4_quantize` to produce packed `torch.float4_e2m1fn_x2` data + scale factors in the 7D MMA layout expected by the FAv4 kernel. Handles `nvfp4_quantize`'s internal padding of M to multiples of 128. |
| `xfuser/envs.py` | `_check_flash_attn_4_fp4()` detects FP4 kernel availability (import check + CUDA cap >= 10.0). Sets `CUTE_DSL_ENABLE_TVM_FFI=1` env var when FP4 is available. |
| `xfuser/core/distributed/runtime_state.py` | Compatibility checks: require Blackwell + FP4 kernel present. Block `ring_degree > 1` with FP4. Include FP4 in hybrid attention warnings. |

### Usage

```bash
# Pure FP4 attention
xdit --model Wan-AI/Wan2.2-I2V-A14B-Diffusers \
    --attention_backend flash_4_fp4 \
    --ulysses_degree 8 --use_torch_compile ...

# Hybrid: cuDNN for first N steps, FP4 for the rest
xdit --model Wan-AI/Wan2.2-I2V-A14B-Diffusers \
    --use_hybrid_attn_schedule \
    --hybrid_attn_high_precision_backend cudnn \
    --hybrid_attn_low_precision_backend flash_4_fp4 \
    --num_hybrid_attn_high_precision_steps 5 \
    --ulysses_degree 8 --use_torch_compile ...

# Combined: NVFP4 GEMMs + FP4 attention
xdit --model Wan-AI/Wan2.2-I2V-A14B-Diffusers \
    --use_fp4_gemms \
    --use_hybrid_attn_schedule \
    --hybrid_attn_high_precision_backend cudnn \
    --hybrid_attn_low_precision_backend flash_4_fp4 \
    --num_hybrid_attn_high_precision_steps 5 \
    --ulysses_degree 8 --use_torch_compile ...
```

### Dependencies

Requires the FP4 fork of flash-attention (only the CUTE subdirectory):
```bash
git clone https://github.com/hao-ai-lab/flash-attention-fp4.git
cd flash-attention-fp4/flash_attn/cute && pip install -e .
pip install "nvidia-cutlass-dsl==4.4.0.dev0" "apache-tvm-ffi==0.1.6" \
    "torch-c-dlpack-ext" "flashinfer-python"
```

### Microbenchmark Results (1xB200, Wan2.2 I2V shapes, seqlen=75600)

| Shape (B,S,H,D) | BF16 FAv4 | FP4 (flashinfer) | FP4 (cutlass-dsl) | Speedup (flashinfer) |
|------------------|-----------|-------------------|-------------------|---------------------|
| 1, 75600, 5, 128 (Ulysses=8) | 11.17 ms (1311 TF) | 8.65 ms (1691 TF) | 8.52 ms (1717 TF) | **1.29x** |
| 1, 75600, 40, 128 (Ulysses=1) | 91.90 ms (1274 TF) | 73.02 ms (1603 TF) | 72.08 ms (1624 TF) | **1.26x** |

> - `force_fp4_impl=True` (kernel-internal BF16->FP4 path) shows no speedup vs BF16, confirming that explicit quantization is essential.
> - cutlass-dsl quantization is ~1-2% faster at kernel level, but unusable for E2E inference due to `@cute.jit` JIT compilation overhead on every new tensor shape (tens of seconds per denoising step during warmup).
> - flashinfer's `nvfp4_quantize` is a pre-compiled kernel with zero JIT overhead -- the correct choice for production.

### E2E Validation Results (8xB200, torch.compile, Ulysses=8)

**Wan2.2 I2V 720x1280 81 frames, 40 steps:**

| Config | Time (s) | vs cuDNN BF16 |
|--------|----------|---------------|
| cuDNN BF16 (baseline) | 58.93 | 1.00x |
| FAv4 BF16 | 63.77 | 0.92x |
| FP4 pure | 55.14 | **1.07x** |
| Hybrid FP4 + cuDNN (5 hi-prec steps) | 55.92 | **1.05x** |
| Hybrid FP4 + FAv4 BF16 (5 hi-prec steps) | 57.01 | 1.03x |

**Wan2.2 T2V 720x1280 81 frames, 40 steps:**

| Config | Time (s) | vs cuDNN BF16 |
|--------|----------|---------------|
| cuDNN BF16 (baseline) | 57.86 | 1.00x |
| FAv4 BF16 | 62.66 | 0.92x |
| FP4 pure | 55.14 | **1.05x** |
| Hybrid FP4 + cuDNN (5 hi-prec steps) | 55.92 | **1.03x** |
| Hybrid FP4 + FAv4 BF16 (5 hi-prec steps) | 57.01 | 1.01x |

**Flux2 t2i 1024x1024, 50 steps:**

| Config | Time (s) | vs cuDNN BF16 |
|--------|----------|---------------|
| cuDNN BF16 (baseline) | 2.14 | 1.00x |
| FAv4 BF16 | 2.56 | 0.84x |
| FP4 pure | 2.72 | 0.79x |
| Hybrid FP4 + cuDNN (5 hi-prec steps) | 2.58 | 0.83x |
| Hybrid FP4 + FAv4 BF16 (5 hi-prec steps) | 2.50 | 0.86x |

**Key observations:**
 - FP4 attention provides **1.05-1.07x speedup** on Wan2.2 (both I2V and T2V) due to large sequence lengths (75600 tokens per GPU with Ulysses=8).
- Flux2 sequences are too short for FP4 to overcome the quantization + kernel launch overhead.


### Quality

bf16 Wan2.2 
https://github.com/user-attachments/assets/33cf3a11-df93-4c59-9d58-2497944c3769

fp4 Wan2.2 (hybrid 5 steps)
https://github.com/user-attachments/assets/429f10a3-f425-4454-9331-046e3b85e383


### Test plan

- [x] Microbenchmark: FP4 vs BF16 on Wan2.2 shapes (nheads=5 and nheads=40)
- [x] E2E: Wan2.2 I2V 5 configs (cuDNN BF16, FAv4 BF16, FP4 pure, hybrid cuDNN, hybrid FAv4)
- [x] E2E: Wan2.2 T2V 5 configs
- [x] E2E: Flux2 t2i 5 configs