### PR TITLE
Z-image ulysses anything PoC

### DIFF
--- a/xfuser/core/distributed/runtime_state.py
+++ b/xfuser/core/distributed/runtime_state.py
@@ -512,7 +512,10 @@ class DiTRuntimeState(RuntimeState):
             )
 
     def _get_model_attention_heads(self, pipeline: DiffusionPipeline) -> int:
-        if "num_attention_heads" in pipeline.transformer.config:
+        # Allows models to override their number of attention heads, for Ulysses Anything
+        if hasattr(pipeline.transformer.config, "num_attention_heads"):
+            return pipeline.transformer.config.num_attention_heads
+        elif "num_attention_heads" in pipeline.transformer.config:
             return pipeline.transformer.config.num_attention_heads
         elif "n_heads" in pipeline.transformer.config:
             return pipeline.transformer.config.n_heads

--- a/xfuser/model_executor/models/runner_models/z_image.py
+++ b/xfuser/model_executor/models/runner_models/z_image.py
@@ -16,7 +16,7 @@ def _normalize_prompt(prompt_input):
     if isinstance(prompt_input, str):
         return [prompt_input]
     if isinstance(prompt_input, list):
-        return prompt_input
+        return list(prompt_input) # Recreates the list to avoid issues with in-place editing
     raise TypeError(f"prompt must be str or list[str], got {type(prompt_input)}")
 
 

--- a/xfuser/model_executor/models/runner_models/z_image.py
+++ b/xfuser/model_executor/models/runner_models/z_image.py
@@ -67,7 +67,7 @@ class xFuserZImageModel(xFuserModel):
             torch_dtype=torch.bfloat16,
             subfolder="transformer",
         )
-        _set_effective_heads_for_ulysses(transformer, getattr(self.config, "ulysses_degree", 1))
+        _set_effective_heads_for_ulysses(transformer, self.config.ulysses_degree)
         pipe = ZImagePipeline.from_pretrained(
             pretrained_model_name_or_path=self.settings.model_name,
             transformer=transformer,
@@ -110,7 +110,7 @@ class xFuserZImageTurboModel(xFuserModel):
             torch_dtype=torch.bfloat16,
             subfolder="transformer",
         )
