### PR TITLE
feat: enable VAE tiling and slicing across all runner models

### DIFF
--- a/xfuser/model_executor/models/runner_models/causal_wan.py
+++ b/xfuser/model_executor/models/runner_models/causal_wan.py
@@ -26,6 +26,7 @@ class xFuserCausalWanModel(xFuserModel):
         fully_shard_degree=False,
         use_fp8_gemms=False,
         use_parallel_vae=False,
+        enable_tiling=True,
     )
     default_input_values = DefaultInputValues(
         height=512,

--- a/xfuser/model_executor/models/runner_models/causal_wan.py
+++ b/xfuser/model_executor/models/runner_models/causal_wan.py
@@ -27,6 +27,7 @@ class xFuserCausalWanModel(xFuserModel):
         use_fp8_gemms=False,
         use_parallel_vae=False,
         enable_tiling=True,
+        enable_slicing=True,
     )
     default_input_values = DefaultInputValues(
         height=512,

--- a/xfuser/model_executor/models/runner_models/flux.py
+++ b/xfuser/model_executor/models/runner_models/flux.py
@@ -53,6 +53,7 @@ class xFuserFluxModel(xFuserModel):
         use_fp8_gemms=True,
         use_parallel_vae=True,
         enable_tiling=True,
+        enable_slicing=True,
     )
     default_input_values = DefaultInputValues(
         height=1024,
@@ -133,6 +134,7 @@ class xFuserFluxKontextModel(xFuserModel):
         ring_degree=True,
         use_fp8_gemms=True,
         enable_tiling=True,
+        enable_slicing=True,
     )
     default_input_values = DefaultInputValues(
         height=1024,
@@ -214,6 +216,7 @@ class xFuserFlux2Model(xFuserModel):
         use_fp4_gemms=True,
         fully_shard_degree=True,
         enable_tiling=True,
+        enable_slicing=True,
     )
     default_input_values = DefaultInputValues(
         height=1024,
@@ -283,6 +286,7 @@ class xFuserFlux2Klein9BModel(xFuserModel):
         ring_degree=True,
         use_fp8_gemms=True,
         enable_tiling=True,
+        enable_slicing=True,
     )
 
     default_input_values = DefaultInputValues(

--- a/xfuser/model_executor/models/runner_models/flux.py
+++ b/xfuser/model_executor/models/runner_models/flux.py
@@ -52,6 +52,7 @@ class xFuserFluxModel(xFuserModel):
         ring_degree=True,
         use_fp8_gemms=True,
         use_parallel_vae=True,
+        enable_tiling=True,
     )
     default_input_values = DefaultInputValues(
         height=1024,
@@ -131,6 +132,7 @@ class xFuserFluxKontextModel(xFuserModel):
         ulysses_degree=True,
         ring_degree=True,
         use_fp8_gemms=True,
+        enable_tiling=True,
     )
     default_input_values = DefaultInputValues(
         height=1024,
@@ -211,6 +213,7 @@ class xFuserFlux2Model(xFuserModel):
         use_fp8_gemms=True,
         use_fp4_gemms=True,
         fully_shard_degree=True,
+        enable_tiling=True,
     )
     default_input_values = DefaultInputValues(
         height=1024,
@@ -279,6 +282,7 @@ class xFuserFlux2Klein9BModel(xFuserModel):
         ulysses_degree=True,
         ring_degree=True,
         use_fp8_gemms=True,
+        enable_tiling=True,
     )
 
     default_input_values = DefaultInputValues(

--- a/xfuser/model_executor/models/runner_models/ltx.py
+++ b/xfuser/model_executor/models/runner_models/ltx.py
@@ -56,6 +56,7 @@ class xFuserLTX23VideoModel(xFuserModel):
     capabilities = ModelCapabilities(
         ulysses_degree=True,
         ring_degree=True,
+        enable_tiling=True,
     )
 
     _STG_SCALE = 1.0
@@ -222,6 +223,7 @@ class xFuserLTX2VideoModel(xFuserModel):
     capabilities = ModelCapabilities(
         ulysses_degree=True,
         ring_degree=True,
+        enable_tiling=True,
     )
 
     def _load_model(self) -> DiffusionPipeline:

--- a/xfuser/model_executor/models/runner_models/ltx.py
+++ b/xfuser/model_executor/models/runner_models/ltx.py
@@ -110,6 +110,11 @@ class xFuserLTX23VideoModel(xFuserModel):
 
         return pipe
 
+    def _enable_options(self) -> None:
+        super()._enable_options()
+        if self.config.enable_slicing:
+            self.second_pipe.vae.enable_slicing()
+
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
         generator = torch.Generator(device="cuda").manual_seed(input_args["seed"])
 
@@ -261,6 +266,13 @@ class xFuserLTX2VideoModel(xFuserModel):
         self.upsample_pipe = upsample_pipe
 
         return pipe
+
+    def _enable_options(self) -> None:
+        super()._enable_options()
+        if self.config.enable_tiling:
+            self.second_pipe.vae.enable_tiling()
+        if self.config.enable_slicing:
+            self.second_pipe.vae.enable_slicing()
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
         video_latent, audio_latent = self.pipe(

--- a/xfuser/model_executor/models/runner_models/ltx.py
+++ b/xfuser/model_executor/models/runner_models/ltx.py
@@ -57,6 +57,7 @@ class xFuserLTX23VideoModel(xFuserModel):
         ulysses_degree=True,
         ring_degree=True,
         enable_tiling=True,
+        enable_slicing=True,
     )
 
     _STG_SCALE = 1.0
@@ -224,6 +225,7 @@ class xFuserLTX2VideoModel(xFuserModel):
         ulysses_degree=True,
         ring_degree=True,
         enable_tiling=True,
+        enable_slicing=True,
     )
 
     def _load_model(self) -> DiffusionPipeline:

