### PR TITLE
feat: FSDP2 sharding with quantized GEMMs support

### DIFF
--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -141,6 +141,7 @@ class xFuserArgs:
     dataset_path: Optional[str] = None
     use_fsdp: bool = False
     fully_shard_degree: int = 1
+    reshard_after_forward: bool = True
     use_vae_channels_last_format: bool = False
     # Hybrid attention schedule
     use_hybrid_attn_schedule: bool = False
@@ -493,6 +494,14 @@ class xFuserArgs:
             type=int,
             default=1,
             help="Fully sharding (sharding) degree."
+        )
+        parser.add_argument(
+            "--no_reshard_after_forward",
+            dest="reshard_after_forward",
+            action="store_false",
+            help="Keep parameters gathered after each block's forward instead of resharding. "
+                 "Trades memory for latency by eliminating repeated all-gathers. "
+                 "Only valid with --fully_shard_degree > 1.",
         )
         parser.add_argument(
             "--height",

--- a/xfuser/core/distributed/sharding.py
+++ b/xfuser/core/distributed/sharding.py
@@ -13,10 +13,11 @@ Key Features:
 Functions:
     - shard_dit: Shard a Diffusion Transformer (DiT) model
     - shard_t5_encoder: Shard a T5 encoder model
-    - shard_transformer_blocks: Generic transformer block sharding
+    - shard_component: Generic transformer block sharding
 """
+import logging
 from functools import partial
-from typing import Iterable, Optional, Any
+from typing import Callable, Iterable, Optional
 
 import torch
 import functools
@@ -25,9 +26,21 @@ from torch.distributed.fsdp import (
     ShardingStrategy,
     FullyShardedDataParallel as FSDP,
 )
-from torch.distributed.fsdp.wrap import (
-    lambda_auto_wrap_policy,
-)
+from torch.distributed.fsdp.wrap import lambda_auto_wrap_policy
+from torch.distributed.device_mesh import DeviceMesh
+
+
+logger = logging.getLogger(__name__)
+
+
+def _make_mesh(
+    process_group: Optional[torch.distributed.ProcessGroup],
+    device_type: str = "cuda",
+):
+    """Wrap an existing ProcessGroup as a 1-D DeviceMesh without creating a new NCCL communicator."""
+    if process_group is None:
+        return None
+    return DeviceMesh.from_group(process_group, device_type)
 
 
 def children_to_device(
@@ -55,7 +68,7 @@ def children_to_device(
     Example:
         >>> model = TransformerModel()
         >>> # Move all children except 'blocks' to GPU
-        >>> _children_to_device(model, 'cuda:0', excluded_children=['blocks'])
+        >>> children_to_device(model, 'cuda:0', excluded_children=['blocks'])
     """
     for name, child in module.named_children():
         if name not in excluded_children:
@@ -182,13 +195,16 @@ def shard_component(
     use_orig_params: bool = True,
     sync_module_states: bool = True,
     forward_prefetch: bool = True,
+    reshard_after_forward: bool = True,
+    quantize_fn: Optional[Callable] = None,
 ) -> torch.nn.Module:
     """
     Wrap a component with FSDP, treating each block as a separate FSDP unit.
 
-    This function applies Fully Sharded Data Parallel (FSDP) to a transformer model,
-    automatically wrapping each transformer block separately for optimal memory
-    distribution. Parameters and buffers are converted to the specified dtype.
+    Uses FSDP1 when quantize_fn is None (O(1) flat-param hooks, no DTensor bookkeeping,
+    fastest for non-quantized inference). Uses FSDP2 (composable fully_shard) when
+    quantize_fn is provided, required for torchao quantized tensor types that cannot
+    be flattened to FSDP1's 1D FlatParameter.
 
     Args:
         component (nn.Module): The transformer model to wrap with FSDP.
@@ -208,6 +224,14 @@ def shard_component(
             Defaults to True.
         forward_prefetch (bool, optional): Whether to use forward prefetch.
             Defaults to True.
+        reshard_after_forward (bool, optional): If True (default), reshard parameters after each
+            block's forward. Set False to keep params gathered post-forward, trading
+            memory for latency. Maps to ShardingStrategy in FSDP1, reshard_after_forward
+            in FSDP2.
+            Defaults to True.
+        quantize_fn (Callable, optional): Called as quantize_fn(block, idx) per block
+            before FSDP2 wrapping. Selects FSDP2 path when provided.
+            Defaults to None.
 
     Returns:
         nn.Module: The FSDP-wrapped component.
@@ -222,41 +246,75 @@ def shard_component(
         ...     device_id=0,
         ...     process_group=get_sp_group().device_group,  # NOT get_sp_group()
         ...     dtype=torch.bfloat16,
-        ...     sync_module_states=True,
-        ...     forward_prefetch=True
+        ...     forward_prefetch=True,
+        ...     reshard_after_forward=True,
+        ...     quantize_fn=quantize_fn,
         ... )
 
     Note:
-        - Uses FULL_SHARD strategy for maximum memory savings
-        - Each element in 'wrap_attrs' becomes a separate FSDP unit
+        - Each element in wrap_attrs becomes a separate FSDP unit
         - Requires PyTorch distributed to be initialized before calling
-        - When passing a GroupCoordinator from get_sp_group() or get_world_group(),
-          extract the ProcessGroup with `.device_group` attribute
     """
-    # Determine device: use CUDA if available and device_id specified, else CPU
-    if device_id is None:
-        if torch.cuda.is_available():
-            device_id = torch.cuda.current_device()
-        else:
-            device_id = None  # CPU mode
+    if device_id is None and torch.cuda.is_available():
+        device_id = torch.cuda.current_device()
 
-    wrapped_elements = []
+    wrapped_blocks = []
     for wrap_attr in wrap_attrs:
-        wrapped_elements.extend(rgetattr(component, wrap_attr))
+        wrapped_blocks.extend(rgetattr(component, wrap_attr))
 
     if dtype:
         component = component.to(dtype)
 
-    component = FSDP(
-        component,
-        process_group=process_group,
-        device_id=device_id,
-        auto_wrap_policy=partial(lambda_auto_wrap_policy, lambda_fn=lambda module: module in wrapped_elements),
-        sharding_strategy=ShardingStrategy.FULL_SHARD,
-        sync_module_states=sync_module_states,
-        use_orig_params=use_orig_params,
-        forward_prefetch=forward_prefetch,
-    )
+    if quantize_fn is None:
+        # FSDP1: Fastest path for non-quantized inference.
+        return FSDP(
+            component,
+            process_group=process_group,
+            device_id=device_id,
+            auto_wrap_policy=partial(lambda_auto_wrap_policy, lambda_fn=lambda m: m in wrapped_blocks),
+            sharding_strategy=ShardingStrategy.FULL_SHARD if reshard_after_forward else ShardingStrategy.SHARD_GRAD_OP,
+            sync_module_states=sync_module_states,
+            use_orig_params=use_orig_params,
+            forward_prefetch=forward_prefetch,
+        )
+
+    # FSDP2: Required for torchao quantized tensors.
+    from torch.distributed._composable.fsdp import fully_shard  # noqa: PLC0415
+    device_type = "cuda" if torch.cuda.is_available() else "cpu"
+    device_str = f"{device_type}:{device_id}"
+    mesh = _make_mesh(process_group, device_type)
+
+    # Move non-block children first; block containers are handled block-by-block below.
+    wrap_top_names = {attr.split(".")[0] for attr in wrap_attrs}
+    for name, child in component.named_children():
+        if name not in wrap_top_names:
+            child.to(device_str)
+
+    # Sequential: after fully_shard(block) each rank holds 1/N params, freeing memory
+    # for the next block. At most one full block on GPU at a time.
+    for i, block in enumerate(wrapped_blocks):
+        block.to(device_str)
+        quantize_fn(block, i)
+        fully_shard(block, mesh=mesh, reshard_after_forward=reshard_after_forward)
+
+    fully_shard(component, mesh=mesh, reshard_after_forward=reshard_after_forward)
+
+    # FSDP2 forward prefetch: each block pre-fetches the next two blocks' all-gathers
+    # so communication overlaps with compute. The first block has no predecessor to
+    # trigger its prefetch, so a pre-hook manually unshards it before the forward begins.
+    if forward_prefetch and len(wrapped_blocks) > 1:
+        for i, block in enumerate(wrapped_blocks):
+            lookahead = [
+                wrapped_blocks[i + j]
+                for j in range(1, 3)
+                if i + j < len(wrapped_blocks)
+            ]
+            if lookahead:
+                block.set_modules_to_forward_prefetch(lookahead)
+
+        def _unshard_first_block(_module, _args, _kwargs):
+            wrapped_blocks[0].unshard(async_op=True)
+        component.register_forward_pre_hook(_unshard_first_block, with_kwargs=True)
 
     return component
 

--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -87,6 +87,174 @@ def _get_fp8_kernel_preference():
     return KernelPreference.AUTO
 
 
+def _patch_torchao_float8_fsdp2() -> list[str]:
+    """
+    Patch torchao's inference Float8Tensor for FSDP2 (fully_shard) compatibility.
+
+    Two separate problems require two sets of patches:
+
+    1. Init-time aten op bugs:
+       FSDP2 calls torch.chunk which passes aten.split.Tensor with dim as a kwarg,
+       but the existing Float8Tensor handler expects 3 positional args which raises
+       a ValueError. We fix split and add new_empty/new_zeros/copy_/view handlers for
+       the param-management ops FSDP2 calls during _init_sharded_param.
+
+    2. Forward-time subclass loss:
+       FSDP2 all-gather reconstructs sharded params as plain torch.Tensors, 
+       stripping the Float8Tensor subclass. F.linear then sees raw fp8 bytes
+       interpreted as bf16, resulting in garbage output. Fix: implement
+       fsdp_pre/post_all_gather so FSDP2 gathers qdata and reconstructs a proper
+       Float8Tensor on the other side. This mirrors WeightWithDynamicFloat8CastTensor
+       in torchao/float8/fsdp_utils.py (the training path).
+
+    Returns list of patch names applied (logged on first call).
+    """
+    from torchao.quantization.quantize_.workflows.float8.float8_tensor import Float8Tensor
+
+    aten = torch.ops.aten
+    table = Float8Tensor._ATEN_OP_TABLE.get(Float8Tensor, {})
+    patched = []
+
+    def _make_float8(tensor, new_qdata, new_block_size=None):
+        _, attr_dict = tensor.__tensor_flatten__()
+        if new_block_size is not None:
+            attr_dict = {**attr_dict, 'block_size': new_block_size}
+        return Float8Tensor.__tensor_unflatten__(
+            {'qdata': new_qdata, 'scale': tensor.scale}, attr_dict, None, None
+        )
+
+    # aten.split.Tensor: torch.chunk passes dim as kwarg; existing handler
+    # expects 3 positional args which raises a ValueError. Also handles PerTensor
+    # scale when FSDP2 flattens weights to 1D before making them a DTensor.
+    split_op = aten.split.Tensor
+    if split_op in table:
+        _orig_split = table[split_op]
+        def _split(func, types, args, kwargs):
+            if len(args) == 2:
+                args = args + (kwargs.pop("dim", 0),)
+            tensor, split_size, dim = args
+            if isinstance(tensor, Float8Tensor) and tensor.scale.numel() == 1:
+                new_qdatas = aten.split.Tensor(tensor.qdata, split_size, dim)
+                return tuple(_make_float8(tensor, qd, list(qd.shape)) for qd in new_qdatas)
+            return _orig_split(func, types, args, kwargs)
+        table[split_op] = _split
+        patched.append("aten.split.Tensor")
+
+    # aten.new_empty: FSDP2 calls _chunk_with_empty which pads short chunk lists with size-0 tensors
+    def _new_empty(_, _t, args, kwargs):
+        tensor = args[0]
+        size = list(args[1]) if len(args) > 1 else list(kwargs.get("size", []))
+        new_qdata = tensor.qdata.new_empty(size, pin_memory=kwargs.get("pin_memory", False))
+        return _make_float8(tensor, new_qdata, size if size else [0])
+    table[aten.new_empty.default] = _new_empty
+    patched.append("aten.new_empty.default")
+
+    # aten.new_zeros: FSDP2 allocates a padded sharded-param buffer
+    def _new_zeros(_, _t, args, kwargs):
+        tensor = args[0]
+        size = list(args[1]) if len(args) > 1 else list(kwargs.get("size", []))
+        new_qdata = tensor.qdata.new_zeros(size, pin_memory=kwargs.get("pin_memory", False))
+        return _make_float8(tensor, new_qdata, size)
+    table[aten.new_zeros.default] = _new_zeros
+    patched.append("aten.new_zeros.default")
+
+    # aten.copy_: FSDP2 fills the padded buffer from the local fp8 shard
+    def _copy_(_, _t, args, _kw):
+        dst, src = args[0], args[1]
+        dst.qdata.copy_(src.qdata if isinstance(src, Float8Tensor) else src)
+        return dst
+    table[aten.copy_.default] = _copy_
+    patched.append("aten.copy_.default")
+
+    # aten.view.default: existing handler only supports 2D↔3D; FSDP2 may call
+    # view(-1) to flatten to 1D before sharding.
+    _orig_view = table.get(aten.view.default)
+    def _view(func, types, args, kwargs):
+        tensor, size = args
+        if len(size) == 1:
+            numel = tensor.numel()
+            return _make_float8(tensor, tensor.qdata.reshape(numel), [numel])
+        if _orig_view is not None:
+            return _orig_view(func, types, args, kwargs)
+        raise NotImplementedError(f"Float8Tensor view patch: unhandled {tensor.shape} -> {size}")
+    table[aten.view.default] = _view
+    patched.append("aten.view.default")
+
+    # aten.as_strided.default: FSDP2 uses this during init_unsharded_param to
+    # create a strided view into the all-gathered buffer.
+    def _as_strided(_, _t, args, kwargs):
+        tensor, size, stride = args[0], args[1], args[2]
+        storage_offset = args[3] if len(args) > 3 else kwargs.get("storage_offset", 0)
+        new_qdata = aten.as_strided.default(tensor.qdata, size, stride, storage_offset)
+        return _make_float8(tensor, new_qdata, list(size))
+    table[aten.as_strided.default] = _as_strided
+    patched.append("aten.as_strided.default")
+
+    # __torch_dispatch__ fallthrough: for any remaining FSDP structural ops not
+    # in the table (e.g. torch.ops.fsdp.*), unwrap to qdata and call through.
+    # Compute ops (linear, mm, addmm) ARE in the table so they won't hit this.
+    @classmethod
+    def _patched_dispatch(cls, func, types, args=(), kwargs=None):
+        if kwargs is None:
+            kwargs = {}
+        inner_table = cls._ATEN_OP_TABLE.get(cls, {})
+        if func in inner_table:
+            return inner_table[func](func, types, args, kwargs)
+        def _unwrap(t):
+            return t.qdata if isinstance(t, cls) else t
+        unwrapped_args = torch.utils._pytree.tree_map(_unwrap, args)
+        unwrapped_kwargs = torch.utils._pytree.tree_map(_unwrap, kwargs)
+        return func(*unwrapped_args, **unwrapped_kwargs)
+    Float8Tensor.__torch_dispatch__ = _patched_dispatch
+    patched.append("__torch_dispatch__ fallthrough")
+
+    # fsdp_pre_all_gather / fsdp_post_all_gather: preserve Float8Tensor subclass
+    # through FSDP2 all-gather. Without these, all-gather returns a plain Tensor,
+    # F.linear bypasses fp8 dispatch and interprets e4m3fn bytes as bf16, resulting
+    # in noise output. For static-scale inference Float8Tensor, scale is per-tensor
+    # (scalar) and identical across all ranks, so only qdata needs to be gathered.
+
+    def _fsdp_pre_all_gather(self, _mesh):
+        _, attr_dict = self.__tensor_flatten__()
+        return (self.qdata,), (self.scale, attr_dict)
+
+    def _fsdp_post_all_gather(_self, all_gather_outputs, metadata, _param_dtype, *, out=None):
+        (qdata,) = all_gather_outputs
+        scale, attr_dict = metadata
+        if out is not None:
+            if isinstance(out, Float8Tensor):
+                out.qdata.copy_(qdata)
+                return
+            raise RuntimeError(
+                f"fsdp_post_all_gather: out must be Float8Tensor, got {type(out)}"
+            )
+        # attr_dict was captured before sharding, so block_size reflects the 1D
+        # shard shape. Patch it to the all-gathered shape before reconstructing.
+        attr_dict = {**attr_dict, 'block_size': list(qdata.shape)}
+        # Return (tensor, inner_tensors): FSDP2 keeps inner_tensors alive until
+        # reshard; without this second element FSDP2 unpacks the tensor itself.
+        fp8 = Float8Tensor.__tensor_unflatten__(
+            {'qdata': qdata, 'scale': scale}, attr_dict, None, None
+        )
+        return fp8, (qdata,)
+
+    Float8Tensor.fsdp_pre_all_gather = _fsdp_pre_all_gather
+    Float8Tensor.fsdp_post_all_gather = _fsdp_post_all_gather
+    patched.append("fsdp_pre_all_gather")
+    patched.append("fsdp_post_all_gather")
+
+    return patched
+
+
+_TORCHAO_FLOAT8_FSDP2_PATCHES: list[str] = []
+
+try:
+    _TORCHAO_FLOAT8_FSDP2_PATCHES = _patch_torchao_float8_fsdp2()
+    logger.debug("torchao Float8Tensor FSDP2 patches applied: %s", _TORCHAO_FLOAT8_FSDP2_PATCHES)
+except Exception as e:
+    logger.debug("torchao Float8Tensor FSDP2 patches skipped (%s): %s", type(e).__name__, e)
+
+
 def quantize_linear_layers_to_fp8(module_or_module_list_to_quantize: torch.nn.Module | torch.nn.ModuleList,
     filter_fn: Optional[Callable[[torch.nn.Module, str], bool]] = None,
     device: Optional[torch.device] = None) -> None:

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -558,21 +558,21 @@ class xFuserModel(abc.ABC):
         """ Hook for any post model-load and state initialization """
 
         local_rank = get_world_group().local_rank
+        # FSDP path handles device placement and quantization (per-block for FSDP2).
         if self.config.fully_shard_degree > 1:
             self._shard_model_with_fsdp()
         else:
             self.pipe = self.pipe.to(f"cuda:{local_rank}")
-
-        if self.config.use_fp4_gemms:
-            if _is_cuda():
-                self._setup_nvfp4_gemms(local_rank=local_rank)
-            else:
-                self._setup_mxfp4_gemms(local_rank=local_rank)
-        elif self.config.use_fp8_gemms:
-            for module_name in self.settings.fp8_gemm_module_list:
-                log(f"Quantizing linear layers in {module_name} to FP8...")
-                module = rgetattr(self.pipe, module_name)
-                quantize_linear_layers_to_fp8(module, device=f"cuda:{local_rank}")
+            if self.config.use_fp4_gemms:
+                if _is_cuda():
+                    self._setup_nvfp4_gemms(local_rank=local_rank)
+                else:
+                    self._setup_mxfp4_gemms(local_rank=local_rank)
+            elif self.config.use_fp8_gemms:
+                for module_name in self.settings.fp8_gemm_module_list:
+                    log(f"Quantizing linear layers in {module_name} to FP8...")
+                    module = rgetattr(self.pipe, module_name)
+                    quantize_linear_layers_to_fp8(module, device=f"cuda:{local_rank}")
 
         if self.config.use_hybrid_attn_schedule:
             self._setup_hybrid_attn_schedule(input_args)
@@ -586,6 +586,12 @@ class xFuserModel(abc.ABC):
 
     def _shard_model_with_fsdp(self) -> None:
         """ Shard the model with FSDP based on settings """
+        if self.config.use_fp8_gemms:
+            from xfuser.core.utils.runner_utils import _TORCHAO_FLOAT8_FSDP2_PATCHES
+            assert _TORCHAO_FLOAT8_FSDP2_PATCHES, (
+                "FSDP2 + FP8 requires torchao Float8Tensor patches but they failed to apply at "
+                "import time. Check for torchao import errors in runner_utils."
+            )
         local_rank = get_world_group().local_rank
         fs_local_rank = get_fs_group().local_rank
         device_group = get_fs_group().device_group
@@ -595,7 +601,13 @@ class xFuserModel(abc.ABC):
                 strategy = self.settings.fsdp_strategy[component_name]
                 wrap_attrs = strategy.get("wrap_attrs", [])
                 dtype = strategy.get("dtype", None)
-                fsdp_object = shard_component(component, wrap_attrs, device_group, fs_local_rank, dtype)
+                quantize_fn = self._build_fsdp_quantize_fn(component_name, wrap_attrs, fs_local_rank)
+                reshard_after_forward = self.config.reshard_after_forward
+                fsdp_object = shard_component(
+                    component, wrap_attrs, device_group, fs_local_rank, dtype,
+                    quantize_fn=quantize_fn,
+                    reshard_after_forward=reshard_after_forward,
+                )
                 setattr(self.pipe, component_name, fsdp_object)
             else:
                 log(f"Skipping FSDP wrapping for {component_name}...")
@@ -604,6 +616,59 @@ class xFuserModel(abc.ABC):
                 else:
                     log(f"Component {component_name} has no .to() method, skipping device move.")
                     pass
+
+    def _build_fsdp_quantize_fn(
+        self, component_name: str, wrap_attrs: list, local_rank: int
+    ):
+        """
+        Return a per-block quantize callable (block, block_idx) -> None for this
+        component, or None if no quantization is configured for it.
+
+        fp8_precision_overrides entries like "5." apply to block index 5. We strip
+        the block-index prefix before passing to the quantize functions so they see
+        the same local FQN paths they would in the non-FSDP path.
+        """
+        if not (self.config.use_fp4_gemms or self.config.use_fp8_gemms):
+            return None
+
+        device = f"cuda:{local_rank}"
+        fp4_list = set(self.settings.fp4_gemm_module_list or [])
+        fp8_list = set(self.settings.fp8_gemm_module_list or [])
+        fp8_overrides = self.settings.fp8_precision_overrides or ()
+
+        paths = [f"{component_name}.{a}" for a in wrap_attrs]
+
+        use_fp4_here = self.config.use_fp4_gemms and any(p in fp4_list for p in paths)
+        # fp8-only: in fp8 list but not fp4 list (e.g. transformer_2 in Wan2.2 FP4 mode)
+        use_fp8_here = (
+            self.config.use_fp8_gemms and any(p in fp8_list for p in paths)
+        ) or (
+            self.config.use_fp4_gemms and any(p in fp8_list and p not in fp4_list for p in paths)
+        )
+
+        if not use_fp4_here and not use_fp8_here:
+            return None
+
+        def quantize_fn(block, block_idx: int) -> None:
+            block_prefix = f"{block_idx}."
+            # Strip the block-index prefix so the quantize functions see local FQN paths.
+            local_fp8 = tuple(
+                o[len(block_prefix):] for o in fp8_overrides if o.startswith(block_prefix)
+            ) or None
+            if use_fp4_here:
+                if _is_cuda():
+                    quantize_linear_layers_to_nvfp4(block, fp8_layers=local_fp8, device=device)
+                else:
+                    quantize_linear_layers_to_fp4(
+                        block,
+                        fp8_layers=local_fp8,
+                        use_hybrid_schedule=self.config.use_hybrid_gemm_schedule,
+                        device=device,
+                    )
+            else:
+                quantize_linear_layers_to_fp8(block, device=device)
+
+        return quantize_fn
 
     def _setup_mxfp4_gemms(self, local_rank):
         for module_name in self.settings.fp4_gemm_module_list:


### PR DESCRIPTION
Adds FSDP2 (`fully_shard`) support to xDiT's sharding pipeline, enabling `torchao` quantized GEMMs to work correctly under distributed sharding. Previously, quantization was applied after FSDP1 wrapping, which is incompatible with `torchao` tensor subclasses that cannot be flattened to FSDP1's 1D `FlatParameter`.

  - `runner_utils.py`: Patches `torchao`'s `Float8Tensor` for FSDP2 compatibility. Fixes `aten.split`, `new_empty`, `new_zeros`, `copy_`, view, `as_strided`, and adds `fsdp_pre`/`post_all_gather` so FSDP2 all-gather correctly reconstructs `Float8Tensor` subclasses instead of returning raw fp8 bytes.                                
  - `sharding.py`: `shard_component` now accepts `quantize_fn` and `reshard_after_forward` params. When `quantize_fn` is provided, takes the FSDP2 path: quantizes each block in-place before `fully_shard`, loading one block at a time to minimise peak memory. `fully_shard` is imported lazily to avoid registering composable FSDP dispatch machinery for non-quantized workloads.                                                                                                                                                                                                                                                                 
  - `base_model.py`: `_shard_model_with_fsdp` wires up per-block quantization via `_build_fsdp_quantize_fn`. Non-FSDP quantization paths (`_setup_nvfp4_gemms`, `_setup_mxfp4_gemms`) are unchanged.
  - `args.py`: Adds `--no_reshard_after_forward` flag.
  
  Tested extensively with Flux2 and Wan2.2.
