### PR TITLE
Compile transformer blocks for LTX2.x

### DIFF
--- a/xfuser/model_executor/models/runner_models/ltx.py
+++ b/xfuser/model_executor/models/runner_models/ltx.py
@@ -173,8 +173,8 @@ class xFuserLTX23VideoModel(xFuserModel):
 
     def _compile_model(self, input_args: dict) -> None:
         torch._inductor.config.reorder_for_compute_comm_overlap = True
-        self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
-        self.second_pipe.transformer = torch.compile(self.second_pipe.transformer, mode="default")
+        self.pipe.transformer.compile_repeated_blocks(mode="default")
+        self.second_pipe.transformer.compile_repeated_blocks(mode="default")
 
         # two steps to warmup the torch compiler
         compile_args = copy.deepcopy(input_args)
@@ -292,8 +292,8 @@ class xFuserLTX2VideoModel(xFuserModel):
 
     def _compile_model(self, input_args: dict) -> None:
         torch._inductor.config.reorder_for_compute_comm_overlap = True
-        self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
-        self.second_pipe.transformer = torch.compile(self.second_pipe.transformer, mode="default")
+        self.pipe.transformer.compile_repeated_blocks(mode="default")
+        self.second_pipe.transformer.compile_repeated_blocks(mode="default")
 
         # two steps to warmup the torch compiler
         compile_args = copy.deepcopy(input_args)


### PR DESCRIPTION
# What

Change compilation on LTX2.x from entire transformer.forward to the transformer blocks.

# Why

Using `torch.compile` with LTX models takes a prohibitively long time (20+ minutes on MI355 and B200) and produces enormous `TORCH_TRACE` logs. This is due to several factors.

1. The entire transformer block unroll is already large but with the additional modality changes in xFuserLTX2AudioVideoAttnProcessor and LTX2AdaLayerNormSingle we see tons of compile artifacts and guard failures.
1. During the second pipeline run cfg is turned off which changes the batch dimension. This forces an entire recompilation of the transformer.forward adding at least 2x compile time.

Changing the compilation to instead target the repeated transformer blocks directly minimizes compile time to a couple minutes, reduces compile logs (494MB to 11MB) and does not affect E2E latency.

# How

Replace `torch.compile(self.pipe.transformer, mode="default")` with `compile_repeated_blocks(mode="default")` which for the LTX2.x models only selects `LTX2VideoTransformerBlock`

# Tests

E2E latency tests and quality comparisons were collected on MI355 and B200. No observed degradation.

