### PR TITLE
Fix HunyuanVideo tokenizer on transformers v5

### DIFF
--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -280,6 +280,43 @@ def quantize_linear_layers_to_nvfp4(
         f"{skipped_fp8_count} overridden to FP8, {skipped_small_count} skipped (too small)")
 
 
+def fix_llama_tokenizer_pretokenizer(pipeline, model_name_or_path, **from_pretrained_kwargs) -> None:
+    """
+    Workaround for transformers v5 bug where LlamaTokenizer.__init__ unconditionally
+    installs a SentencePiece Metaspace pre-tokenizer, silently breaking newer models
+    that use ByteLevel BPE under the ``tokenizer_class="LlamaTokenizerFast"`` label.
+
+    Reloads affected tokenizer components as ``PreTrainedTokenizerFast``, which
+    respects the pre-tokenizer defined in ``tokenizer.json`` without the override.
+
+    See https://github.com/huggingface/transformers/pull/45345
+    """
+    import transformers
+    from packaging.version import Version
+    if Version(transformers.__version__) < Version("5.0.0"):
+        return
+
+    from transformers import PreTrainedTokenizerFast
+
+    for component_name, component in pipeline.components.items():
+        if component is None or not component_name.startswith("tokenizer"):
+            continue
+
+        if "Llama" not in type(component).__name__:
+            continue
+
+        log(f"Replacing tokenizer '{component_name}' (type={type(component).__name__}) "
+            f"with PreTrainedTokenizerFast...", debug=True)
+
+        fixed = PreTrainedTokenizerFast.from_pretrained(
+            model_name_or_path, subfolder=component_name, **from_pretrained_kwargs
+        )
+        setattr(pipeline, component_name, fixed)
+
+        log(f"Fixed tokenizer '{component_name}': "
+            f"reloaded as PreTrainedTokenizerFast (transformers v5 LlamaTokenizer bug workaround)")
+
+
 def convert_model_convs_to_channels_last(model: torch.nn.Module) -> None:
     """
     Manually convert 2D and 3D convolutional layer weights to channels_last format.

--- a/xfuser/model_executor/models/runner_models/flux.py
+++ b/xfuser/model_executor/models/runner_models/flux.py
@@ -15,7 +15,7 @@ from xfuser.model_executor.models.runner_models.base_model import (
 from xfuser.core.utils.runner_utils import (
     log,
     resize_and_crop_image,
-    quantize_linear_layers_to_fp8
+    quantize_linear_layers_to_fp8,
 )
 from xfuser.core.distributed import (
     get_runtime_state,

--- a/xfuser/model_executor/models/runner_models/hunyuan.py
+++ b/xfuser/model_executor/models/runner_models/hunyuan.py
@@ -16,6 +16,7 @@ from xfuser.model_executor.models.runner_models.base_model import (
 from xfuser.core.distributed.runtime_state import get_runtime_state
 from xfuser.core.utils.runner_utils import (
     resize_and_crop_image,
+    fix_llama_tokenizer_pretokenizer,
 )
 
 @register_model("tencent/HunyuanVideo")
@@ -57,6 +58,7 @@ class xFuserHunyuanvideoModel(xFuserModel):
             torch_dtype=torch.bfloat16,
             revision="refs/pr/18",
         )
+        fix_llama_tokenizer_pretokenizer(pipe, self.settings.model_name, revision="refs/pr/18")
         return pipe
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:


### PR DESCRIPTION
## Fix tokenizer breakage with transformers >= 5

### Problem

Transformers v5 introduced a change in `LlamaTokenizer.__init__` that unconditionally installs a SentencePiece Metaspace pre-tokenizer, even for models that use ByteLevel BPE under the `tokenizer_class="LlamaTokenizerFast"` label (e.g. HunyuanVideo). This changes the tokenization and causes a difference in the model outputs.

Upstream issue: https://github.com/huggingface/transformers/pull/45345

### Fix

Applying the suggestion provided in the linked upstream issue, add a `fix_llama_tokenizer_pretokenizer` utility that detects affected Llama-based tokenizer components in the HunyuanVideo pipeline and reloads them as `PreTrainedTokenizerFast`, which correctly respects the pre-tokenizer defined in `tokenizer.json`. The fix is version-gated to only activate on transformers >= 5.0.0.

### Changes

- `xfuser/core/utils/runner_utils.py` — new `fix_llama_tokenizer_pretokenizer()` function
- `xfuser/model_executor/models/runner_models/hunyuan.py` — call the fix after pipeline load
- `xfuser/model_executor/models/runner_models/flux.py` — minor import trailing comma fix

### Testing
Reference video on `transformers==4.57.6`:

https://github.com/user-attachments/assets/ab39e10d-a4ed-4c5a-94d3-31912f55481c



Altered output - `transformers==5.5.4`, no fix:


https://github.com/user-attachments/assets/e2358add-f0ec-4cc9-a345-028a35f72b39


Restored output - `transformers==5.5.4`, with fix from this PR:

https://github.com/user-attachments/assets/96a3ed20-525a-4be0-8483-d371ed84fcdb

