### PR TITLE
Use ATen-level distributed optimizations for Inductor compute/comm overlap

### DIFF
--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -18,6 +18,29 @@ def log(message: str, debug=False, log_from_all_processes: bool = False) -> None
         else:
             logger.info(message)
 
+def configure_inductor_comm_overlap() -> None:
+    """Enable Inductor compute/communication overlap.
+
+    PyTorch 2.10 emptied the default value of
+    ``torch._inductor.config.reorder_for_compute_comm_overlap_passes`` (it
+    used to be ``["reorder_compute_for_overlap", "sink_waits", "raise_comms"]``
+    on 2.9). With the list empty, even though
+    ``reorder_for_compute_comm_overlap`` is on, no scheduler-IR reorder
+    runs and bucketed collectives stay issued in source order, so the
+    runtime never gets a chance to overlap them with compute.
+
+    Restoring the 2.9 default list here is a no-op on torch <= 2.9
+    (the value is already that list) and recovers the 2.9 overlap
+    behavior on torch >= 2.10.
+    """
+    torch._inductor.config.reorder_for_compute_comm_overlap = True
+    torch._inductor.config.reorder_for_compute_comm_overlap_passes = [
+        "reorder_compute_for_overlap",
+        "sink_waits",
+        "raise_comms",
+    ]
+
+
 def is_last_process() -> bool:
     """
     Checks based on env rank and world size if this is last process in

--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -21,18 +21,43 @@ def log(message: str, debug=False, log_from_all_processes: bool = False) -> None
 def configure_inductor_comm_overlap() -> None:
     """Enable Inductor compute/communication overlap.
 
