### PR TITLE
xfuser: union FP8 precision overrides with FP4 GEMMs (--fp8_precision_override_extend)

### DIFF
--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -126,6 +126,8 @@ class xFuserArgs:
     cross_attention_backend: Optional[str] = None
     use_fp8_gemms: bool = False
     use_fp4_gemms: bool = False
+    fp8_precision_override_mode: str = "prefix"
+    fp8_precision_override_patterns: Optional[str] = None
     # Model runner specific
     num_iterations: int = 1
     profile: bool = False
@@ -591,6 +593,19 @@ class xFuserArgs:
             help="Quantize the transformer linear layers (selected models only).",
         )
 
+        parser.add_argument(
+            "--fp8_precision_override_mode",
+            type=str,
+            default="prefix",
+            choices=["prefix", "suffix", "contains"],
+            help="Pattern match mode used for FP8 override selection when FP4 GEMMs are enabled.",
+        )
+        parser.add_argument(
+            "--fp8_precision_override_patterns",
+            type=nullable_str,
+            default=None,
+            help="Comma-delimited layer patterns to keep in FP8 while running FP4 GEMMs.",
+        )
         parser.add_argument(
             "--num_iterations",
             type=int,

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -126,9 +126,8 @@ class xFuserArgs:
     cross_attention_backend: Optional[str] = None
     use_fp8_gemms: bool = False
     use_fp4_gemms: bool = False
-    fp8_precision_override_mode: str = "prefix"
-    fp8_precision_override_patterns: Optional[str] = None
-    fp8_precision_override_extend: bool = False
+    fp8_precision_override_prefix_patterns: Optional[str] = None
+    fp8_precision_override_suffix_patterns: Optional[str] = None
     # Model runner specific
     num_iterations: int = 1
     profile: bool = False
@@ -594,25 +593,18 @@ class xFuserArgs:
             help="Quantize the transformer linear layers (selected models only).",
         )
         parser.add_argument(
-            "--fp8_precision_override_mode",
-            type=str,
-            default="prefix",
-            choices=["prefix", "suffix", "contains"],
-            help="Pattern match mode used for FP8 override selection when FP4 GEMMs are enabled.",
-        )
-        parser.add_argument(
-            "--fp8_precision_override_patterns",
+            "--fp8_precision_override_prefix_patterns",
             type=nullable_str,
             default=None,
-            help="Comma-delimited layer patterns to keep in FP8 while running FP4 GEMMs.",
+            help="Comma-delimited FQN prefix patterns to keep in FP8 during FP4 GEMMs "
+                 "(replaces model default prefix overrides when set).",
         )
         parser.add_argument(
-            "--fp8_precision_override_extend",
-            action="store_true",
-            help="Treat --fp8_precision_override_patterns as an ADDITIONAL rule on top of "
-                 "the model's default fp8_precision_overrides rather than replacing them. "
-                 "Useful for stacking targeted overrides (e.g. FFN-only) on top of the "
-                 "built-in boundary-block protections.",
+            "--fp8_precision_override_suffix_patterns",
+            type=nullable_str,
+            default=None,
+            help="Comma-delimited FQN suffix patterns to keep in FP8 during FP4 GEMMs "
+                 "(replaces model default suffix overrides when set).",
         )
 
         parser.add_argument(
@@ -822,28 +814,14 @@ class xFuserArgs:
             if not self.use_fp4_gemms:
                 raise ValueError("When use_hybrid_gemm_schedule is True, use_fp4_gemms must be set.")
 
-        # FP8 precision overrides during FP4 GEMMs: --fp8_precision_override_extend unions user
-        # patterns with per-model defaults (see wan.py). Fail fast if the flag is set without
-        # actionable patterns, or without --use_fp4_gemms (otherwise the CLI implies a no-op).
-        if self.fp8_precision_override_extend:
-            if not self.use_fp4_gemms:
-                raise ValueError(
-                    "When fp8_precision_override_extend is True, use_fp4_gemms must be set: "
-                    "extra FP8 override patterns are only applied when quantizing linear layers for FP4 GEMMs."
-                )
-            raw = self.fp8_precision_override_patterns
-            if raw is None or not raw.strip():
-                raise ValueError(
-                    "When fp8_precision_override_extend is True, --fp8_precision_override_patterns "
-                    "must be a non-empty comma-separated list (each entry non-blank after trim). "
-                    "Those patterns are UNIONed with the model's built-in fp8_precision_overrides."
-                )
-            parts = [p.strip() for p in raw.split(",") if p.strip()]
-            if not parts:
-                raise ValueError(
-                    "When fp8_precision_override_extend is True, --fp8_precision_override_patterns "
-                    "must contain at least one non-empty pattern (got only commas/whitespace)."
-                )
+        if (
+            self.fp8_precision_override_prefix_patterns is not None
+            or self.fp8_precision_override_suffix_patterns is not None
+        ) and not self.use_fp4_gemms:
+            raise ValueError(
+                "FP8 precision override patterns require --use_fp4_gemms: "
+                "overrides apply when quantizing linear layers for FP4 GEMMs."
+            )
 
         model_config = ModelConfig(
             model=self.model,

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -832,13 +832,13 @@ class xFuserArgs:
                     "extra FP8 override patterns are only applied when quantizing linear layers for FP4 GEMMs."
                 )
             raw = self.fp8_precision_override_patterns
-            if raw is None or not str(raw).strip():
+            if raw is None or not raw.strip():
                 raise ValueError(
                     "When fp8_precision_override_extend is True, --fp8_precision_override_patterns "
                     "must be a non-empty comma-separated list (each entry non-blank after trim). "
                     "Those patterns are UNIONed with the model's built-in fp8_precision_overrides."
                 )
-            parts = [p.strip() for p in str(raw).split(",") if p.strip()]
+            parts = [p.strip() for p in raw.split(",") if p.strip()]
             if not parts:
                 raise ValueError(
                     "When fp8_precision_override_extend is True, --fp8_precision_override_patterns "

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -128,6 +128,7 @@ class xFuserArgs:
     use_fp4_gemms: bool = False
     fp8_precision_override_mode: str = "prefix"
     fp8_precision_override_patterns: Optional[str] = None
+    fp8_precision_override_extend: bool = False
     # Model runner specific
     num_iterations: int = 1
     profile: bool = False
@@ -592,7 +593,6 @@ class xFuserArgs:
             action="store_true",
             help="Quantize the transformer linear layers (selected models only).",
         )
-
         parser.add_argument(
             "--fp8_precision_override_mode",
             type=str,
@@ -606,6 +606,15 @@ class xFuserArgs:
             default=None,
             help="Comma-delimited layer patterns to keep in FP8 while running FP4 GEMMs.",
         )
+        parser.add_argument(
+            "--fp8_precision_override_extend",
+            action="store_true",
+            help="Treat --fp8_precision_override_patterns as an ADDITIONAL rule on top of "
+                 "the model's default fp8_precision_overrides rather than replacing them. "
+                 "Useful for stacking targeted overrides (e.g. FFN-only) on top of the "
+                 "built-in boundary-block protections.",
+        )
+
         parser.add_argument(
             "--num_iterations",
             type=int,
@@ -812,6 +821,29 @@ class xFuserArgs:
         if self.use_hybrid_gemm_schedule:
             if not self.use_fp4_gemms:
                 raise ValueError("When use_hybrid_gemm_schedule is True, use_fp4_gemms must be set.")
+
+        # FP8 precision overrides during FP4 GEMMs: --fp8_precision_override_extend unions user
+        # patterns with per-model defaults (see wan.py). Fail fast if the flag is set without
+        # actionable patterns, or without --use_fp4_gemms (otherwise the CLI implies a no-op).
+        if self.fp8_precision_override_extend:
+            if not self.use_fp4_gemms:
+                raise ValueError(
+                    "When fp8_precision_override_extend is True, use_fp4_gemms must be set: "
+                    "extra FP8 override patterns are only applied when quantizing linear layers for FP4 GEMMs."
+                )
+            raw = self.fp8_precision_override_patterns
+            if raw is None or not str(raw).strip():
+                raise ValueError(
+                    "When fp8_precision_override_extend is True, --fp8_precision_override_patterns "
+                    "must be a non-empty comma-separated list (each entry non-blank after trim). "
+                    "Those patterns are UNIONed with the model's built-in fp8_precision_overrides."
+                )
+            parts = [p.strip() for p in str(raw).split(",") if p.strip()]
+            if not parts:
+                raise ValueError(
+                    "When fp8_precision_override_extend is True, --fp8_precision_override_patterns "
+                    "must contain at least one non-empty pattern (got only commas/whitespace)."
+                )
 
         model_config = ModelConfig(
             model=self.model,

--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -311,11 +311,33 @@ def _matches_fp8_override(layer_fqn: str, fp8_layers: tuple[str] | None, match_m
     raise ValueError(f"Unsupported FP8 override match mode: {match_mode}")
 
 
+def _matches_fp8_override_any(
+    layer_fqn: str,
+    primary_patterns: tuple[str] | None,
+    primary_mode: str = "prefix",
+    extra_patterns: tuple[str] | None = None,
+    extra_mode: str = "prefix",
+) -> bool:
+    """Match if EITHER the primary rule OR the (optional) extra rule fires.
+
+    Used to support unioning a per-model default override (e.g. boundary blocks)
+    with a user-supplied extra override (e.g. FFN-suffix), without giving up the
+    default protection.
+    """
+    if _matches_fp8_override(layer_fqn, primary_patterns, primary_mode):
+        return True
+    if _matches_fp8_override(layer_fqn, extra_patterns, extra_mode):
+        return True
+    return False
+
+
 def quantize_linear_layers_to_fp4(
     model,
     parent_name='',
     fp8_layers=None,
     fp8_layer_match_mode: str = "prefix",
+    fp8_extra_layers=None,
+    fp8_extra_match_mode: str = "prefix",
     use_hybrid_schedule: bool = False,
     device: Optional[torch.device] = None,
 ):
@@ -327,7 +349,13 @@ def quantize_linear_layers_to_fp4(
         full_name = f"{parent_name}.{name}" if parent_name else name
 
         if isinstance(module, torch.nn.Linear):
-            if _matches_fp8_override(full_name, fp8_layers, fp8_layer_match_mode):
+            if _matches_fp8_override_any(
+                full_name,
+                fp8_layers,
+                fp8_layer_match_mode,
+                fp8_extra_layers,
+                fp8_extra_match_mode,
+            ):
                 quantize_(
                       module,
                       config=Float8DynamicActivationFloat8WeightConfig(
@@ -385,6 +413,8 @@ def quantize_linear_layers_to_fp4(
                 full_name,
                 fp8_layers=fp8_layers,
                 fp8_layer_match_mode=fp8_layer_match_mode,
+                fp8_extra_layers=fp8_extra_layers,
+                fp8_extra_match_mode=fp8_extra_match_mode,
                 use_hybrid_schedule=use_hybrid_schedule,
                 device=device,
             )
@@ -394,6 +424,8 @@ def quantize_linear_layers_to_nvfp4(
     module_or_module_list_to_quantize: torch.nn.Module | torch.nn.ModuleList,
     fp8_layers: tuple[str] = None,
     fp8_layer_match_mode: str = "prefix",
+    fp8_extra_layers: tuple[str] = None,
+    fp8_extra_match_mode: str = "prefix",
     device: Optional[torch.device] = None,
     min_layer_size: int = 0,
     use_triton_kernel: bool = True,
@@ -405,6 +437,10 @@ def quantize_linear_layers_to_nvfp4(
         fp8_layers: FQN patterns of layers that should use FP8 instead of NVFP4.
         fp8_layer_match_mode: Match mode for fp8_layers patterns: prefix/suffix/contains.
             for quality-sensitive blocks.
+        fp8_extra_layers: optional second set of FQN patterns; layers matching the
+            primary OR the extra rule are promoted to FP8. Used to union user-supplied
+            overrides with the model's default boundary protections.
+        fp8_extra_match_mode: Match mode for fp8_extra_layers patterns.
         device: Target device.
         min_layer_size: Skip NVFP4 for layers where min(out_features, in_features)
             is below this threshold (quantization overhead may exceed the speedup).
@@ -432,7 +468,13 @@ def quantize_linear_layers_to_nvfp4(
             if not isinstance(submodule, torch.nn.Linear):
                 continue
 
-            if _matches_fp8_override(fqn, fp8_layers, fp8_layer_match_mode):
+            if _matches_fp8_override_any(
+                fqn,
+                fp8_layers,
+                fp8_layer_match_mode,
+                fp8_extra_layers,
+                fp8_extra_match_mode,
+            ):
                 skipped_fp8_count += 1
                 continue
 
@@ -446,7 +488,13 @@ def quantize_linear_layers_to_nvfp4(
         def nvfp4_filter_fn(mod, fqn):
             if not _is_linear(mod, fqn):
                 return False
-            if _matches_fp8_override(fqn, fp8_layers, fp8_layer_match_mode):
+            if _matches_fp8_override_any(
+                fqn,
+                fp8_layers,
+                fp8_layer_match_mode,
+                fp8_extra_layers,
+                fp8_extra_match_mode,
+            ):
                 return False
             if min_layer_size > 0:
                 layer_min = min(mod.out_features, mod.in_features)
@@ -456,7 +504,7 @@ def quantize_linear_layers_to_nvfp4(
 
         quantize_(module, config=nvfp4_config, filter_fn=nvfp4_filter_fn, device=device)
 
-        if fp8_layers:
+        if fp8_layers or fp8_extra_layers:
             from torchao.quantization.granularity import PerTensor
             from torchao.quantization.quant_api import Float8DynamicActivationFloat8WeightConfig
 
@@ -469,7 +517,13 @@ def quantize_linear_layers_to_nvfp4(
             def fp8_filter_fn(mod, fqn):
                 if not _is_linear(mod, fqn):
                     return False
-                return _matches_fp8_override(fqn, fp8_layers, fp8_layer_match_mode)
+                return _matches_fp8_override_any(
+                    fqn,
+                    fp8_layers,
+                    fp8_layer_match_mode,
+                    fp8_extra_layers,
+                    fp8_extra_match_mode,
+                )
 
             quantize_(module, config=fp8_config, filter_fn=fp8_filter_fn, device=device)
 

--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -299,7 +299,26 @@ def rgetattr(obj: object, attr: str) -> object:
     """ Recursive getattr to get nested attributes """
     return functools.reduce(getattr, [obj] + attr.split("."))
 
-def quantize_linear_layers_to_fp4(model, parent_name='', fp8_layers=None, use_hybrid_schedule: bool = False, device: Optional[torch.device] = None):
+def _matches_fp8_override(layer_fqn: str, fp8_layers: tuple[str] | None, match_mode: str = "prefix") -> bool:
+    if not fp8_layers:
+        return False
+    if match_mode == "prefix":
+        return layer_fqn.startswith(fp8_layers)
+    if match_mode == "suffix":
+        return layer_fqn.endswith(fp8_layers)
+    if match_mode == "contains":
+        return any(pattern in layer_fqn for pattern in fp8_layers)
+    raise ValueError(f"Unsupported FP8 override match mode: {match_mode}")
+
+
+def quantize_linear_layers_to_fp4(
+    model,
+    parent_name='',
+    fp8_layers=None,
+    fp8_layer_match_mode: str = "prefix",
+    use_hybrid_schedule: bool = False,
+    device: Optional[torch.device] = None,
+):
     from torchao.quantization.granularity import PerTensor
     from torchao.quantization.quant_api import Float8DynamicActivationFloat8WeightConfig, quantize_
     from xfuser.model_executor.layers.mxfp4_linear import xFuserMXFP4Linear, xFuserHybridMXFP4Linear
@@ -308,7 +327,7 @@ def quantize_linear_layers_to_fp4(model, parent_name='', fp8_layers=None, use_hy
         full_name = f"{parent_name}.{name}" if parent_name else name
 
         if isinstance(module, torch.nn.Linear):
-            if fp8_layers and full_name.startswith(fp8_layers):
+            if _matches_fp8_override(full_name, fp8_layers, fp8_layer_match_mode):
                 quantize_(
                       module,
                       config=Float8DynamicActivationFloat8WeightConfig(
@@ -361,12 +380,20 @@ def quantize_linear_layers_to_fp4(model, parent_name='', fp8_layers=None, use_hy
                 setattr(model, name, new_layer)
 
         elif len(list(module.children())) > 0:
-            quantize_linear_layers_to_fp4(module, full_name, fp8_layers=fp8_layers, use_hybrid_schedule=use_hybrid_schedule, device=device)
+            quantize_linear_layers_to_fp4(
+                module,
+                full_name,
+                fp8_layers=fp8_layers,
+                fp8_layer_match_mode=fp8_layer_match_mode,
+                use_hybrid_schedule=use_hybrid_schedule,
+                device=device,
+            )
 
 
 def quantize_linear_layers_to_nvfp4(
     module_or_module_list_to_quantize: torch.nn.Module | torch.nn.ModuleList,
     fp8_layers: tuple[str] = None,
+    fp8_layer_match_mode: str = "prefix",
     device: Optional[torch.device] = None,
     min_layer_size: int = 0,
     use_triton_kernel: bool = True,
@@ -375,7 +402,8 @@ def quantize_linear_layers_to_nvfp4(
 
     Args:
         module_or_module_list_to_quantize: Module(s) whose linear layers will be quantized.
-        fp8_layers: FQN prefixes of layers that should use FP8 instead of NVFP4
+        fp8_layers: FQN patterns of layers that should use FP8 instead of NVFP4.
+        fp8_layer_match_mode: Match mode for fp8_layers patterns: prefix/suffix/contains.
             for quality-sensitive blocks.
         device: Target device.
         min_layer_size: Skip NVFP4 for layers where min(out_features, in_features)
@@ -404,7 +432,7 @@ def quantize_linear_layers_to_nvfp4(
             if not isinstance(submodule, torch.nn.Linear):
                 continue
 
-            if fp8_layers and fqn.startswith(fp8_layers):
+            if _matches_fp8_override(fqn, fp8_layers, fp8_layer_match_mode):
                 skipped_fp8_count += 1
                 continue
 
@@ -418,7 +446,7 @@ def quantize_linear_layers_to_nvfp4(
         def nvfp4_filter_fn(mod, fqn):
             if not _is_linear(mod, fqn):
                 return False
-            if fp8_layers and fqn.startswith(fp8_layers):
+            if _matches_fp8_override(fqn, fp8_layers, fp8_layer_match_mode):
                 return False
             if min_layer_size > 0:
                 layer_min = min(mod.out_features, mod.in_features)
@@ -441,7 +469,7 @@ def quantize_linear_layers_to_nvfp4(
             def fp8_filter_fn(mod, fqn):
                 if not _is_linear(mod, fqn):
                     return False
-                return fqn.startswith(fp8_layers)
+                return _matches_fp8_override(fqn, fp8_layers, fp8_layer_match_mode)
 
             quantize_(module, config=fp8_config, filter_fn=fp8_filter_fn, device=device)
 

--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -299,34 +299,14 @@ def rgetattr(obj: object, attr: str) -> object:
     """ Recursive getattr to get nested attributes """
     return functools.reduce(getattr, [obj] + attr.split("."))
 
-def _matches_fp8_override(layer_fqn: str, fp8_layers: tuple[str] | None, match_mode: str = "prefix") -> bool:
-    if not fp8_layers:
-        return False
-    if match_mode == "prefix":
-        return layer_fqn.startswith(fp8_layers)
-    if match_mode == "suffix":
-        return layer_fqn.endswith(fp8_layers)
-    if match_mode == "contains":
-        return any(pattern in layer_fqn for pattern in fp8_layers)
-    raise ValueError(f"Unsupported FP8 override match mode: {match_mode}")
-
-
-def _matches_fp8_override_any(
+def _layer_uses_fp8_override(
     layer_fqn: str,
-    primary_patterns: tuple[str] | None,
-    primary_mode: str = "prefix",
-    extra_patterns: tuple[str] | None = None,
-    extra_mode: str = "prefix",
+    fp8_layers: tuple[str] | None,
+    fp8_suffix_layers: tuple[str] | None,
 ) -> bool:
-    """Match if EITHER the primary rule OR the (optional) extra rule fires.
-
-    Used to support unioning a per-model default override (e.g. boundary blocks)
-    with a user-supplied extra override (e.g. FFN-suffix), without giving up the
-    default protection.
-    """
-    if _matches_fp8_override(layer_fqn, primary_patterns, primary_mode):
+    if fp8_layers and layer_fqn.startswith(fp8_layers):
         return True
-    if _matches_fp8_override(layer_fqn, extra_patterns, extra_mode):
+    if fp8_suffix_layers and layer_fqn.endswith(fp8_suffix_layers):
         return True
     return False
 
@@ -335,9 +315,7 @@ def quantize_linear_layers_to_fp4(
     model,
     parent_name='',
     fp8_layers=None,
-    fp8_layer_match_mode: str = "prefix",
-    fp8_extra_layers=None,
-    fp8_extra_match_mode: str = "prefix",
+    fp8_suffix_layers: tuple[str] | None = None,
     use_hybrid_schedule: bool = False,
     device: Optional[torch.device] = None,
 ):
@@ -349,13 +327,7 @@ def quantize_linear_layers_to_fp4(
         full_name = f"{parent_name}.{name}" if parent_name else name
 
         if isinstance(module, torch.nn.Linear):
-            if _matches_fp8_override_any(
-                full_name,
-                fp8_layers,
-                fp8_layer_match_mode,
-                fp8_extra_layers,
-                fp8_extra_match_mode,
-            ):
+            if _layer_uses_fp8_override(full_name, fp8_layers, fp8_suffix_layers):
                 quantize_(
                       module,
                       config=Float8DynamicActivationFloat8WeightConfig(
@@ -412,9 +384,7 @@ def quantize_linear_layers_to_fp4(
                 module,
                 full_name,
                 fp8_layers=fp8_layers,
-                fp8_layer_match_mode=fp8_layer_match_mode,
-                fp8_extra_layers=fp8_extra_layers,
-                fp8_extra_match_mode=fp8_extra_match_mode,
+                fp8_suffix_layers=fp8_suffix_layers,
                 use_hybrid_schedule=use_hybrid_schedule,
                 device=device,
             )
@@ -423,9 +393,7 @@ def quantize_linear_layers_to_fp4(
 def quantize_linear_layers_to_nvfp4(
     module_or_module_list_to_quantize: torch.nn.Module | torch.nn.ModuleList,
     fp8_layers: tuple[str] = None,
-    fp8_layer_match_mode: str = "prefix",
-    fp8_extra_layers: tuple[str] = None,
-    fp8_extra_match_mode: str = "prefix",
+    fp8_suffix_layers: tuple[str] | None = None,
     device: Optional[torch.device] = None,
     min_layer_size: int = 0,
     use_triton_kernel: bool = True,
@@ -434,13 +402,8 @@ def quantize_linear_layers_to_nvfp4(
 
     Args:
         module_or_module_list_to_quantize: Module(s) whose linear layers will be quantized.
-        fp8_layers: FQN patterns of layers that should use FP8 instead of NVFP4.
-        fp8_layer_match_mode: Match mode for fp8_layers patterns: prefix/suffix/contains.
-            for quality-sensitive blocks.
-        fp8_extra_layers: optional second set of FQN patterns; layers matching the
-            primary OR the extra rule are promoted to FP8. Used to union user-supplied
-            overrides with the model's default boundary protections.
-        fp8_extra_match_mode: Match mode for fp8_extra_layers patterns.
+        fp8_layers: FQN prefixes of layers that should use FP8 instead of NVFP4.
+        fp8_suffix_layers: FQN suffixes of layers that should use FP8 instead of NVFP4.
         device: Target device.
         min_layer_size: Skip NVFP4 for layers where min(out_features, in_features)
             is below this threshold (quantization overhead may exceed the speedup).
@@ -468,13 +431,7 @@ def quantize_linear_layers_to_nvfp4(
             if not isinstance(submodule, torch.nn.Linear):
                 continue
 
-            if _matches_fp8_override_any(
-                fqn,
-                fp8_layers,
-                fp8_layer_match_mode,
-                fp8_extra_layers,
-                fp8_extra_match_mode,
-            ):
+            if _layer_uses_fp8_override(fqn, fp8_layers, fp8_suffix_layers):
                 skipped_fp8_count += 1
                 continue
 
@@ -488,13 +445,7 @@ def quantize_linear_layers_to_nvfp4(
         def nvfp4_filter_fn(mod, fqn):
             if not _is_linear(mod, fqn):
                 return False
-            if _matches_fp8_override_any(
-                fqn,
-                fp8_layers,
-                fp8_layer_match_mode,
-                fp8_extra_layers,
-                fp8_extra_match_mode,
-            ):
+            if _layer_uses_fp8_override(fqn, fp8_layers, fp8_suffix_layers):
                 return False
             if min_layer_size > 0:
                 layer_min = min(mod.out_features, mod.in_features)
@@ -504,7 +455,7 @@ def quantize_linear_layers_to_nvfp4(
 
         quantize_(module, config=nvfp4_config, filter_fn=nvfp4_filter_fn, device=device)
 
-        if fp8_layers or fp8_extra_layers:
+        if fp8_layers or fp8_suffix_layers:
             from torchao.quantization.granularity import PerTensor
             from torchao.quantization.quant_api import Float8DynamicActivationFloat8WeightConfig
 
@@ -517,13 +468,7 @@ def quantize_linear_layers_to_nvfp4(
             def fp8_filter_fn(mod, fqn):
                 if not _is_linear(mod, fqn):
                     return False
-                return _matches_fp8_override_any(
-                    fqn,
-                    fp8_layers,
-                    fp8_layer_match_mode,
-                    fp8_extra_layers,
-                    fp8_extra_match_mode,
-                )
+                return _layer_uses_fp8_override(fqn, fp8_layers, fp8_suffix_layers)
 
             quantize_(module, config=fp8_config, filter_fn=fp8_filter_fn, device=device)
 

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -136,7 +136,6 @@ class DefaultInputValues:
     max_sequence_length: Optional[int] = None
     num_hybrid_attn_high_precision_steps: Optional[int] = None
     num_hybrid_gemm_high_precision_steps: Optional[int] = None
-    ssta_tile_thw: Optional[Tuple[int, int, int]] = None
 
 @dataclass
 class ModelSettings:
@@ -150,6 +149,8 @@ class ModelSettings:
     fp4_gemm_module_list: List[str] = None
     fp8_precision_overrides: Tuple[str] = None
     fp8_precision_override_match_mode: str = "prefix"
+    fp8_precision_override_extra_patterns: Tuple[str] = None
+    fp8_precision_override_extra_match_mode: str = "prefix"
     # FSDP strategy is just for the components to be sharded - other components will be moved to correct device automatically
     fsdp_strategy: dict = field(default_factory=lambda: {
         "": { # name, e.g. transformer
@@ -269,14 +270,14 @@ class xFuserModel(abc.ABC):
     def _validate_config(self, config: xFuserArgs) -> None:
         """ Validate if the model supports requested config """
         for key in ModelCapabilities.__annotations__.keys():
-            config_value = getattr(config, key, None) # Some config options might not be set in the CLI, such as support for specific attention backends.
+            config_value = getattr(config, key)
             if isinstance(config_value, int):
                 if not getattr(self.capabilities, key) and config_value > 1:
                     raise ValueError(f"Model {self.settings.model_name} does not support {key}.")
             else:
                 if config_value and not getattr(self.capabilities, key):
                     raise ValueError(f"Model {self.settings.model_name} does not support {key}.")
-        
+
         backend = _parse_attention_backend(config.attention_backend, "attention backend")
         supports_sparse = self.capabilities.supports_sparse_attention_backends
         supports_sparge = self.capabilities.supports_sparge_attention_backends
@@ -683,11 +684,19 @@ class xFuserModel(abc.ABC):
                     f"{self.settings.fp8_precision_overrides} "
                     f"(match_mode={self.settings.fp8_precision_override_match_mode})"
                 )
+            if self.settings.fp8_precision_override_extra_patterns:
+                log(
+                    "Additional FP8 override rule (union with primary): "
+                    f"{self.settings.fp8_precision_override_extra_patterns} "
+                    f"(match_mode={self.settings.fp8_precision_override_extra_match_mode})"
+                )
             module = rgetattr(self.pipe, module_name)
             quantize_linear_layers_to_fp4(
                 module,
                 fp8_layers=self.settings.fp8_precision_overrides,
                 fp8_layer_match_mode=self.settings.fp8_precision_override_match_mode,
+                fp8_extra_layers=self.settings.fp8_precision_override_extra_patterns,
+                fp8_extra_match_mode=self.settings.fp8_precision_override_extra_match_mode,
                 use_hybrid_schedule=self.config.use_hybrid_gemm_schedule,
                 device=f"cuda:{local_rank}",
             )
@@ -711,11 +720,19 @@ class xFuserModel(abc.ABC):
                     f"{self.settings.fp8_precision_overrides} "
                     f"(match_mode={self.settings.fp8_precision_override_match_mode})"
                 )
+            if self.settings.fp8_precision_override_extra_patterns:
+                log(
+                    "Additional FP8 override rule (union with primary): "
+                    f"{self.settings.fp8_precision_override_extra_patterns} "
+                    f"(match_mode={self.settings.fp8_precision_override_extra_match_mode})"
+                )
             module = rgetattr(self.pipe, module_name)
             quantize_linear_layers_to_nvfp4(
                 module,
                 fp8_layers=self.settings.fp8_precision_overrides,
                 fp8_layer_match_mode=self.settings.fp8_precision_override_match_mode,
+                fp8_extra_layers=self.settings.fp8_precision_override_extra_patterns,
+                fp8_extra_match_mode=self.settings.fp8_precision_override_extra_match_mode,
                 device=f"cuda:{local_rank}",
             )
         for module_name in self.settings.fp8_gemm_module_list:

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -149,6 +149,7 @@ class ModelSettings:
     fp8_gemm_module_list: List[str] = None
     fp4_gemm_module_list: List[str] = None
     fp8_precision_overrides: Tuple[str] = None
+    fp8_precision_override_match_mode: str = "prefix"
     # FSDP strategy is just for the components to be sharded - other components will be moved to correct device automatically
     fsdp_strategy: dict = field(default_factory=lambda: {
         "": { # name, e.g. transformer
@@ -677,11 +678,16 @@ class xFuserModel(abc.ABC):
             # approach balances performance and output quality better than uniform quantization.
             log(f"Quantizing linear layers in {module_name} to FP4...")
             if self.settings.fp8_precision_overrides:
-                log(f"The following blocks will be quantized to FP8, to maintain output quality: {self.settings.fp8_precision_overrides}")
+                log(
+                    "The following blocks will be quantized to FP8, to maintain output quality: "
+                    f"{self.settings.fp8_precision_overrides} "
+                    f"(match_mode={self.settings.fp8_precision_override_match_mode})"
+                )
             module = rgetattr(self.pipe, module_name)
             quantize_linear_layers_to_fp4(
                 module,
                 fp8_layers=self.settings.fp8_precision_overrides,
+                fp8_layer_match_mode=self.settings.fp8_precision_override_match_mode,
                 use_hybrid_schedule=self.config.use_hybrid_gemm_schedule,
                 device=f"cuda:{local_rank}",
             )
@@ -700,11 +706,16 @@ class xFuserModel(abc.ABC):
         for module_name in self.settings.fp4_gemm_module_list:
             log(f"Quantizing linear layers in {module_name} to NVFP4 (torchao)...")
             if self.settings.fp8_precision_overrides:
-                log(f"The following blocks will use FP8 instead, to maintain output quality: {self.settings.fp8_precision_overrides}")
+                log(
+                    "The following blocks will use FP8 instead, to maintain output quality: "
+                    f"{self.settings.fp8_precision_overrides} "
+                    f"(match_mode={self.settings.fp8_precision_override_match_mode})"
+                )
             module = rgetattr(self.pipe, module_name)
             quantize_linear_layers_to_nvfp4(
                 module,
                 fp8_layers=self.settings.fp8_precision_overrides,
+                fp8_layer_match_mode=self.settings.fp8_precision_override_match_mode,
                 device=f"cuda:{local_rank}",
             )
         for module_name in self.settings.fp8_gemm_module_list:

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -148,9 +148,7 @@ class ModelSettings:
     fp8_gemm_module_list: List[str] = None
     fp4_gemm_module_list: List[str] = None
     fp8_precision_overrides: Tuple[str] = None
-    fp8_precision_override_match_mode: str = "prefix"
-    fp8_precision_override_extra_patterns: Tuple[str] = None
-    fp8_precision_override_extra_match_mode: str = "prefix"
+    fp8_precision_override_suffixes: Tuple[str] = None
     # FSDP strategy is just for the components to be sharded - other components will be moved to correct device automatically
     fsdp_strategy: dict = field(default_factory=lambda: {
         "": { # name, e.g. transformer
@@ -556,8 +554,29 @@ class xFuserModel(abc.ABC):
             name += f"_{self.config.task}"
         return name
 
+    def _apply_fp8_override_cli_from_config(self) -> None:
+        """Apply optional CLI FP8 override patterns (per-slot) before quantization."""
+
+        def _parse_csv_patterns(raw: Optional[str]) -> Optional[Tuple[str, ...]]:
+            if raw is None or not raw.strip():
+                return None
+            patterns = tuple(p.strip() for p in raw.split(",") if p.strip())
+            return patterns or None
+
+        if self.config.fp8_precision_override_prefix_patterns is not None:
+            self.settings.fp8_precision_overrides = _parse_csv_patterns(
+                self.config.fp8_precision_override_prefix_patterns
+            )
+        if self.config.fp8_precision_override_suffix_patterns is not None:
+            self.settings.fp8_precision_override_suffixes = _parse_csv_patterns(
+                self.config.fp8_precision_override_suffix_patterns
+            )
+
     def _post_load_and_state_initialization(self, input_args: dict) -> None: ##TODO: should this be renamed?
         """ Hook for any post model-load and state initialization """
+
+        if self.config.use_fp4_gemms:
+            self._apply_fp8_override_cli_from_config()
 
         local_rank = get_world_group().local_rank
         # FSDP path handles device placement and quantization (per-block for FSDP2).
@@ -637,6 +656,7 @@ class xFuserModel(abc.ABC):
         fp4_list = set(self.settings.fp4_gemm_module_list or [])
         fp8_list = set(self.settings.fp8_gemm_module_list or [])
         fp8_overrides = self.settings.fp8_precision_overrides or ()
+        fp8_suffix_overrides = self.settings.fp8_precision_override_suffixes
 
         paths = [f"{component_name}.{a}" for a in wrap_attrs]
 
@@ -659,11 +679,17 @@ class xFuserModel(abc.ABC):
             ) or None
             if use_fp4_here:
                 if _is_cuda():
-                    quantize_linear_layers_to_nvfp4(block, fp8_layers=local_fp8, device=device)
+                    quantize_linear_layers_to_nvfp4(
+                        block,
+                        fp8_layers=local_fp8,
+                        fp8_suffix_layers=fp8_suffix_overrides,
+                        device=device,
+                    )
                 else:
                     quantize_linear_layers_to_fp4(
                         block,
                         fp8_layers=local_fp8,
+                        fp8_suffix_layers=fp8_suffix_overrides,
                         use_hybrid_schedule=self.config.use_hybrid_gemm_schedule,
                         device=device,
                     )
@@ -681,22 +707,18 @@ class xFuserModel(abc.ABC):
             if self.settings.fp8_precision_overrides:
                 log(
                     "The following blocks will be quantized to FP8, to maintain output quality: "
-                    f"{self.settings.fp8_precision_overrides} "
-                    f"(match_mode={self.settings.fp8_precision_override_match_mode})"
+                    f"{self.settings.fp8_precision_overrides} (prefix match)"
                 )
-            if self.settings.fp8_precision_override_extra_patterns:
+            if self.settings.fp8_precision_override_suffixes:
                 log(
-                    "Additional FP8 override rule (union with primary): "
-                    f"{self.settings.fp8_precision_override_extra_patterns} "
-                    f"(match_mode={self.settings.fp8_precision_override_extra_match_mode})"
+                    "The following layers will be quantized to FP8 via suffix match: "
+                    f"{self.settings.fp8_precision_override_suffixes}"
                 )
             module = rgetattr(self.pipe, module_name)
             quantize_linear_layers_to_fp4(
                 module,
                 fp8_layers=self.settings.fp8_precision_overrides,
-                fp8_layer_match_mode=self.settings.fp8_precision_override_match_mode,
-                fp8_extra_layers=self.settings.fp8_precision_override_extra_patterns,
-                fp8_extra_match_mode=self.settings.fp8_precision_override_extra_match_mode,
+                fp8_suffix_layers=self.settings.fp8_precision_override_suffixes,
                 use_hybrid_schedule=self.config.use_hybrid_gemm_schedule,
                 device=f"cuda:{local_rank}",
             )
@@ -717,22 +739,18 @@ class xFuserModel(abc.ABC):
             if self.settings.fp8_precision_overrides:
                 log(
                     "The following blocks will use FP8 instead, to maintain output quality: "
-                    f"{self.settings.fp8_precision_overrides} "
-                    f"(match_mode={self.settings.fp8_precision_override_match_mode})"
+                    f"{self.settings.fp8_precision_overrides} (prefix match)"
                 )
-            if self.settings.fp8_precision_override_extra_patterns:
+            if self.settings.fp8_precision_override_suffixes:
                 log(
-                    "Additional FP8 override rule (union with primary): "
-                    f"{self.settings.fp8_precision_override_extra_patterns} "
-                    f"(match_mode={self.settings.fp8_precision_override_extra_match_mode})"
+                    "The following layers will use FP8 via suffix match: "
+                    f"{self.settings.fp8_precision_override_suffixes}"
                 )
             module = rgetattr(self.pipe, module_name)
             quantize_linear_layers_to_nvfp4(
                 module,
                 fp8_layers=self.settings.fp8_precision_overrides,
-                fp8_layer_match_mode=self.settings.fp8_precision_override_match_mode,
-                fp8_extra_layers=self.settings.fp8_precision_override_extra_patterns,
-                fp8_extra_match_mode=self.settings.fp8_precision_override_extra_match_mode,
+                fp8_suffix_layers=self.settings.fp8_precision_override_suffixes,
                 device=f"cuda:{local_rank}",
             )
         for module_name in self.settings.fp8_gemm_module_list:

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -270,7 +270,7 @@ class xFuserModel(abc.ABC):
     def _validate_config(self, config: xFuserArgs) -> None:
         """ Validate if the model supports requested config """
         for key in ModelCapabilities.__annotations__.keys():
-            config_value = getattr(config, key)
+            config_value = getattr(config, key, None)  # Some config options might not be set in the CLI, such as support for specific attention backends.
             if isinstance(config_value, int):
                 if not getattr(self.capabilities, key) and config_value > 1:
                     raise ValueError(f"Model {self.settings.model_name} does not support {key}.")

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -351,9 +351,11 @@ class xFuserWan21T2VModel(xFuserModel):
 class xFuserWan22T2VModel(xFuserWan21T2VModel):
 
     def __init__(self, config: xFuserArgs) -> None:
-        super().__init__(config)
+        # Must set registry identity before super().__init__ → _validate_config (see xFuserWan22I2VModel).
         self.settings.model_name = "Wan-AI/Wan2.2-T2V-A14B-Diffusers"
         self.settings.output_name = "wan2.2_t2v"
+        self.settings.valid_tasks = ["t2v"]
+        super().__init__(config)
         self.settings.fsdp_strategy["transformer_2"] = {
                 "wrap_attrs": ["blocks"],
                 "dtype": torch.bfloat16,

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -368,13 +368,30 @@ class xFuserWan22T2VModel(xFuserWan21T2VModel):
                 if pattern.strip()
             )
             if patterns:
-                self.settings.fp8_precision_overrides = patterns
-                self.settings.fp8_precision_override_match_mode = config.fp8_precision_override_mode
-                log(
-                    "Using custom FP8 override patterns for Wan2.2 T2V: "
-                    f"{self.settings.fp8_precision_overrides} "
-                    f"(match_mode={self.settings.fp8_precision_override_match_mode})"
-                )
+                if config.fp8_precision_override_extend:
+                    # UNION applies only to transformer.blocks (fp4_gemm_module_list);
+                    # transformer_2.blocks stays full FP8 via fp8_gemm_module_list pass.
+                    self.settings.fp8_precision_override_extra_patterns = patterns
+                    self.settings.fp8_precision_override_extra_match_mode = (
+                        config.fp8_precision_override_mode
+                    )
+                    log(
+                        "Extending Wan2.2 T2V tower-1 FP8 overrides "
+                        f"{self.settings.fp8_precision_overrides} "
+                        f"(mode={self.settings.fp8_precision_override_match_mode}) "
+                        f"with extra rule {patterns} "
+                        f"(mode={config.fp8_precision_override_mode})"
+                    )
+                else:
+                    self.settings.fp8_precision_overrides = patterns
+                    self.settings.fp8_precision_override_match_mode = (
+                        config.fp8_precision_override_mode
+                    )
+                    log(
+                        "Using custom FP8 override patterns for Wan2.2 T2V (tower 1 only): "
+                        f"{self.settings.fp8_precision_overrides} "
+                        f"(match_mode={self.settings.fp8_precision_override_match_mode})"
+                    )
 
     def _load_model(self) -> DiffusionPipeline:
         transformer = xFuserWanTransformer3DWrapper.from_pretrained(

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -222,8 +222,40 @@ class xFuserWan22I2VModel(xFuserWan21I2VModel):
                 "wrap_attrs": ["blocks"],
                 "dtype": torch.bfloat16,
         }
-        self.settings.fp8_gemm_module_list=["transformer.blocks", "transformer_2.blocks"]
-        self.settings.fp8_precision_overrides=None
+        self.settings.fp8_gemm_module_list = ["transformer.blocks", "transformer_2.blocks"]
+        self.settings.fp8_precision_overrides = None
+        self.settings.fp8_precision_override_match_mode = "prefix"
+        if config.fp8_precision_override_patterns:
+            patterns = tuple(
+                pattern.strip()
+                for pattern in config.fp8_precision_override_patterns.split(",")
+                if pattern.strip()
+            )
+            if patterns:
+                if config.fp8_precision_override_extend:
+                    # UNION applies only to transformer.blocks (fp4_gemm_module_list);
+                    # transformer_2.blocks stays full FP8 via fp8_gemm_module_list pass.
+                    self.settings.fp8_precision_override_extra_patterns = patterns
+                    self.settings.fp8_precision_override_extra_match_mode = (
+                        config.fp8_precision_override_mode
+                    )
+                    log(
+                        "Extending Wan2.2 I2V tower-1 FP8 overrides "
+                        f"{self.settings.fp8_precision_overrides} "
+                        f"(mode={self.settings.fp8_precision_override_match_mode}) "
+                        f"with extra rule {patterns} "
+                        f"(mode={config.fp8_precision_override_mode})"
+                    )
+                else:
+                    self.settings.fp8_precision_overrides = patterns
+                    self.settings.fp8_precision_override_match_mode = (
+                        config.fp8_precision_override_mode
+                    )
+                    log(
+                        "Using custom FP8 override patterns for Wan2.2 I2V (tower 1 only): "
+                        f"{self.settings.fp8_precision_overrides} "
+                        f"(match_mode={self.settings.fp8_precision_override_match_mode})"
+                    )
 
 
     def _load_model(self) -> DiffusionPipeline:
@@ -352,9 +384,9 @@ class xFuserWan22T2VModel(xFuserWan21T2VModel):
 
     def __init__(self, config: xFuserArgs) -> None:
         # Must set registry identity before super().__init__ → _validate_config (see xFuserWan22I2VModel).
+        # Leave settings.valid_tasks unset so callers do not need --task (matches xFuserWan21T2VModel).
         self.settings.model_name = "Wan-AI/Wan2.2-T2V-A14B-Diffusers"
         self.settings.output_name = "wan2.2_t2v"
-        self.settings.valid_tasks = ["t2v"]
         super().__init__(config)
         self.settings.fsdp_strategy["transformer_2"] = {
                 "wrap_attrs": ["blocks"],

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -215,6 +215,7 @@ class xFuserWan21I2VModel(xFuserModel):
 class xFuserWan22I2VModel(xFuserWan21I2VModel):
 
     def __init__(self, config: xFuserArgs) -> None:
+        self.settings = copy.deepcopy(self.settings)
         self.settings.model_name = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
         self.settings.output_name = "wan2.2_i2v"
         super().__init__(config)
@@ -385,6 +386,7 @@ class xFuserWan22T2VModel(xFuserWan21T2VModel):
     def __init__(self, config: xFuserArgs) -> None:
         # Must set registry identity before super().__init__ → _validate_config (see xFuserWan22I2VModel).
         # Leave settings.valid_tasks unset so callers do not need --task (matches xFuserWan21T2VModel).
+        self.settings = copy.deepcopy(self.settings)
         self.settings.model_name = "Wan-AI/Wan2.2-T2V-A14B-Diffusers"
         self.settings.output_name = "wan2.2_t2v"
         super().__init__(config)
@@ -498,6 +500,7 @@ class xFuserWan22TI2VModel(xFuserWan21T2VModel):
     )
 
     def __init__(self, config: xFuserArgs) -> None:
+        self.settings = copy.deepcopy(self.settings)
         super().__init__(config)
         if config.fp8_precision_override_patterns:
             patterns = tuple(

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -225,38 +225,6 @@ class xFuserWan22I2VModel(xFuserWan21I2VModel):
         }
         self.settings.fp8_gemm_module_list = ["transformer.blocks", "transformer_2.blocks"]
         self.settings.fp8_precision_overrides = None
-        self.settings.fp8_precision_override_match_mode = "prefix"
-        if config.fp8_precision_override_patterns:
-            patterns = tuple(
-                pattern.strip()
-                for pattern in config.fp8_precision_override_patterns.split(",")
-                if pattern.strip()
-            )
-            if patterns:
-                if config.fp8_precision_override_extend:
-                    # UNION applies only to transformer.blocks (fp4_gemm_module_list);
-                    # transformer_2.blocks stays full FP8 via fp8_gemm_module_list pass.
-                    self.settings.fp8_precision_override_extra_patterns = patterns
-                    self.settings.fp8_precision_override_extra_match_mode = (
-                        config.fp8_precision_override_mode
-                    )
-                    log(
-                        "Extending Wan2.2 I2V tower-1 FP8 overrides "
-                        f"{self.settings.fp8_precision_overrides} "
-                        f"(mode={self.settings.fp8_precision_override_match_mode}) "
-                        f"with extra rule {patterns} "
-                        f"(mode={config.fp8_precision_override_mode})"
-                    )
-                else:
-                    self.settings.fp8_precision_overrides = patterns
-                    self.settings.fp8_precision_override_match_mode = (
-                        config.fp8_precision_override_mode
-                    )
-                    log(
-                        "Using custom FP8 override patterns for Wan2.2 I2V (tower 1 only): "
-                        f"{self.settings.fp8_precision_overrides} "
-                        f"(match_mode={self.settings.fp8_precision_override_match_mode})"
-                    )
 
 
     def _load_model(self) -> DiffusionPipeline:
@@ -396,38 +364,6 @@ class xFuserWan22T2VModel(xFuserWan21T2VModel):
         }
         self.settings.fp8_gemm_module_list=["transformer.blocks", "transformer_2.blocks"]
         self.settings.fp8_precision_overrides=None
-        self.settings.fp8_precision_override_match_mode="prefix"
-        if config.fp8_precision_override_patterns:
-            patterns = tuple(
-                pattern.strip()
-                for pattern in config.fp8_precision_override_patterns.split(",")
-                if pattern.strip()
-            )
-            if patterns:
-                if config.fp8_precision_override_extend:
-                    # UNION applies only to transformer.blocks (fp4_gemm_module_list);
-                    # transformer_2.blocks stays full FP8 via fp8_gemm_module_list pass.
-                    self.settings.fp8_precision_override_extra_patterns = patterns
-                    self.settings.fp8_precision_override_extra_match_mode = (
-                        config.fp8_precision_override_mode
-                    )
-                    log(
-                        "Extending Wan2.2 T2V tower-1 FP8 overrides "
-                        f"{self.settings.fp8_precision_overrides} "
-                        f"(mode={self.settings.fp8_precision_override_match_mode}) "
-                        f"with extra rule {patterns} "
-                        f"(mode={config.fp8_precision_override_mode})"
-                    )
-                else:
-                    self.settings.fp8_precision_overrides = patterns
-                    self.settings.fp8_precision_override_match_mode = (
-                        config.fp8_precision_override_mode
-                    )
-                    log(
-                        "Using custom FP8 override patterns for Wan2.2 T2V (tower 1 only): "
-                        f"{self.settings.fp8_precision_overrides} "
-                        f"(match_mode={self.settings.fp8_precision_override_match_mode})"
-                    )
 
     def _load_model(self) -> DiffusionPipeline:
         transformer = xFuserWanTransformer3DWrapper.from_pretrained(
@@ -495,36 +431,10 @@ class xFuserWan22TI2VModel(xFuserWan21T2VModel):
         fp8_gemm_module_list=["transformer.blocks"],
         fp4_gemm_module_list=["transformer.blocks"],
         fp8_precision_overrides=("0.", "1.", "28.", "29."),
+        fp8_precision_override_suffixes=(".net.0.proj", ".net.2"),
         fsdp_strategy=COMMON_FSDP_STRATEGY,
         valid_tasks=["i2v", "t2v"],
     )
-
-    def __init__(self, config: xFuserArgs) -> None:
-        self.settings = copy.deepcopy(self.settings)
-        super().__init__(config)
-        if config.fp8_precision_override_patterns:
-            patterns = tuple(
-                pattern.strip()
-                for pattern in config.fp8_precision_override_patterns.split(",")
-                if pattern.strip()
-            )
-            if patterns:
-                if config.fp8_precision_override_extend:
-                    self.settings.fp8_precision_override_extra_patterns = patterns
-                    self.settings.fp8_precision_override_extra_match_mode = config.fp8_precision_override_mode
-                    log(
-                        f"Extending TI2V default FP8 overrides {self.settings.fp8_precision_overrides} "
-                        f"(mode={self.settings.fp8_precision_override_match_mode}) with extra rule "
-                        f"{patterns} (mode={config.fp8_precision_override_mode})"
-                    )
-                else:
-                    self.settings.fp8_precision_overrides = patterns
-                    self.settings.fp8_precision_override_match_mode = config.fp8_precision_override_mode
-                    log(
-                        "Using custom FP8 override patterns for Wan2.2 TI2V: "
-                        f"{self.settings.fp8_precision_overrides} "
-                        f"(match_mode={self.settings.fp8_precision_override_match_mode})"
-                    )
 
     def _load_model(self) -> DiffusionPipeline:
         torch.set_float32_matmul_precision('high')

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -446,6 +446,32 @@ class xFuserWan22TI2VModel(xFuserWan21T2VModel):
         valid_tasks=["i2v", "t2v"],
     )
 
+    def __init__(self, config: xFuserArgs) -> None:
+        super().__init__(config)
+        if config.fp8_precision_override_patterns:
+            patterns = tuple(
+                pattern.strip()
+                for pattern in config.fp8_precision_override_patterns.split(",")
+                if pattern.strip()
+            )
+            if patterns:
+                if config.fp8_precision_override_extend:
+                    self.settings.fp8_precision_override_extra_patterns = patterns
+                    self.settings.fp8_precision_override_extra_match_mode = config.fp8_precision_override_mode
+                    log(
+                        f"Extending TI2V default FP8 overrides {self.settings.fp8_precision_overrides} "
+                        f"(mode={self.settings.fp8_precision_override_match_mode}) with extra rule "
+                        f"{patterns} (mode={config.fp8_precision_override_mode})"
+                    )
+                else:
+                    self.settings.fp8_precision_overrides = patterns
+                    self.settings.fp8_precision_override_match_mode = config.fp8_precision_override_mode
+                    log(
+                        "Using custom FP8 override patterns for Wan2.2 TI2V: "
+                        f"{self.settings.fp8_precision_overrides} "
+                        f"(match_mode={self.settings.fp8_precision_override_match_mode})"
+                    )
+
     def _load_model(self) -> DiffusionPipeline:
         torch.set_float32_matmul_precision('high')
         transformer = xFuserWanTransformer3DWrapper.from_pretrained(

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -360,6 +360,21 @@ class xFuserWan22T2VModel(xFuserWan21T2VModel):
         }
         self.settings.fp8_gemm_module_list=["transformer.blocks", "transformer_2.blocks"]
         self.settings.fp8_precision_overrides=None
+        self.settings.fp8_precision_override_match_mode="prefix"
+        if config.fp8_precision_override_patterns:
+            patterns = tuple(
+                pattern.strip()
+                for pattern in config.fp8_precision_override_patterns.split(",")
+                if pattern.strip()
+            )
+            if patterns:
+                self.settings.fp8_precision_overrides = patterns
+                self.settings.fp8_precision_override_match_mode = config.fp8_precision_override_mode
+                log(
+                    "Using custom FP8 override patterns for Wan2.2 T2V: "
+                    f"{self.settings.fp8_precision_overrides} "
+                    f"(match_mode={self.settings.fp8_precision_override_match_mode})"
+                )
 
     def _load_model(self) -> DiffusionPipeline:
         transformer = xFuserWanTransformer3DWrapper.from_pretrained(


### PR DESCRIPTION
## Summary

Adds `--fp8_precision_override_extend` so user-supplied `--fp8_precision_override_patterns` are **unioned** with each model's built-in `fp8_precision_overrides` (instead of replacing them) when FP4 GEMMs are enabled. Also adds `prefix` / `suffix` / `contains` pattern modes and wires Wan2.2 TI2V / T2V / I2V tower-1 paths (including T2V-A14B `fp4ffn`).

## Motivation

Targeted FP8 islands (e.g. FFN projections via suffix `.net.0.proj`, `.net.2`) on top of default boundary-block FP8 protections reduce quality drift vs full FP4 without dropping stock safeties. This enables the `fp4ffn` configuration validated on MI355X (FP4 attention + FP8 FFN on tower 1).

## Implementation

- `xfuser/config/args.py` — CLI flags on **`add_runner_args`**; `create_config()` guards (`extend` requires `use_fp4_gemms` + non-empty patterns).
- `xfuser/core/utils/runner_utils.py` — `_matches_fp8_override_any` (OR across pattern rules).
- `xfuser/model_executor/models/runner_models/base_model.py` — MXFP4 setup respects combined overrides.
- `xfuser/model_executor/models/runner_models/wan.py` — UNION semantics for Wan2.2 models; T2V-A14B tower-1 extend branch.

## How to test

```bash
# Config guards + happy path (same path as xdit runner)
python3 -c "
from xfuser.config import FlexibleArgumentParser
from xfuser import xFuserArgs
p = FlexibleArgumentParser()
xFuserArgs.add_runner_args(p)
argv = ['--model','Wan-AI/Wan2.2-TI2V-5B-Diffusers','--use_fp4_gemms',
        '--fp8_precision_override_mode','suffix',
        '--fp8_precision_override_patterns','.net.0.proj,.net.2',
        '--fp8_precision_override_extend']
cfg = xFuserArgs.from_runner_args(vars(p.parse_args(argv)))
cfg.create_config()
print('OK', cfg.fp8_precision_override_extend)
"
```

Example inference flags:

```
--use_fp4_gemms --fp8_precision_override_mode suffix \
--fp8_precision_override_patterns .net.0.proj,.net.2 \
--fp8_precision_override_extend
```

## Known limitations

On T2V-A14B with `--attention_backend aiter_sage_v2`, `torch.compile` + `fp4ffn` can hit an inductor lowering issue in aiter's `sage_quant_v_kernel` (`KeyError: 'V_Output'`). Workaround: `--attention_backend aiter_sage` (v1). This is a torch.compile/aiter interaction, not incorrect override semantics.


Made with [Cursor](https://cursor.com)