### PR TITLE
feat: parallel VAE decode for FLUX.1-Kontext, FLUX.2-dev, and FLUX.2-klein

### DIFF
--- a/xfuser/model_executor/models/runner_models/flux.py
+++ b/xfuser/model_executor/models/runner_models/flux.py
@@ -131,6 +131,7 @@ class xFuserFluxKontextModel(xFuserModel):
         ulysses_degree=True,
         ring_degree=True,
         use_fp8_gemms=True,
+        use_parallel_vae=True,
     )
     default_input_values = DefaultInputValues(
         height=1024,
@@ -146,6 +147,11 @@ class xFuserFluxKontextModel(xFuserModel):
         mod_value=16,
         fp8_gemm_module_list=["transformer.transformer_blocks", "transformer.single_transformer_blocks"],
     )
+
+    def _post_load_and_state_initialization(self, input_args: dict) -> None:
+        super()._post_load_and_state_initialization(input_args)
+        if self.config.use_parallel_vae:
+            _setup_parallel_vae(self.pipe.vae)
 
     def _load_model(self) -> DiffusionPipeline:
         transformer = xFuserFlux1Transformer2DWrapper.from_pretrained(
@@ -211,6 +217,7 @@ class xFuserFlux2Model(xFuserModel):
         use_fp8_gemms=True,
         use_fp4_gemms=True,
         fully_shard_degree=True,
+        use_parallel_vae=True,
     )
     default_input_values = DefaultInputValues(
         height=1024,
@@ -232,6 +239,11 @@ class xFuserFlux2Model(xFuserModel):
             }
         }
     )
+
+    def _post_load_and_state_initialization(self, input_args: dict) -> None:
+        super()._post_load_and_state_initialization(input_args)
+        if self.config.use_parallel_vae:
+            _setup_parallel_vae(self.pipe.vae)
 
     def _load_model(self) -> DiffusionPipeline:
         transformer = xFuserFlux2Transformer2DWrapper.from_pretrained(
@@ -279,6 +291,7 @@ class xFuserFlux2Klein9BModel(xFuserModel):
         ulysses_degree=True,
         ring_degree=True,
         use_fp8_gemms=True,
+        use_parallel_vae=True,
     )
 
     default_input_values = DefaultInputValues(
@@ -293,6 +306,11 @@ class xFuserFlux2Klein9BModel(xFuserModel):
         model_output_type="image",
         fp8_gemm_module_list=["transformer.transformer_blocks", "transformer.single_transformer_blocks"],
     )
+
+    def _post_load_and_state_initialization(self, input_args: dict) -> None:
+        super()._post_load_and_state_initialization(input_args)
+        if self.config.use_parallel_vae:
+            _setup_parallel_vae(self.pipe.vae)
 
     def _load_model(self) -> DiffusionPipeline:
         transformer = xFuserFlux2Transformer2DWrapper.from_pretrained(


### PR DESCRIPTION
## Summary

Extends parallel VAE decode to the remaining FLUX model families. FLUX.1-dev already supported
`use_parallel_vae` (merged previously). This PR adds the same to:

- `xFuserFluxKontextModel` (FLUX.1-Kontext-dev)
- `xFuserFlux2Model` (FLUX.2-dev)
- `xFuserFlux2Klein9BModel` / `xFuserFlux2Klein4BModel` (FLUX.2-klein)

Per model: adds `use_parallel_vae=True` to `ModelCapabilities` and a
`_post_load_and_state_initialization` method identical to the FLUX.1-dev pattern.
`_setup_parallel_vae` is unchanged. It patches the VAE decoder via DistVAE's
`DecoderAdapter` with a clear error if DistVAE is not installed.

## Validation

On AMD AI Pro R9700 (gfx1201, 32 GB) coupled with the other changes in the associated PRs, parallel VAE is part of most viable multi-GPU recipes for these models.