-    PyTorch 2.10 emptied the default value of
-    ``torch._inductor.config.reorder_for_compute_comm_overlap_passes`` (it
-    used to be ``["reorder_compute_for_overlap", "sink_waits", "raise_comms"]``
-    on 2.9). With the list empty, even though
-    ``reorder_for_compute_comm_overlap`` is on, no scheduler-IR reorder
-    runs and bucketed collectives stay issued in source order, so the
-    runtime never gets a chance to overlap them with compute.
+    Prefers the ATen-level distributed optimization passes that PyTorch upstream
+    now recommends over the legacy scheduler-IR passes
+    (see https://github.com/pytorch/pytorch/issues/169461). They run on the ATen
+    FX graph before Inductor scheduling and enable overlap scheduling,
+    overlap-preserving collective bucketing, and overlap dependency insertion.
+    ``collective_estimator="benchmark"`` is required on RCCL/MI355X, where the
+    analytical NCCL bandwidth model can be ~10x off and leaves the scheduler
+    thinking collectives are far more expensive than they are.
 
-    Restoring the 2.9 default list here is a no-op on torch <= 2.9
-    (the value is already that list) and recovers the 2.9 overlap
-    behavior on torch >= 2.10.
+    Falls back to the legacy scheduler-IR passes when
+    ``torch._inductor.config.aten_distributed_optimizations`` is unavailable
+    (it landed in torch >= 2.10). PyTorch 2.10 also emptied the default value of
+    ``reorder_for_compute_comm_overlap_passes`` (it used to be
+    ``["reorder_compute_for_overlap", "sink_waits", "raise_comms"]`` on 2.9), so
+    the fallback restores the 2.9 list to recover the old overlap behavior on
+    torch builds without the ATen passes.
     """
+    aten_opts = getattr(torch._inductor.config, "aten_distributed_optimizations", None)
+
+    if aten_opts is not None:
+        aten_opts.enable_overlap_scheduling = True
+        aten_opts.collective_bucketing = True
+        aten_opts.insert_overlap_deps = True
+        aten_opts.collective_estimator = "benchmark"
+        # Disable the legacy scheduler-IR overlap passes so we don't run two
+        # competing reorderers on the same graph.
+        torch._inductor.config.reorder_for_compute_comm_overlap = False
+        torch._inductor.config.reorder_for_compute_comm_overlap_passes = []
+        log("Inductor comm/compute overlap: using aten_distributed_optimizations "
+            "(enable_overlap_scheduling, collective_bucketing, insert_overlap_deps, "
+            "collective_estimator=benchmark)",
+            debug=True)
+        return
+
+    log("torch._inductor.config.aten_distributed_optimizations is unavailable "
+        "on this torch build; using legacy scheduler-IR overlap passes.",
+        debug=True)
     torch._inductor.config.reorder_for_compute_comm_overlap = True
     torch._inductor.config.reorder_for_compute_comm_overlap_passes = [
         "reorder_compute_for_overlap",

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -21,6 +21,7 @@ from xfuser.envs import (
 )
 from xfuser.core.distributed.parallel_state import get_fs_group
 from xfuser.core.utils.runner_utils import (
+    configure_inductor_comm_overlap,
     log,
     load_dataset_prompts,
     quantize_linear_layers_to_fp8,
@@ -286,7 +287,7 @@ class xFuserModel(abc.ABC):
 
     def _compile_model(self, input_args: dict) -> None:
         """ Compile the model using torch.compile."""
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
+        configure_inductor_comm_overlap()
         self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default") # TODO: Configurable
         # two steps to warmup the torch compiler
         input_args["num_inference_steps"] = 2  # Reduce steps for warmup # TODO: make this more generic

--- a/xfuser/model_executor/models/runner_models/causal_wan.py
+++ b/xfuser/model_executor/models/runner_models/causal_wan.py
@@ -14,6 +14,7 @@ from xfuser.model_executor.models.runner_models.base_model import (
     DefaultInputValues,
     DiffusionOutput,
 )
+from xfuser.core.utils.runner_utils import configure_inductor_comm_overlap
 
 
 
@@ -144,7 +145,7 @@ class xFuserCausalWanModel(xFuserModel):
             raise ValueError("Exactly one input image is required for CausalWan I2V mode.")
 
     def _compile_model(self, input_args):
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
+        configure_inductor_comm_overlap()
         self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
         self.pipe.transformer_2 = torch.compile(self.pipe.transformer_2, mode="default")
         compile_args = copy.deepcopy(input_args)

--- a/xfuser/model_executor/models/runner_models/flux.py
+++ b/xfuser/model_executor/models/runner_models/flux.py
@@ -13,6 +13,7 @@ from xfuser.model_executor.models.runner_models.base_model import (
     ModelSettings,
 )
 from xfuser.core.utils.runner_utils import (
+    configure_inductor_comm_overlap,
     log,
     resize_and_crop_image,
     quantize_linear_layers_to_fp8,
@@ -74,7 +75,7 @@ class xFuserFluxModel(xFuserModel):
 
     def _compile_model(self, input_args: dict) -> None:
         """ Compile the model using torch.compile."""
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
+        configure_inductor_comm_overlap()
         self.pipe.transformer = torch.compile(self.pipe.transformer, mode="reduce-overhead") # Better perf for FLUX.1
         # two steps to warmup the torch compiler
         input_args["num_inference_steps"] = 2

--- a/xfuser/model_executor/models/runner_models/hunyuan.py
+++ b/xfuser/model_executor/models/runner_models/hunyuan.py
@@ -21,6 +21,7 @@ from xfuser.model_executor.models.runner_models.base_model import (
 from xfuser.core.distributed.attention_backend import AttentionBackendType
 from xfuser.core.distributed.runtime_state import get_runtime_state
 from xfuser.core.utils.runner_utils import (
+    configure_inductor_comm_overlap,
     resize_and_crop_image,
     fix_llama_tokenizer_pretokenizer,
 )
@@ -82,7 +83,7 @@ class xFuserHunyuanvideoModel(xFuserModel):
 
     def _compile_model(self, input_args: dict) -> None:
         """ Compile the model using torch.compile """
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
+        configure_inductor_comm_overlap()
         self.pipe.transformer.compile()
 
         compile_args = copy.deepcopy(input_args)
@@ -180,7 +181,7 @@ class xFuserHunyuanvideo15Model(xFuserModel):
 
     def _compile_model(self, input_args: dict) -> None:
         """ Compile the model using torch.compile """
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
+        configure_inductor_comm_overlap()
         self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
 
         # two steps to warmup the torch compiler

--- a/xfuser/model_executor/models/runner_models/ltx.py
+++ b/xfuser/model_executor/models/runner_models/ltx.py
@@ -17,6 +17,7 @@ from xfuser.model_executor.models.runner_models.base_model import (
 )
 
 from xfuser.core.utils.runner_utils import (
+    configure_inductor_comm_overlap,
     log,
 )
 
@@ -172,7 +173,7 @@ class xFuserLTX23VideoModel(xFuserModel):
         return DiffusionOutput(videos=output, pipe_args=input_args)
 
     def _compile_model(self, input_args: dict) -> None:
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
+        configure_inductor_comm_overlap()
         self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
         self.second_pipe.transformer = torch.compile(self.second_pipe.transformer, mode="default")
 
@@ -291,7 +292,7 @@ class xFuserLTX2VideoModel(xFuserModel):
         return DiffusionOutput(videos=output, pipe_args=input_args)
 
     def _compile_model(self, input_args: dict) -> None:
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
+        configure_inductor_comm_overlap()
         self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
         self.second_pipe.transformer = torch.compile(self.second_pipe.transformer, mode="default")
 

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -25,6 +25,7 @@ from xfuser.model_executor.models.runner_models.base_model import (
 from xfuser.core.distributed.runtime_state import get_runtime_state
 from xfuser.core.distributed.parallel_state import get_vae_parallel_group
 from xfuser.core.utils.runner_utils import (
+    configure_inductor_comm_overlap,
     log,
     resize_and_crop_image,
     resize_image_to_max_area,
@@ -163,7 +164,7 @@ class xFuserWan21I2VModel(xFuserModel):
             raise ValueError("Exactly one input image is required for Wan I2V model.")
 
     def _compile_model(self, input_args):
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
+        configure_inductor_comm_overlap()
         self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
         compile_args = copy.deepcopy(input_args)
         # If a per-step attention schedule is active, do a full warmup to trigger all backend paths.
@@ -208,7 +209,7 @@ class xFuserWan22I2VModel(xFuserWan21I2VModel):
         return pipe
 
     def _compile_model(self, input_args):
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
+        configure_inductor_comm_overlap()
         self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
         self.pipe.transformer_2 = torch.compile(self.pipe.transformer_2, mode="default")
         # Full cycle to warmup the torch compiler
@@ -295,7 +296,7 @@ class xFuserWan21T2VModel(xFuserModel):
         return DiffusionOutput(videos=output.frames, pipe_args=input_args)
 
     def _compile_model(self, input_args):
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
+        configure_inductor_comm_overlap()
         self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
         compile_args = copy.deepcopy(input_args)
         # If a per-step attention schedule is active, do a full warmup to trigger all backend paths.
@@ -339,7 +340,7 @@ class xFuserWan22T2VModel(xFuserWan21T2VModel):
         return pipe
 
     def _compile_model(self, input_args):
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
+        configure_inductor_comm_overlap()
         self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
         self.pipe.transformer_2 = torch.compile(self.pipe.transformer_2, mode="default")
         # Full cycle to warmup the torch compiler
@@ -419,7 +420,7 @@ class xFuserWan22TI2VModel(xFuserWan21T2VModel):
         return DiffusionOutput(videos=output.frames, pipe_args=input_args)
 
     def _compile_model(self, input_args):
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
+        configure_inductor_comm_overlap()
         self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
         self._run_timed_pipe(input_args)
 


### PR DESCRIPTION
## Use ATen-level distributed optimizations for Inductor compute/comm overlap

### Problem

Every runner model toggles Inductor compute/communication overlap by hand
right before `torch.compile`:

```python
torch._inductor.config.reorder_for_compute_comm_overlap = True
self.pipe.transformer = torch.compile(...)
```

This has two issues:

1. **Duplication.** The same line is copy-pasted across `base_model.py`,
   `flux.py`, `hunyuan.py` (×2), `ltx.py` (×2), `wan.py` (×5) and
   `causal_wan.py`. Any change to the policy has to be made in nine places.
2. **Stale on PyTorch 2.10+.** PyTorch upstream now recommends the new
   ATen-level distributed optimization passes
   (`torch._inductor.config.aten_distributed_optimizations`) over the legacy
   scheduler-IR passes — see
   [pytorch/pytorch#169461](https://github.com/pytorch/pytorch/issues/169461).
   On top of that, PyTorch 2.10 emptied the default value of
   `reorder_for_compute_comm_overlap_passes` (it used to be
   `["reorder_compute_for_overlap", "sink_waits", "raise_comms"]` on 2.9), so
   simply flipping `reorder_for_compute_comm_overlap = True` on a 2.10 build
   is a no-op and silently regresses overlap.

### Fix

Add a `configure_inductor_comm_overlap()` helper in
`xfuser/core/utils/runner_utils.py` and call it from every runner model's
`_compile_model`.

The helper:

- **Prefers the ATen passes** when
  `torch._inductor.config.aten_distributed_optimizations` is available
  (torch ≥ 2.10). It enables `enable_overlap_scheduling`,
  `collective_bucketing` and `insert_overlap_deps`, and forces
  `collective_estimator="benchmark"`. The benchmarking estimator is required
  on platforms such as MI355X, where the analytical NCCL bandwidth model can be ~10×
  off and leaves the scheduler thinking collectives are far more expensive
  than they actually are, suppressing overlap.
- **Disables the legacy scheduler-IR overlap passes** in the same path, so
  the ATen reorderer and the scheduler reorderer don't fight over the same
  graph.
- **Falls back to the legacy passes** on older torch builds, and explicitly
  restores the pre-2.10 default
  `reorder_for_compute_comm_overlap_passes = ["reorder_compute_for_overlap",
  "sink_waits", "raise_comms"]` so 2.10 builds without the ATen API still
  get real overlap instead of an empty pass list.

### Changes

- `xfuser/core/utils/runner_utils.py` — new
  `configure_inductor_comm_overlap()` helper with ATen-pass preference and
  legacy fallback.
- `xfuser/model_executor/models/runner_models/base_model.py`
- `xfuser/model_executor/models/runner_models/causal_wan.py`
- `xfuser/model_executor/models/runner_models/flux.py`
- `xfuser/model_executor/models/runner_models/hunyuan.py` (HunyuanVideo and HunyuanVideo-1.5)
- `xfuser/model_executor/models/runner_models/ltx.py` (LTX-2 and LTX-2.3)
- `xfuser/model_executor/models/runner_models/wan.py` (Wan2.1/Wan2.2 I2V, T2V, TI2V)

  All `_compile_model` methods now call `configure_inductor_comm_overlap()`
  instead of setting `torch._inductor.config.reorder_for_compute_comm_overlap`
  directly.
