### PR TITLE
LTX2 compile mode to reduce-overhead to reduce CPU overhead

### DIFF
--- a/xfuser/model_executor/models/runner_models/ltx.py
+++ b/xfuser/model_executor/models/runner_models/ltx.py
@@ -173,8 +173,7 @@ class xFuserLTX23VideoModel(xFuserModel):
 
     def _compile_model(self, input_args: dict) -> None:
         torch._inductor.config.reorder_for_compute_comm_overlap = True
-        self.pipe.transformer.compile_repeated_blocks(mode="default")
-        self.second_pipe.transformer.compile_repeated_blocks(mode="default")
+        self.pipe.transformer.compile_repeated_blocks(mode="reduce-overhead")
 
         # two steps to warmup the torch compiler
         compile_args = copy.deepcopy(input_args)
@@ -292,8 +291,7 @@ class xFuserLTX2VideoModel(xFuserModel):
 
     def _compile_model(self, input_args: dict) -> None:
         torch._inductor.config.reorder_for_compute_comm_overlap = True
-        self.pipe.transformer.compile_repeated_blocks(mode="default")
-        self.second_pipe.transformer.compile_repeated_blocks(mode="default")
+        self.pipe.transformer.compile_repeated_blocks(mode="reduce-overhead")
 
         # two steps to warmup the torch compiler
         compile_args = copy.deepcopy(input_args)

--- a/xfuser/model_executor/models/transformers/transformer_ltx2.py
+++ b/xfuser/model_executor/models/transformers/transformer_ltx2.py
@@ -639,6 +639,13 @@ class xFuserLTX2VideoTransformer3DWrapper(LTX2VideoTransformer3DModel):
                     perturbation_mask=block_perturbation_mask,
                     all_perturbed=block_all_perturbed,
                 )
+                # Workaround for pytorch/pytorch#152887: when compile_repeated_blocks
+                # is used with mode="reduce-overhead", every block call hits the same
+                # compiled callable. CUDA Graph Trees cannot handle the resulting
+                # ``x = f(x)`` chain (the previous call's static-memory output is the
+                # next call's input). Cloning into fresh user memory breaks the alias.
+                hidden_states = hidden_states.clone()
+                audio_hidden_states = audio_hidden_states.clone()
 
         # 6. Output layers (including unpatchification)
         scale_shift_values = self.scale_shift_table[None, None] + embedded_timestep[:, :, None]


### PR DESCRIPTION
# What?
Changes compile mode of LTX models to lessen CPU overhead.

# Why?
During benchmarking the LTX models have been observed to be sensitive to CPU overhead, showing large e2e variance depending on what is currently running on the CPU. This can make benchmarking difficult since you don't always have full control over the running environment and, for example, active coding agents can influence the final numbers.

Numbers from MI355

Simulating heavy CPU usage with stress-ng during benchmarking showed:
- 17.6% increase in average e2e times for LTX2.0
- 55.31% increase in average e2e times for LTX2.3 

Changing compile mode to reduce-overhead and simulating the same heavy CPU usages now shows:
- 4.2% increase in average e2e times for LTX2.0
- 16.19% increase in average e2e times for LTX2.3 

Demonstrating more resilience to CPU-overhead. Also tested on B200 with good results.

Additionally removed one of the transformer compiles since TORCH_TRACE logs showed the single compile
to be identical to the two pipeline compile. Torch compile registers the same transformer block. E2E latency results are identical.


# How?

Due to compiling per-block using reduce-overhead runs into this open issue: https://github.com/pytorch/pytorch/issues/152887 and will crash with the error 

```
  [rank0]: RuntimeError: Error: accessing tensor output of CUDAGraphs that has been overwritten by a subsequent run. Stack trace: File "/app/external/diffusers/src/diffusers/models/transformers/transformer_ltx2.py", line 786, in forward
  [rank0]:     hidden_states = hidden_states + ff_output * gate_mlp. To prevent overwriting, clone the tensor outside of torch.compile() or call torch.compiler.cudagraph_mark_step_begin() before each model invocation.
```

the suggested fix to call `torch.compiler.cudagraph_mark_step_begin()` does not work, as mentioned in the issue, however adding a [.clone()](https://docs.pytorch.org/docs/2.12/generated/torch.clone.html) statement fixes this. This extra copy showed either no, or negligible overhead during testing.