### PR TITLE
Fix torch.cuda.get_device_properties() call for PyTorch < 2.6.0 compatibility

### DIFF
--- a/xfuser/envs.py
+++ b/xfuser/envs.py
@@ -388,7 +388,8 @@ class PackagesEnvChecker:
         return self.packages_info
 
     def _on_mi3xx(self):
-        gcn_arch_name = torch.cuda.get_device_properties().gcnArchName
+        device = torch.cuda.current_device()
+        gcn_arch_name = torch.cuda.get_device_properties(device).gcnArchName
         return any(arch in gcn_arch_name for arch in ["gfx950", "gfx942"])
 
 


### PR DESCRIPTION
## what
`torch.cuda.get_device_properties()` without arguments was introduced in PyTorch 2.6.0. Calling it without the device argument on earlier versions raises an error. This patch explicitly passes `torch.cuda.current_device()` as the device argument, which is supported across all PyTorch versions.