-        _set_effective_heads_for_ulysses(transformer, getattr(self.config, "ulysses_degree", 1))
+        _set_effective_heads_for_ulysses(transformer, self.config.ulysses_degree)
         pipe = ZImagePipeline.from_pretrained(
             pretrained_model_name_or_path=self.settings.model_name,
             transformer=transformer,

--- a/xfuser/model_executor/models/runner_models/z_image.py
+++ b/xfuser/model_executor/models/runner_models/z_image.py
@@ -11,6 +11,30 @@ from xfuser.model_executor.models.runner_models.base_model import (
     ModelSettings,
 )
 
+
+
+def _set_effective_heads_for_ulysses(transformer, ulysses_degree: int) -> None:
+    """Expose a Ulysses-divisible head count for runtime validation.
+
+    Keep the real model head layout untouched (e.g., n_heads=30) and only set
+    config.num_attention_heads used by runtime pre-checks.
+    """
+    ulysses_degree = int(ulysses_degree or 1)
+    if ulysses_degree <= 1:
+        return
+
+    real_heads = getattr(transformer.config, "n_heads", None)
+    if not isinstance(real_heads, int):
+        real_heads = getattr(transformer.config, "num_attention_heads", None)
+    if not isinstance(real_heads, int):
+        return
+
+    effective_heads = ((real_heads + ulysses_degree - 1) // ulysses_degree) * ulysses_degree
+    if effective_heads == real_heads:
+        return
+
+    transformer.config.num_attention_heads = effective_heads
+
 @register_model("Tongyi-MAI/Z-Image")
 @register_model("Z-Image")
 class xFuserZImageModel(xFuserModel):
@@ -36,6 +60,7 @@ class xFuserZImageModel(xFuserModel):
             torch_dtype=torch.bfloat16,
             subfolder="transformer",
         )
+        _set_effective_heads_for_ulysses(transformer, getattr(self.config, "ulysses_degree", 1))
         pipe = ZImagePipeline.from_pretrained(
             pretrained_model_name_or_path=self.settings.model_name,
             transformer=transformer,
@@ -78,6 +103,7 @@ class xFuserZImageTurboModel(xFuserModel):
             torch_dtype=torch.bfloat16,
             subfolder="transformer",
         )
+        _set_effective_heads_for_ulysses(transformer, getattr(self.config, "ulysses_degree", 1))
         pipe = ZImagePipeline.from_pretrained(
             pretrained_model_name_or_path=self.settings.model_name,
             transformer=transformer,

--- a/xfuser/model_executor/models/runner_models/z_image.py
+++ b/xfuser/model_executor/models/runner_models/z_image.py
@@ -12,6 +12,13 @@ from xfuser.model_executor.models.runner_models.base_model import (
 )
 
 
+def _normalize_prompt(prompt_input):
+    if isinstance(prompt_input, str):
+        return [prompt_input]
+    if isinstance(prompt_input, list):
+        return prompt_input
+    raise TypeError(f"prompt must be str or list[str], got {type(prompt_input)}")
+
 
 def _set_effective_heads_for_ulysses(transformer, ulysses_degree: int) -> None:
     """Expose a Ulysses-divisible head count for runtime validation.
@@ -69,7 +76,7 @@ class xFuserZImageModel(xFuserModel):
         return pipe
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
-        prompt = list(input_args["prompt"]) if isinstance(input_args["prompt"], list) else prompt
+        prompt = _normalize_prompt(input_args["prompt"])
         output = self.pipe(
             height=input_args["height"],
             width=input_args["width"],
@@ -112,7 +119,7 @@ class xFuserZImageTurboModel(xFuserModel):
         return pipe
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
-        prompt = list(input_args["prompt"])
+        prompt = _normalize_prompt(input_args["prompt"])
         output = self.pipe(
             height=input_args["height"],
             width=input_args["width"],

--- a/xfuser/model_executor/models/transformers/transformer_z_image.py
+++ b/xfuser/model_executor/models/transformers/transformer_z_image.py
@@ -13,6 +13,7 @@ from xfuser.model_executor.layers.usp import USP
 from xfuser.core.distributed import (
     get_sequence_parallel_world_size,
     get_sequence_parallel_rank,
+    get_ulysses_parallel_world_size,
     get_sp_group,
     get_classifier_free_guidance_world_size,
     get_classifier_free_guidance_rank,
@@ -27,6 +28,14 @@ class xFuserZSingleStreamAttnProcessor:
     Processor for Z-Image single stream attention that adapts the existing Attention class to match the behavior of the
     original Z-ImageAttention module.
     """
+
+    @staticmethod
+    def _pad_heads(x: torch.Tensor, pad_heads: int) -> torch.Tensor:
+        if pad_heads <= 0:
+            return x
+        pad_shape = list(x.shape)
+        pad_shape[1] = pad_heads
+        return torch.cat([x, x.new_zeros(pad_shape)], dim=1)
 
     def __call__(
         self,
@@ -75,6 +84,15 @@ class xFuserZSingleStreamAttnProcessor:
         key = key.transpose(1, 2)
         value = value.transpose(1, 2)
 
+        ulysses_world_size = get_ulysses_parallel_world_size()
+        pad_heads = 0
+        if ulysses_world_size > 1:
+            pad_heads = (ulysses_world_size - (query.shape[1] % ulysses_world_size)) % ulysses_world_size
+            if pad_heads:
+                query = self._pad_heads(query, pad_heads)
+                key = self._pad_heads(key, pad_heads)
+                value = self._pad_heads(value, pad_heads)
+
         # Compute joint attention
         hidden_states = USP(
             query,
@@ -83,6 +101,9 @@ class xFuserZSingleStreamAttnProcessor:
             dropout_p=0.0,
             is_causal=False,
         )
+
+        if pad_heads:
+            hidden_states = hidden_states[:, :-pad_heads, :, :]
 
         # Transpose back to original shape
         hidden_states = hidden_states.transpose(1, 2)

--- a/xfuser/model_executor/models/transformers/transformer_z_image.py
+++ b/xfuser/model_executor/models/transformers/transformer_z_image.py
@@ -8,7 +8,7 @@ from diffusers.models.attention_processor import Attention
 from diffusers.models.modeling_outputs import Transformer2DModelOutput
 
 
-from xfuser.model_executor.layers.usp import USP, attention
+from xfuser.model_executor.layers.usp import USP
 
 from xfuser.core.distributed import (
     get_sequence_parallel_world_size,
@@ -28,12 +28,6 @@ class xFuserZSingleStreamAttnProcessor:
     Processor for Z-Image single stream attention that adapts the existing Attention class to match the behavior of the
     original Z-ImageAttention module.
     """
-
-    def __init__(self, use_ulysses_parallel_attention: bool = True):
-        if use_ulysses_parallel_attention:
-            self.attention_function = USP
-        else:
-            self.attention_function = attention
 
     @staticmethod
     def _pad_heads(x: torch.Tensor, pad_heads: int) -> torch.Tensor:
@@ -100,7 +94,7 @@ class xFuserZSingleStreamAttnProcessor:
                 value = self._pad_heads(value, pad_heads)
 
         # Compute joint attention
-        hidden_states = self.attention_function(
+        hidden_states = USP(
             query,
             key,
             value,
@@ -133,9 +127,7 @@ class xFuserZImageTransformer2DWrapper(ZImageTransformer2DModel):
         super().__init__(
             **kwargs
         )
-        for layer in self.layers:
-            layer.attention.processor = xFuserZSingleStreamAttnProcessor()
-        for layer in self.context_refiner + self.noise_refiner:
+        for layer in self.layers + self.context_refiner + self.noise_refiner:
             layer.attention.processor = xFuserZSingleStreamAttnProcessor()
 
 

--- a/xfuser/model_executor/models/transformers/transformer_z_image.py
+++ b/xfuser/model_executor/models/transformers/transformer_z_image.py
@@ -8,7 +8,7 @@ from diffusers.models.attention_processor import Attention
 from diffusers.models.modeling_outputs import Transformer2DModelOutput
 
 
-from xfuser.model_executor.layers.usp import USP
+from xfuser.model_executor.layers.usp import USP, attention
 
 from xfuser.core.distributed import (
     get_sequence_parallel_world_size,
@@ -28,6 +28,12 @@ class xFuserZSingleStreamAttnProcessor:
     Processor for Z-Image single stream attention that adapts the existing Attention class to match the behavior of the
     original Z-ImageAttention module.
     """
+
+    def __init__(self, use_ulysses_parallel_attention: bool = True):
+        if use_ulysses_parallel_attention:
+            self.attention_function = USP
+        else:
+            self.attention_function = attention
 
     @staticmethod
     def _pad_heads(x: torch.Tensor, pad_heads: int) -> torch.Tensor:
@@ -94,7 +100,7 @@ class xFuserZSingleStreamAttnProcessor:
                 value = self._pad_heads(value, pad_heads)
 
         # Compute joint attention
-        hidden_states = USP(
+        hidden_states = self.attention_function(
             query,
             key,
             value,
@@ -129,6 +135,8 @@ class xFuserZImageTransformer2DWrapper(ZImageTransformer2DModel):
         )
         for layer in self.layers:
             layer.attention.processor = xFuserZSingleStreamAttnProcessor()
+        for layer in self.context_refiner + self.noise_refiner:
+            layer.attention.processor = xFuserZSingleStreamAttnProcessor(use_ulysses_parallel_attention=False)
 
 
     def _chunk_and_pad_sequence(self, x: torch.Tensor, sp_world_rank: int, sp_world_size: int, pad_amount: int, dim: int) -> torch.Tensor:

--- a/xfuser/model_executor/models/transformers/transformer_z_image.py
+++ b/xfuser/model_executor/models/transformers/transformer_z_image.py
@@ -136,7 +136,7 @@ class xFuserZImageTransformer2DWrapper(ZImageTransformer2DModel):
         for layer in self.layers:
             layer.attention.processor = xFuserZSingleStreamAttnProcessor()
         for layer in self.context_refiner + self.noise_refiner:
-            layer.attention.processor = xFuserZSingleStreamAttnProcessor(use_ulysses_parallel_attention=False)
+            layer.attention.processor = xFuserZSingleStreamAttnProcessor()
 
 
     def _chunk_and_pad_sequence(self, x: torch.Tensor, sp_world_rank: int, sp_world_size: int, pad_amount: int, dim: int) -> torch.Tensor:
@@ -224,23 +224,20 @@ class xFuserZImageTransformer2DWrapper(ZImageTransformer2DModel):
             x_attn_mask[i, :seq_len] = 1
 
         # SP support
-        # Leaving these here for posteriority - these would make the model slightly faster
-        # but causes slight numerical differences.
-
-        # pad_amount = (sp_world_size - (x.shape[1] % sp_world_size)) % sp_world_size
-        # x = self._chunk_and_pad_sequence(x, sp_world_rank, sp_world_size, pad_amount, dim=-2)
-        # x_attn_mask = self._chunk_and_pad_sequence(x_attn_mask, sp_world_rank, sp_world_size, pad_amount, dim=-1)
-        # x_freqs_cis_chunked = self._chunk_and_pad_sequence(x_freqs_cis, sp_world_rank, sp_world_size, pad_amount, dim=-2)
+        pad_amount = (sp_world_size - (x.shape[1] % sp_world_size)) % sp_world_size
+        x = self._chunk_and_pad_sequence(x, sp_world_rank, sp_world_size, pad_amount, dim=-2)
+        x_attn_mask = self._chunk_and_pad_sequence(x_attn_mask, sp_world_rank, sp_world_size, pad_amount, dim=-1)
+        x_freqs_cis_chunked = self._chunk_and_pad_sequence(x_freqs_cis, sp_world_rank, sp_world_size, pad_amount, dim=-2)
 
         if torch.is_grad_enabled() and self.gradient_checkpointing:
             for layer in self.noise_refiner:
-                x = self._gradient_checkpointing_func(layer, x, x_attn_mask, x_freqs_cis, adaln_input)
+                x = self._gradient_checkpointing_func(layer, x, x_attn_mask, x_freqs_cis_chunked, adaln_input)
         else:
             for layer in self.noise_refiner:
-                x = layer(x, x_attn_mask, x_freqs_cis, adaln_input)
+                x = layer(x, x_attn_mask, x_freqs_cis_chunked, adaln_input)
 
         # Gather SP outputs and remove padding
-        #x = self._gather_and_unpad(x, pad_amount, dim=-2)
+        x = self._gather_and_unpad(x, pad_amount, dim=-2)
 
         # cap embed & refine
         cap_item_seqlens = [len(_) for _ in cap_feats]
@@ -264,22 +261,20 @@ class xFuserZImageTransformer2DWrapper(ZImageTransformer2DModel):
 
 
         # SP support
-        # Same as above comments about speed vs numerical differences apply here.
-
-        # pad_amount = (sp_world_size - (cap_feats.shape[1] % sp_world_size)) % sp_world_size
-        # cap_feats = self._chunk_and_pad_sequence(cap_feats, sp_world_rank, sp_world_size, pad_amount, dim=-2)
-        # cap_attn_mask = self._chunk_and_pad_sequence(cap_attn_mask, sp_world_rank, sp_world_size, pad_amount, dim=-1)
-        # cap_freqs_cis_chunked = self._chunk_and_pad_sequence(cap_freqs_cis, sp_world_rank, sp_world_size, pad_amount, dim=-2)
+        pad_amount = (sp_world_size - (cap_feats.shape[1] % sp_world_size)) % sp_world_size
+        cap_feats = self._chunk_and_pad_sequence(cap_feats, sp_world_rank, sp_world_size, pad_amount, dim=-2)
+        cap_attn_mask = self._chunk_and_pad_sequence(cap_attn_mask, sp_world_rank, sp_world_size, pad_amount, dim=-1)
+        cap_freqs_cis_chunked = self._chunk_and_pad_sequence(cap_freqs_cis, sp_world_rank, sp_world_size, pad_amount, dim=-2)
 
         if torch.is_grad_enabled() and self.gradient_checkpointing:
             for layer in self.context_refiner:
-                cap_feats = self._gradient_checkpointing_func(layer, cap_feats, cap_attn_mask, cap_freqs_cis)
+                cap_feats = self._gradient_checkpointing_func(layer, cap_feats, cap_attn_mask, cap_freqs_cis_chunked)
         else:
             for layer in self.context_refiner:
-                cap_feats = layer(cap_feats, cap_attn_mask, cap_freqs_cis)
+                cap_feats = layer(cap_feats, cap_attn_mask, cap_freqs_cis_chunked)
 
         # Gather SP outputs and remove padding
-        # cap_feats = self._gather_and_unpad(cap_feats, pad_amount, dim=-2)
+        cap_feats = self._gather_and_unpad(cap_feats, pad_amount, dim=-2)
 
 
         # unified


### PR DESCRIPTION
These changes allow running z-image with full Ulysses-parallel on 8x mi355x (or any other GPU)
This improves the e2e latency of a single image generation from 4.2 to 2.4 sec
The profile of a full denoising step changes in the following manner:

* ulysses=2 + ring=2 + cfg-parallel --> 140 ms

<img width="1597" height="252" alt="image" src="https://github.com/user-attachments/assets/59874901-addc-4571-929d-75a34f7ced39" />

* ulysses=8 --> 93ms

<img width="1615" height="183" alt="image" src="https://github.com/user-attachments/assets/76624e4b-9b30-45d7-9e1c-51fa774433aa" />
