### PR TITLE
Revert "Use ATen-level distributed optimizations for Inductor compute/comm overlap (#696)"

### DIFF
--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -18,54 +18,6 @@ def log(message: str, debug=False, log_from_all_processes: bool = False) -> None
         else:
             logger.info(message)
 
-def configure_inductor_comm_overlap() -> None:
-    """Enable Inductor compute/communication overlap.
-
-    Prefers the ATen-level distributed optimization passes that PyTorch upstream
-    now recommends over the legacy scheduler-IR passes
-    (see https://github.com/pytorch/pytorch/issues/169461). They run on the ATen
-    FX graph before Inductor scheduling and enable overlap scheduling,
-    overlap-preserving collective bucketing, and overlap dependency insertion.
-    ``collective_estimator="benchmark"`` is required on RCCL/MI355X, where the
-    analytical NCCL bandwidth model can be ~10x off and leaves the scheduler
-    thinking collectives are far more expensive than they are.
-
-    Falls back to the legacy scheduler-IR passes when
-    ``torch._inductor.config.aten_distributed_optimizations`` is unavailable
-    (it landed in torch >= 2.10). PyTorch 2.10 also emptied the default value of
-    ``reorder_for_compute_comm_overlap_passes`` (it used to be
-    ``["reorder_compute_for_overlap", "sink_waits", "raise_comms"]`` on 2.9), so
-    the fallback restores the 2.9 list to recover the old overlap behavior on
-    torch builds without the ATen passes.
-    """
-    aten_opts = getattr(torch._inductor.config, "aten_distributed_optimizations", None)
-
-    if aten_opts is not None:
-        aten_opts.enable_overlap_scheduling = True
-        aten_opts.collective_bucketing = True
-        aten_opts.insert_overlap_deps = True
-        aten_opts.collective_estimator = "benchmark"
-        # Disable the legacy scheduler-IR overlap passes so we don't run two
-        # competing reorderers on the same graph.
-        torch._inductor.config.reorder_for_compute_comm_overlap = False
-        torch._inductor.config.reorder_for_compute_comm_overlap_passes = []
-        log("Inductor comm/compute overlap: using aten_distributed_optimizations "
-            "(enable_overlap_scheduling, collective_bucketing, insert_overlap_deps, "
-            "collective_estimator=benchmark)",
-            debug=True)
-        return
-
-    log("torch._inductor.config.aten_distributed_optimizations is unavailable "
-        "on this torch build; using legacy scheduler-IR overlap passes.",
-        debug=True)
-    torch._inductor.config.reorder_for_compute_comm_overlap = True
-    torch._inductor.config.reorder_for_compute_comm_overlap_passes = [
-        "reorder_compute_for_overlap",
-        "sink_waits",
-        "raise_comms",
-    ]
-
-
 def is_last_process() -> bool:
     """
     Checks based on env rank and world size if this is last process in

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -21,7 +21,6 @@ from xfuser.envs import (
 )
 from xfuser.core.distributed.parallel_state import get_fs_group
 from xfuser.core.utils.runner_utils import (
-    configure_inductor_comm_overlap,
     log,
     load_dataset_prompts,
     quantize_linear_layers_to_fp8,
@@ -358,7 +357,7 @@ class xFuserModel(abc.ABC):
 
     def _compile_model(self, input_args: dict) -> None:
         """ Compile the model using torch.compile."""
-        configure_inductor_comm_overlap()
+        torch._inductor.config.reorder_for_compute_comm_overlap = True
         self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default") # TODO: Configurable
         # two steps to warmup the torch compiler
         input_args["num_inference_steps"] = 2  # Reduce steps for warmup # TODO: make this more generic

--- a/xfuser/model_executor/models/runner_models/causal_wan.py
+++ b/xfuser/model_executor/models/runner_models/causal_wan.py
@@ -14,7 +14,6 @@ from xfuser.model_executor.models.runner_models.base_model import (
     DefaultInputValues,
     DiffusionOutput,
 )
-from xfuser.core.utils.runner_utils import configure_inductor_comm_overlap
 
 
 
@@ -145,7 +144,7 @@ class xFuserCausalWanModel(xFuserModel):
             raise ValueError("Exactly one input image is required for CausalWan I2V mode.")
 
     def _compile_model(self, input_args):
-        configure_inductor_comm_overlap()
+        torch._inductor.config.reorder_for_compute_comm_overlap = True
         self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
         self.pipe.transformer_2 = torch.compile(self.pipe.transformer_2, mode="default")
         compile_args = copy.deepcopy(input_args)

--- a/xfuser/model_executor/models/runner_models/flux.py
+++ b/xfuser/model_executor/models/runner_models/flux.py
@@ -13,7 +13,6 @@ from xfuser.model_executor.models.runner_models.base_model import (
     ModelSettings,
 )
 from xfuser.core.utils.runner_utils import (
-    configure_inductor_comm_overlap,
     log,
     resize_and_crop_image,
     quantize_linear_layers_to_fp8,
@@ -75,7 +74,7 @@ class xFuserFluxModel(xFuserModel):
 
     def _compile_model(self, input_args: dict) -> None:
         """ Compile the model using torch.compile."""
-        configure_inductor_comm_overlap()
+        torch._inductor.config.reorder_for_compute_comm_overlap = True
         self.pipe.transformer = torch.compile(self.pipe.transformer, mode="reduce-overhead") # Better perf for FLUX.1
         # two steps to warmup the torch compiler
         input_args["num_inference_steps"] = 2

--- a/xfuser/model_executor/models/runner_models/hunyuan.py
+++ b/xfuser/model_executor/models/runner_models/hunyuan.py
@@ -21,7 +21,6 @@ from xfuser.model_executor.models.runner_models.base_model import (
 from xfuser.core.distributed.attention_backend import AttentionBackendType
 from xfuser.core.distributed.runtime_state import get_runtime_state
 from xfuser.core.utils.runner_utils import (
-    configure_inductor_comm_overlap,
     resize_and_crop_image,
     fix_llama_tokenizer_pretokenizer,
 )
@@ -83,7 +82,7 @@ class xFuserHunyuanvideoModel(xFuserModel):
 
     def _compile_model(self, input_args: dict) -> None:
         """ Compile the model using torch.compile """
-        configure_inductor_comm_overlap()
+        torch._inductor.config.reorder_for_compute_comm_overlap = True
         self.pipe.transformer.compile()
 
         compile_args = copy.deepcopy(input_args)
@@ -181,7 +180,7 @@ class xFuserHunyuanvideo15Model(xFuserModel):
 
     def _compile_model(self, input_args: dict) -> None:
         """ Compile the model using torch.compile """
-        configure_inductor_comm_overlap()
+        torch._inductor.config.reorder_for_compute_comm_overlap = True
         self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
 
         # two steps to warmup the torch compiler

--- a/xfuser/model_executor/models/runner_models/ltx.py
+++ b/xfuser/model_executor/models/runner_models/ltx.py
@@ -17,7 +17,6 @@ from xfuser.model_executor.models.runner_models.base_model import (
 )
 
 from xfuser.core.utils.runner_utils import (
-    configure_inductor_comm_overlap,
     log,
 )
 
@@ -173,7 +172,7 @@ class xFuserLTX23VideoModel(xFuserModel):
         return DiffusionOutput(videos=output, pipe_args=input_args)
 
     def _compile_model(self, input_args: dict) -> None:
-        configure_inductor_comm_overlap()
+        torch._inductor.config.reorder_for_compute_comm_overlap = True
         self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
         self.second_pipe.transformer = torch.compile(self.second_pipe.transformer, mode="default")
 
@@ -292,7 +291,7 @@ class xFuserLTX2VideoModel(xFuserModel):
         return DiffusionOutput(videos=output, pipe_args=input_args)
 
     def _compile_model(self, input_args: dict) -> None:
-        configure_inductor_comm_overlap()
+        torch._inductor.config.reorder_for_compute_comm_overlap = True
         self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
         self.second_pipe.transformer = torch.compile(self.second_pipe.transformer, mode="default")
 

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -25,7 +25,6 @@ from xfuser.model_executor.models.runner_models.base_model import (
 from xfuser.core.distributed.runtime_state import get_runtime_state
 from xfuser.core.distributed.parallel_state import get_vae_parallel_group
 from xfuser.core.utils.runner_utils import (
-    configure_inductor_comm_overlap,
     log,
     resize_and_crop_image,
     resize_image_to_max_area,
@@ -202,7 +201,7 @@ class xFuserWan21I2VModel(xFuserModel):
             raise ValueError("Exactly one input image is required for Wan I2V model.")
 
     def _compile_model(self, input_args):
-        configure_inductor_comm_overlap()
+        torch._inductor.config.reorder_for_compute_comm_overlap = True
         self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
         compile_args = copy.deepcopy(input_args)
         # If a per-step attention schedule is active, do a full warmup to trigger all backend paths.
@@ -249,7 +248,7 @@ class xFuserWan22I2VModel(xFuserWan21I2VModel):
         return pipe
 
     def _compile_model(self, input_args):
-        configure_inductor_comm_overlap()
+        torch._inductor.config.reorder_for_compute_comm_overlap = True
         self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
         self.pipe.transformer_2 = torch.compile(self.pipe.transformer_2, mode="default")
         # Full cycle to warmup the torch compiler
@@ -338,7 +337,7 @@ class xFuserWan21T2VModel(xFuserModel):
         return DiffusionOutput(videos=output.frames, pipe_args=input_args)
 
     def _compile_model(self, input_args):
-        configure_inductor_comm_overlap()
+        torch._inductor.config.reorder_for_compute_comm_overlap = True
         self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
         compile_args = copy.deepcopy(input_args)
         # If a per-step attention schedule is active, do a full warmup to trigger all backend paths.
@@ -384,7 +383,7 @@ class xFuserWan22T2VModel(xFuserWan21T2VModel):
         return pipe
 
     def _compile_model(self, input_args):
-        configure_inductor_comm_overlap()
+        torch._inductor.config.reorder_for_compute_comm_overlap = True
         self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
         self.pipe.transformer_2 = torch.compile(self.pipe.transformer_2, mode="default")
         # Full cycle to warmup the torch compiler
@@ -466,7 +465,7 @@ class xFuserWan22TI2VModel(xFuserWan21T2VModel):
         return DiffusionOutput(videos=output.frames, pipe_args=input_args)
 
     def _compile_model(self, input_args):
-        configure_inductor_comm_overlap()
+        torch._inductor.config.reorder_for_compute_comm_overlap = True
         self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
         self._run_timed_pipe(input_args)
 


### PR DESCRIPTION
After testing other workloads than Wan 2.2 I2V, the flags introduced in PR #696 can sometimes trigger an inductor bug on PyTorch>=2.10 that causes the inference to crash. This PR reverts the changes until there is a workaround that can be introduced along with the feature, and/or the bug is fixed upstream.

Models that were affected:
- Z-Image
- Qwen-Image-Edit
- LTX.2

Upstream bug ticket: https://github.com/pytorch/pytorch/issues/182947