### PR TITLE
Support parallel Wan VAE encoder

### DIFF
--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -67,6 +67,7 @@ class ModelCapabilities:
     tensor_parallel_degree: bool = False
     use_cfg_parallel: bool = False
     use_parallel_vae: bool = False
+    use_parallel_vae_encoder: bool = False
     fully_shard_degree: bool = False
     # Memory optimizations
     enable_slicing: bool = False

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -44,7 +44,23 @@ COMMON_FSDP_STRATEGY = {
 
 
 def _setup_parallel_vae(vae) -> None:
-    """ Parallalizes the VAE decoder using distvae """
+    """ Parallelizes VAE en-/decoder using distvae """
+    # Handle encoder
+    try:
+        from distvae.modules.adapters.vae.encoder_adapters import WanEncoderAdapter
+        patched_encoder = WanEncoderAdapter(
+            vae.encoder, vae_group=get_vae_parallel_group().device_group, vae_scale_factor=8,
+        ).to(vae.device)
+        vae.encoder = patched_encoder
+    except ImportError:
+        raise log(
+            "DistVAE library is missing or does not support WanEncoderAdapter. "
+            "Try installing latest DistVAE from https://github.com/xdit-project/DistVAE. "
+            "Defaulting to single-rank encoder."
+        )
+    except Exception as e:
+        raise ValueError(f"Failed to patch VAE encoder. {e}")
+    # Handle decoder
     try:
         from distvae.modules.adapters.vae.decoder_adapters import WanDecoderAdapter
         patched_decoder = WanDecoderAdapter(
@@ -53,9 +69,10 @@ def _setup_parallel_vae(vae) -> None:
         vae.decoder = patched_decoder
         log(f"Parallel VAE decoder enabled successfully.")
     except ImportError:
-        raise ValueError(
+        raise log(
             "DistVAE library is missing or does not support WanDecoderAdapter. "
-            "Try installing latest DistVAE from https://github.com/xdit-project/DistVAE."
+            "Try installing latest DistVAE from https://github.com/xdit-project/DistVAE. "
+            "Defaulting to single-rank decoder."
         )
     except Exception as e:
         raise ValueError(f"Failed to patch VAE decoder. {e}")

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -60,7 +60,7 @@ def _setup_parallel_vae(vae, enable_parallel_encoder: bool = True) -> None:
             vae.encoder = patched_encoder
             log(f"Parallel VAE encoder enabled successfully.")
         except ImportError:
-            raise log(
+            log(
                 "DistVAE library is missing or does not support WanEncoderAdapter. "
                 "Try installing latest DistVAE from https://github.com/xdit-project/DistVAE. "
                 "Defaulting to single-rank encoder."
@@ -76,7 +76,7 @@ def _setup_parallel_vae(vae, enable_parallel_encoder: bool = True) -> None:
         vae.decoder = patched_decoder
         log(f"Parallel VAE decoder enabled successfully.")
     except ImportError:
-        raise log(
+        log(
             "DistVAE library is missing or does not support WanDecoderAdapter. "
             "Try installing latest DistVAE from https://github.com/xdit-project/DistVAE. "
             "Defaulting to single-rank decoder."

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -51,7 +51,7 @@ def _setup_parallel_vae(vae, enable_parallel_encoder: bool = True) -> None:
             from distvae.modules.adapters.vae.encoder_adapters import WanEncoderAdapter
             vae_scale_factor = getattr(vae.config, 'scaling_factor', 8)
             if hasattr(vae.config, 'vae_scale_factor_spatial'):
-                vae_scale_factor = self.vae_config.vae_scale_factor_spatial
+                vae_scale_factor = vae_config.vae_scale_factor_spatial
             patched_encoder = WanEncoderAdapter(
                 vae.encoder,
                 vae_group=get_vae_parallel_group().device_group,

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -51,7 +51,7 @@ def _setup_parallel_vae(vae, enable_parallel_encoder: bool = True) -> None:
             from distvae.modules.adapters.vae.encoder_adapters import WanEncoderAdapter
             vae_scale_factor = getattr(vae.config, 'scaling_factor', 8)
             if hasattr(vae.config, 'vae_scale_factor_spatial'):
-                vae_scale_factor = vae_config.vae_scale_factor_spatial
+                vae_scale_factor = vae.config.vae_scale_factor_spatial
             patched_encoder = WanEncoderAdapter(
                 vae.encoder,
                 vae_group=get_vae_parallel_group().device_group,

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -49,7 +49,9 @@ def _setup_parallel_vae(vae) -> None:
     try:
         from distvae.modules.adapters.vae.encoder_adapters import WanEncoderAdapter
         patched_encoder = WanEncoderAdapter(
-            vae.encoder, vae_group=get_vae_parallel_group().device_group, vae_scale_factor=8,
+            vae.encoder,
+            vae_group=get_vae_parallel_group().device_group,
+            vae_scale_factor=get_runtime_state().vae_scale_factor_spatial,
         ).to(vae.device)
         vae.encoder = patched_encoder
     except ImportError:

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -289,7 +289,7 @@ class xFuserWan21T2VModel(xFuserModel):
     def _post_load_and_state_initialization(self, input_args: dict) -> None:
         super()._post_load_and_state_initialization(input_args)
         if self.config.use_parallel_vae:
-            _setup_parallel_vae(self.pipe.vae)
+            _setup_parallel_vae(self.pipe.vae, self.capabilities.use_parallel_vae_encoder)
         self.pipe.scheduler.config.flow_shift = input_args["flow_shift"]
 
     def _load_model(self) -> DiffusionPipeline:

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -43,25 +43,30 @@ COMMON_FSDP_STRATEGY = {
 }
 
 
-def _setup_parallel_vae(vae) -> None:
+def _setup_parallel_vae(vae, enable_parallel_encoder: bool = True) -> None:
     """ Parallelizes VAE en-/decoder using distvae """
     # Handle encoder
-    try:
-        from distvae.modules.adapters.vae.encoder_adapters import WanEncoderAdapter
-        patched_encoder = WanEncoderAdapter(
-            vae.encoder,
-            vae_group=get_vae_parallel_group().device_group,
-            vae_scale_factor=get_runtime_state().vae_scale_factor_spatial,
-        ).to(vae.device)
-        vae.encoder = patched_encoder
-    except ImportError:
-        raise log(
-            "DistVAE library is missing or does not support WanEncoderAdapter. "
-            "Try installing latest DistVAE from https://github.com/xdit-project/DistVAE. "
-            "Defaulting to single-rank encoder."
-        )
-    except Exception as e:
-        raise ValueError(f"Failed to patch VAE encoder. {e}")
+    if enable_parallel_encoder:
+        try:
+            from distvae.modules.adapters.vae.encoder_adapters import WanEncoderAdapter
+            vae_scale_factor = getattr(vae.config, 'scaling_factor', 8)
+            if hasattr(vae.config, 'vae_scale_factor_spatial'):
+                vae_scale_factor = self.vae_config.vae_scale_factor_spatial
+            patched_encoder = WanEncoderAdapter(
+                vae.encoder,
+                vae_group=get_vae_parallel_group().device_group,
+                vae_scale_factor=vae_scale_factor,
+            ).to(vae.device)
+            vae.encoder = patched_encoder
+            log(f"Parallel VAE encoder enabled successfully.")
+        except ImportError:
+            raise log(
+                "DistVAE library is missing or does not support WanEncoderAdapter. "
+                "Try installing latest DistVAE from https://github.com/xdit-project/DistVAE. "
+                "Defaulting to single-rank encoder."
+            )
+        except Exception as e:
+            raise ValueError(f"Failed to patch VAE encoder. {e}")
     # Handle decoder
     try:
         from distvae.modules.adapters.vae.decoder_adapters import WanDecoderAdapter
@@ -99,6 +104,7 @@ class xFuserWan21I2VModel(xFuserModel):
         use_fp4_gemms=True,
         use_hybrid_attn_schedule=True,
         use_parallel_vae=True,
+        use_parallel_vae_encoder=True,
         cross_attention_backend=True,
     )
     default_input_values = DefaultInputValues(
@@ -130,7 +136,7 @@ class xFuserWan21I2VModel(xFuserModel):
     def _post_load_and_state_initialization(self, input_args: dict) -> None:
         super()._post_load_and_state_initialization(input_args)
         if self.config.use_parallel_vae:
-            _setup_parallel_vae(self.pipe.vae)
+            _setup_parallel_vae(self.pipe.vae, self.capabilities.use_parallel_vae_encoder)
         self.pipe.scheduler.config.flow_shift = input_args["flow_shift"]
 
     def _load_model(self) -> DiffusionPipeline:


### PR DESCRIPTION
Add support for parallel Wan VAE encoder

#### Background

Recent [DistVAE](https://github.com/xdit-project/DistVAE/pull/12) supports parallel Wan VAE encoder.

#### Tasks

Do

- [x] `WanEncoderAdapter` support when parallelizing VAE controlled by `ModelCapabilities`
- [x] Make import error into a logged warning to allow flexibility with DistVAE versions

for completeness.

#### Test

Run Wan 2.2 I2V 14B and TI2V 5B end-to-end with success. See DistVAE PR for evidence