### PR TITLE
Add Flex Block Attention Backend for SSTA Support on Nvidia

### DIFF
--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -335,6 +335,8 @@ if env_info["has_transformer_engine"]:
     )
 if env_info["has_sage"]:
     from sageattention import sageattn
+if env_info["has_flex_block_attn"]:
+    from flex_block_attn import flex_block_attn_func
 if env_info["has_npu_flash_attn"]:
     import torch_npu
 
@@ -351,6 +353,7 @@ class AttentionBackendType(Enum):
     FLASH_4 = "Flash Attention V4"
     FLASH_4_FP4 = "Flash Attention V4 FP4"
     SAGE = "Sage Attention"
+    FLEX_BLOCK_ATTN = "Flex Block Attention"
     AITER = "AITER"
     AITER_FP8 = "AITER FP8"
     AITER_MLA = "AITER MLA"
@@ -771,6 +774,30 @@ def _sage_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs=No
     )
     return output, softmax_lse
 
+@torch.library.custom_op("xfuser::flex_block_attn", mutates_args=())
+def flex_block_attn_op(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    block_m: int,
+    block_n: int,
+    block_mask: torch.Tensor,
+) -> torch.Tensor:
+    return flex_block_attn_func(q, k, v, block_m, block_n, block_mask)
+
+@flex_block_attn_op.register_fake
+def _(q, k, v, block_m, block_n, block_mask):
+    return torch.empty_like(q)
+
+@register_attention_function(AttentionBackendType.FLEX_BLOCK_ATTN)
+def _flex_block_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs=None):
+    attention_kwargs["sp_size"] = get_ulysses_parallel_world_size()
+    block_size = math.prod(attention_kwargs["tile_size"])
+    q, k, v, mask_config, ssta_state = setup_ssta(query, key, value, attention_kwargs)
+    block_mask = get_sparse_mask(mask_config, sparse_type=attention_kwargs["attn_sparse_type"])
+    output = flex_block_attn_op(q, k, v, block_size, block_size, block_mask)
+    output = untile_ssta_output(output, ssta_state, attention_kwargs["encoder_sequence_length"], attention_kwargs["sp_size"])
+    return output, None
 
 @register_attention_function(AttentionBackendType.AITER_SPARSE_SAGE)
 def _aiter_sparse_sage_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs=None):

--- a/xfuser/core/distributed/runtime_state.py
+++ b/xfuser/core/distributed/runtime_state.py
@@ -210,7 +210,8 @@ class RuntimeState(metaclass=ABCMeta):
                                  AttentionBackendType.AITER_SAGE,
                                  AttentionBackendType.AITER_SPARSE_SAGE,
                                  AttentionBackendType.AITER_SAGE_V2,
-                                 AttentionBackendType.AITER_SPARSE_SAGE_V2,]:
+                                 AttentionBackendType.AITER_SPARSE_SAGE_V2,
+                                 AttentionBackendType.FLEX_BLOCK_ATTN]:
             if self.parallel_config.ring_degree > 1:
                 raise RuntimeError("Selected attention backend does not support ring parallelism.")
         if attention_backend == AttentionBackendType.AITER_FP8:
@@ -253,6 +254,9 @@ class RuntimeState(metaclass=ABCMeta):
         elif attention_backend == AttentionBackendType.SAGE:
             if not env_info["has_sage"]:
                 raise RuntimeError("SageAttention is not available, please install SageAttention.")
+        elif attention_backend == AttentionBackendType.FLEX_BLOCK_ATTN:
+            if not env_info["has_flex_block_attn"]:
+                raise RuntimeError("Flex Block Attention is not available, please install Flex Block Attention.")
 
 
 

--- a/xfuser/envs.py
+++ b/xfuser/envs.py
@@ -207,6 +207,7 @@ class PackagesEnvChecker:
         packages_info["has_flash_attn_4_fp4"] = self._check_flash_attn_4_fp4()
         packages_info["has_transformer_engine"] = self.check_transformer_engine()
         packages_info["has_sage"] = self._check_sage()
+        packages_info["has_flex_block_attn"] = self._check_flex_block_attn()
         packages_info["has_long_ctx_attn"] = self.check_long_ctx_attn()
         packages_info["diffusers_version"] = self.check_diffusers_version()
         packages_info["has_npu_flash_attn"] = self.check_npu_flash_attn()
@@ -325,6 +326,13 @@ class PackagesEnvChecker:
     def _check_sage(self):
         try:
             from sageattention import sageattn
+            return True
+        except:
+            return False
+
+    def _check_flex_block_attn(self):
+        try:
+            from flex_block_attn import flex_block_attn_func
             return True
         except:
             return False

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -235,7 +235,8 @@ class xFuserModel(abc.ABC):
                     raise ValueError(f"Model {self.settings.model_name} does not support {key}.")
         
         sparse_attention_backend_types = [AttentionBackendType.AITER_SPARSE_SAGE,
-                                        AttentionBackendType.AITER_SPARSE_SAGE_V2]
+                                        AttentionBackendType.AITER_SPARSE_SAGE_V2,
+                                        AttentionBackendType.FLEX_BLOCK_ATTN]
         if config.attention_backend is None:
             if self.capabilities.supports_sparse_attention_backends:
                 raise ValueError(f"Model {config.model} supports sparse attention backends, but no attention backend was specified. Please specify a sparse attention backend to take advantage of the model's capabilities."


### PR DESCRIPTION
This pull request introduces support for the Flex Block Attention backend. The main changes include adding detection and import logic for the new backend, registering its attention function, updating compatibility checks, and ensuring that configuration validation recognizes it as a sparse attention backend.

The following command:
`xdit --model Hunyuanvideo-1.5-Sparse --prompt "Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside." --input_images https://huggingface.co/datasets/YiYiXu/testing-images/resolve/main/wan_i2v_input.JPG --use_torch_compile --enable_slicing --enable_tiling --attention_backend flex_block_attn --nproc_per_node=8 --ulysses_degree 8 --task i2v --use_ssta_sparse_text_to_image --height 720 --width 1280 --num_frames 129`

Gives an E2E time of ~60s on H200.


https://github.com/user-attachments/assets/2d827b40-3459-43a4-87ea-c2469544f604

