### PR TITLE
Add explicit NV check to kernel preference selection

### DIFF
--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -6,6 +6,7 @@ import functools
 import numpy as np
 from PIL.Image import Image
 from typing import Callable, Optional
+from xfuser.envs import _is_cuda
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +82,7 @@ def _get_fp8_kernel_preference():
     under torch.compile, so we force TORCH (_scaled_mm) on Blackwell+.
     """
     from torchao.quantization.quantize_.common import KernelPreference
-    if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 10:
+    if torch.cuda.is_available() and _is_cuda() and torch.cuda.get_device_capability()[0] >= 10:
         return KernelPreference.TORCH
     return KernelPreference.AUTO
 


### PR DESCRIPTION
# What?
Adds an explicit check when choosing the fp8 kernel preference.

# Why?
Blackwell requires a different kernel from others. Current check works, but is not explicit enough. It might not work in the future, if ROCm device capability goes to 10 from 9.