### PR TITLE
Fix missing attention kwargs paramater in the ring attention call

### DIFF
--- a/xfuser/model_executor/layers/usp.py
+++ b/xfuser/model_executor/layers/usp.py
@@ -26,11 +26,12 @@ from xfuser.core.cache_manager.cache_manager import get_cache_manager
 from xfuser.core.distributed.attention_backend import ATTENTION_FUNCTION_REGISTRY
 
 
-def ring_attn(attention_function, query, key, value, dropout_p=0.0, is_causal=False, joint_attn_kwargs=None):
+def ring_attn(attention_function, query, key, value, dropout_p=0.0, is_causal=False, joint_attn_kwargs=None, attention_kwargs=None):
     kwargs = {
         "dropout_p": dropout_p,
         "is_causal": is_causal,
         "joint_attn_kwargs": joint_attn_kwargs,
+        "attention_kwargs": attention_kwargs,
     }
     if parse(torch.__version__).release >= parse("2.6.0").release:
         from torch.distributed.tensor.experimental._attention import _cp_options


### PR DESCRIPTION
The new attention kwargs paramater used for sparse attention was not added to the ring attention function call signature, causing `TypeError: ring_attn() got an unexpected keyword argument 'attention_kwargs'. `