--- a/xfuser/model_executor/models/runner_models/qwen.py
+++ b/xfuser/model_executor/models/runner_models/qwen.py
@@ -27,6 +27,7 @@ class xFuserQwenImageEditModel(xFuserModel):
         fully_shard_degree=True,
         use_fp8_gemms=True,
         enable_tiling=True,
+        enable_slicing=True,
     )
     default_input_values = DefaultInputValues(
         num_inference_steps=50,
@@ -102,6 +103,7 @@ class xFuserQwenImageModel(xFuserModel):
         ring_degree=True,
         fully_shard_degree=True,
         enable_tiling=True,
+        enable_slicing=True,
     )
     default_input_values = DefaultInputValues(
         height=928,

--- a/xfuser/model_executor/models/runner_models/qwen.py
+++ b/xfuser/model_executor/models/runner_models/qwen.py
@@ -26,6 +26,7 @@ class xFuserQwenImageEditModel(xFuserModel):
         ring_degree=True,
         fully_shard_degree=True,
         use_fp8_gemms=True,
+        enable_tiling=True,
     )
     default_input_values = DefaultInputValues(
         num_inference_steps=50,
@@ -100,6 +101,7 @@ class xFuserQwenImageModel(xFuserModel):
         ulysses_degree=True,
         ring_degree=True,
         fully_shard_degree=True,
+        enable_tiling=True,
     )
     default_input_values = DefaultInputValues(
         height=928,

--- a/xfuser/model_executor/models/runner_models/stable_diffusion.py
+++ b/xfuser/model_executor/models/runner_models/stable_diffusion.py
@@ -20,6 +20,7 @@ class xFuserStableDiffusionModel(xFuserModel):
         ring_degree=True,
         pipefusion_parallel_degree=True,
         use_cfg_parallel=True,
+        enable_tiling=True,
     )
     default_input_values = DefaultInputValues(
         height=1024,

--- a/xfuser/model_executor/models/runner_models/stable_diffusion.py
+++ b/xfuser/model_executor/models/runner_models/stable_diffusion.py
@@ -21,6 +21,7 @@ class xFuserStableDiffusionModel(xFuserModel):
         pipefusion_parallel_degree=True,
         use_cfg_parallel=True,
         enable_tiling=True,
+        enable_slicing=True,
     )
     default_input_values = DefaultInputValues(
         height=1024,

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -118,6 +118,7 @@ class xFuserWan21I2VModel(xFuserModel):
         use_parallel_vae_encoder=True,
         cross_attention_backend=True,
         supports_sparge_attention_backends=True,
+        enable_tiling=True,
     )
     default_input_values = DefaultInputValues(
         height=720,
@@ -275,6 +276,7 @@ class xFuserWan21T2VModel(xFuserModel):
         use_parallel_vae=True,
         cross_attention_backend=True,
         supports_sparge_attention_backends=True,
+        enable_tiling=True,
     )
     default_input_values = DefaultInputValues(
         height=720,
@@ -405,6 +407,7 @@ class xFuserWan22TI2VModel(xFuserWan21T2VModel):
         use_parallel_vae=True,
         cross_attention_backend=True,
         supports_sparge_attention_backends=True,
+        enable_tiling=True,
     )
     default_input_values = DefaultInputValues(
         height=736,
@@ -509,6 +512,7 @@ class xFuserWan21VACEModel(xFuserModel):
         ring_degree=True,
         use_fp8_gemms=True,
         cross_attention_backend=True,
+        enable_tiling=True,
     )
 
     default_input_values = DefaultInputValues(

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -119,6 +119,7 @@ class xFuserWan21I2VModel(xFuserModel):
         cross_attention_backend=True,
         supports_sparge_attention_backends=True,
         enable_tiling=True,
+        enable_slicing=True,
     )
     default_input_values = DefaultInputValues(
         height=720,
@@ -277,6 +278,7 @@ class xFuserWan21T2VModel(xFuserModel):
         cross_attention_backend=True,
         supports_sparge_attention_backends=True,
         enable_tiling=True,
+        enable_slicing=True,
     )
     default_input_values = DefaultInputValues(
         height=720,
@@ -408,6 +410,7 @@ class xFuserWan22TI2VModel(xFuserWan21T2VModel):
         cross_attention_backend=True,
         supports_sparge_attention_backends=True,
         enable_tiling=True,
+        enable_slicing=True,
     )
     default_input_values = DefaultInputValues(
         height=736,
@@ -513,6 +516,7 @@ class xFuserWan21VACEModel(xFuserModel):
         use_fp8_gemms=True,
         cross_attention_backend=True,
         enable_tiling=True,
+        enable_slicing=True,
     )
 
     default_input_values = DefaultInputValues(

--- a/xfuser/model_executor/models/runner_models/z_image.py
+++ b/xfuser/model_executor/models/runner_models/z_image.py
@@ -55,6 +55,7 @@ class xFuserZImageModel(xFuserModel):
     capabilities = ModelCapabilities(
         use_cfg_parallel=True,
         enable_tiling=True,
+        enable_slicing=True,
     )
     settings = ModelSettings(
         model_name="Tongyi-MAI/Z-Image",
@@ -93,14 +94,16 @@ class xFuserZImageModel(xFuserModel):
 @register_model("Z-Image-Turbo")
 class xFuserZImageTurboModel(xFuserModel):
 
+    capabilities = ModelCapabilities(
+        fully_shard_degree=True,
+        enable_tiling=True,
+        enable_slicing=True,
+    )
     default_input_values = DefaultInputValues(
         height=1024,
         width=1024,
         num_inference_steps=9,
         guidance_scale=0.0,
-    )
-    capabilities = ModelCapabilities(
-        enable_tiling=True,
     )
     settings = ModelSettings(
         model_name="Tongyi-MAI/Z-Image-Turbo",

--- a/xfuser/model_executor/models/runner_models/z_image.py
+++ b/xfuser/model_executor/models/runner_models/z_image.py
@@ -95,7 +95,6 @@ class xFuserZImageModel(xFuserModel):
 class xFuserZImageTurboModel(xFuserModel):
 
     capabilities = ModelCapabilities(
-        fully_shard_degree=True,
         enable_tiling=True,
         enable_slicing=True,
     )

--- a/xfuser/model_executor/models/runner_models/z_image.py
+++ b/xfuser/model_executor/models/runner_models/z_image.py
@@ -53,7 +53,8 @@ class xFuserZImageModel(xFuserModel):
         guidance_scale=4.0,
     )
     capabilities = ModelCapabilities(
-        use_cfg_parallel=True
+        use_cfg_parallel=True,
+        enable_tiling=True,
     )
     settings = ModelSettings(
         model_name="Tongyi-MAI/Z-Image",
@@ -97,6 +98,9 @@ class xFuserZImageTurboModel(xFuserModel):
         width=1024,
         num_inference_steps=9,
         guidance_scale=0.0,
+    )
+    capabilities = ModelCapabilities(
+        enable_tiling=True,
     )
     settings = ModelSettings(
         model_name="Tongyi-MAI/Z-Image-Turbo",


### PR DESCRIPTION
## Summary

Two small changes that expose existing diffusers VAE memory optimizations through xDiT's runner.

### 1. VAE tiling (`--enable_tiling`)

Adds `enable_tiling=True` to `ModelCapabilities` for all models that were missing it. Previously, passing `--enable_tiling` raised a validation error for these models even though their VAEs support it.

VAE tiling decodes in spatial tiles to reduce peak VRAM during decode. The benefit is resolution-dependent. At higher resolutions it becomes essential for low VRAM cards.

On AMD AI Pro R9700 32GB (gfx1201), FLUX.1-dev at 2048×2048:

| Config | s/iter | Peak VRAM |
|--------|--------|-----------|
| 1 GPU + compile + model offload, no tiling | ~252 | ~32.5 GB |
| 1 GPU + compile + model offload + tiling | 139.55 | 29.5 GB |

### 2. VAE slicing (`--enable_slicing`)

Adds `enable_slicing=True` to `ModelCapabilities` for all models that were missing it. Same issue. `--enable_slicing` raised a validation error despite the VAEs supporting it via `AutoencoderMixin`.

VAE slicing decodes one image at a time when `batch_size > 1`, reducing peak VRAM during batch inference. No effect at batch size 1.