### PR TITLE
Add Wan2.2-Distilled-I2V model (LightX2V 4-step BF16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ The following open-sourced DiT Models are released with xDiT in day 1.
 | [🎬 Latte](https://huggingface.co/maxin-cn/Latte-1) | ❎ | ✔️ | ❎ | ❎ | ❎ | [Report](./docs/performance/latte.md) |
 | [🎬 Wan2.1](https://huggingface.co/Wan-AI/Wan2.1-T2V-14B-Diffusers) | ❎ | ✔️ | ❎ | ❎ | ✔️ | NA |
 | [🎬 Wan2.2](https://huggingface.co/Wan-AI/Wan2.2-I2V-A14B-Diffusers) | ❎ | ✔️ | ❎ | ❎ | ✔️ | NA |
+| [🎬 Wan2.2-Distilled (LightX2V 4-step)](https://huggingface.co/lightx2v/Wan2.2-Distill-Models) | ❎ | ✔️ | ❎ | ❎ | ✔️ | NA |
 | [🎬 CausalWan2.2](https://huggingface.co/FastVideo/CausalWan2.2-I2V-A14B-Preview-Diffusers) | ❎ | ❎ | ❎ | ❎ | ✔️ | NA |
 | [🎬 LTX-2](https://huggingface.co/Lightricks/LTX-2) | ❎ | ✔️ | ❎ | ❎ | ✔️ | NA |
 | [🔵 HunyuanDiT-v1.2-Diffusers](https://huggingface.co/Tencent-Hunyuan/HunyuanDiT-v1.2-Diffusers) | ✔️ | ✔️ | ✔️ | ❎ | ❎ | [Report](./docs/performance/hunyuandit.md) |
@@ -311,6 +312,7 @@ Below is a list of validated diffusers version requirements. If the model is not
 | [HunyuanVideo](https://github.com/Tencent/HunyuanVideo) | >= 0.35.2 |
 | [Wan2.1](https://huggingface.co/Wan-AI/Wan2.1-T2V-14B-Diffusers) | >= 0.35.2 |
 | [Wan2.2](https://huggingface.co/Wan-AI/Wan2.2-I2V-A14B-Diffusers) | >= 0.35.2 |
+| [Wan2.2-Distilled (LightX2V)](https://huggingface.co/lightx2v/Wan2.2-Distill-Models) | >= 0.35.2 |
 
 <h2 id="dev-guide">📚  Develop Guide</h2>
 

--- a/docs/runner/runner.md
+++ b/docs/runner/runner.md
@@ -92,6 +92,7 @@ Individual model classes that inherit from `xFuserModel`:
 | HunyuanVideo | `HunyuanVideo`, `tencent/HunyuanVideo` |
 | HunyuanVideo-1.5 | `HunyuanVideo-1.5`, `tencent/HunyuanVideo-1.5` |
 | Wan 2.1/2.2 I2V | `Wan2.1-I2V`, `Wan2.2-I2V`, `Wan-AI/Wan2.1-I2V-14B-720P-Diffusers`, `Wan-AI/Wan2.2-I2V-A14B-Diffusers` |
+| Wan 2.2 Distilled I2V (LightX2V 4-step) | `Wan2.2-Distilled-I2V` |
 | Wan 2.1/2.2 T2V | `Wan2.1-T2V`, `Wan2.2-T2V`, `Wan-AI/Wan2.1-T2V-14B-720P-Diffusers`, `Wan-AI/Wan2.2-T2V-A14B-Diffusers` |
 | Wan 2.1 VACE | `Wan2.1-VACE-14B`, `Wan2.1-VACE-1.3B`, `Wan-AI/Wan2.1-VACE-14B`, `Wan-AI/Wan2.1-VACE-1.3B` |
 | Stable Diffusion 3 | `SD3.5`, `stabilityai/stable-diffusion-3.5-large` |
@@ -153,6 +154,13 @@ Individual model classes that inherit from `xFuserModel`:
 | `--enable_sequential_cpu_offload` | Enable sequential CPU offload | False |
 | `--attention_backend` | Attention backend selection | None |
 
+### Model-specific Arguments
+
+| Argument | Description | Required for |
+|----------|-------------|--------------|
+| `--distilled_transformer_path` | Path to the **high-noise** distilled transformer safetensors (used for denoising steps 0–1) | `Wan2.2-Distilled-I2V` |
+| `--distilled_transformer_2_path` | Path to the **low-noise** distilled transformer safetensors (used for denoising steps 2–3) | `Wan2.2-Distilled-I2V` |
+
 ### Benchmarking
 
 | Argument | Description | Default |
@@ -193,6 +201,17 @@ xdit --model HunyuanVideo \
     --height 720 \
     --width 1280 \
     --num_frames 49 \
+    --ulysses_degree 8
+```
+
+### Distilled Video Generation
+
+```bash
+xdit --model Wan2.2-Distilled-I2V \
+    --distilled_transformer_path   /path/to/wan2.2_i2v_A14b_high_noise_lightx2v_4step_720p_260412.safetensors \
+    --distilled_transformer_2_path /path/to/wan2.2_i2v_A14b_low_noise_lightx2v_4step_720p_260412.safetensors \
+    --input_images /path/to/image.jpg \
+    --prompt "A cat walking in a garden" \
     --ulysses_degree 8
 ```
 

--- a/docs/runner/runner.md
+++ b/docs/runner/runner.md
@@ -158,8 +158,8 @@ Individual model classes that inherit from `xFuserModel`:
 
 | Argument | Description | Required for |
 |----------|-------------|--------------|
-| `--distilled_transformer_path` | Path to the **high-noise** distilled transformer safetensors (used for denoising steps 0–1) | `Wan2.2-Distilled-I2V` |
-| `--distilled_transformer_2_path` | Path to the **low-noise** distilled transformer safetensors (used for denoising steps 2–3) | `Wan2.2-Distilled-I2V` |
+| `--distilled_transformer_path` | Path to the **high-noise** distilled transformer safetensors | `Wan2.2-Distilled-I2V` |
+| `--distilled_transformer_2_path` | Path to the **low-noise** distilled transformer safetensors | `Wan2.2-Distilled-I2V` |
 
 ### Benchmarking
 

--- a/tests/test_wan_distilled.py
+++ b/tests/test_wan_distilled.py
@@ -1,0 +1,214 @@
+"""
+Unit tests for the Wan2.2 LightX2V distilled model components.
+
+All tests are CPU-only and have no HuggingFace or GPU dependencies.
+
+Run with:
+    pytest tests/test_wan_distilled.py -v
+"""
+import pytest
+import torch
+
+
+# ---------------------------------------------------------------------------
+# Helpers — import only the pure functions / classes under test
+# ---------------------------------------------------------------------------
+
+from xfuser.model_executor.models.runner_models.wan import (
+    _remap_lightx2v_to_diffusers,
+    _distilled_scheduler_sigmas,
+    _DistilledWanScheduler,
+)
+
+
+# ---------------------------------------------------------------------------
+# _remap_lightx2v_to_diffusers
+# ---------------------------------------------------------------------------
+
+
+class TestRemapLightx2vToDiffusers:
+    """Key remapping from LightX2V state-dict naming to diffusers naming."""
+
+    @pytest.mark.parametrize(
+        "src, expected",
+        [
+            # self-attention projections
+            ("blocks.0.self_attn.q.weight", "blocks.0.attn1.to_q.weight"),
+            ("blocks.0.self_attn.k.weight", "blocks.0.attn1.to_k.weight"),
+            ("blocks.0.self_attn.v.weight", "blocks.0.attn1.to_v.weight"),
+            ("blocks.0.self_attn.o.weight", "blocks.0.attn1.to_out.0.weight"),
+            ("blocks.0.self_attn.norm_q.weight", "blocks.0.attn1.norm_q.weight"),
+            ("blocks.0.self_attn.norm_k.weight", "blocks.0.attn1.norm_k.weight"),
+            # cross-attention projections
+            ("blocks.5.cross_attn.q.weight", "blocks.5.attn2.to_q.weight"),
+            ("blocks.5.cross_attn.k.weight", "blocks.5.attn2.to_k.weight"),
+            ("blocks.5.cross_attn.v.weight", "blocks.5.attn2.to_v.weight"),
+            ("blocks.5.cross_attn.o.weight", "blocks.5.attn2.to_out.0.weight"),
+            ("blocks.5.cross_attn.norm_q.weight", "blocks.5.attn2.norm_q.weight"),
+            ("blocks.5.cross_attn.norm_k.weight", "blocks.5.attn2.norm_k.weight"),
+            # feed-forward
+            ("blocks.10.ffn.0.weight", "blocks.10.ffn.net.0.proj.weight"),
+            ("blocks.10.ffn.2.weight", "blocks.10.ffn.net.2.weight"),
+            # norms and modulation
+            ("blocks.3.norm3.weight", "blocks.3.norm2.weight"),
+            ("blocks.3.modulation", "blocks.3.scale_shift_table"),
+            # output head
+            ("head.head.weight", "proj_out.weight"),
+            ("head.modulation", "scale_shift_table"),
+            # text / time embeddings
+            ("text_embedding.0.weight", "condition_embedder.text_embedder.linear_1.weight"),
+            ("text_embedding.2.weight", "condition_embedder.text_embedder.linear_2.weight"),
+            ("time_embedding.0.weight", "condition_embedder.time_embedder.linear_1.weight"),
+            ("time_embedding.2.weight", "condition_embedder.time_embedder.linear_2.weight"),
+            ("time_projection.1.weight", "condition_embedder.time_proj.weight"),
+            # keys that should pass through unchanged (diffusers native)
+            ("patch_embedding.weight", "patch_embedding.weight"),
+        ],
+    )
+    def test_known_mappings(self, src, expected):
+        assert _remap_lightx2v_to_diffusers(src) == expected
+
+    def test_deep_block_index(self):
+        # Make sure multi-digit block indices work
+        result = _remap_lightx2v_to_diffusers("blocks.39.self_attn.q.weight")
+        assert result == "blocks.39.attn1.to_q.weight"
+
+    def test_modulation_not_confused_with_norm(self):
+        # blocks.N.modulation → scale_shift_table, not touching norm3
+        result = _remap_lightx2v_to_diffusers("blocks.7.modulation")
+        assert result == "blocks.7.scale_shift_table"
+        # norm3 rename should not touch modulation
+        result2 = _remap_lightx2v_to_diffusers("blocks.7.norm3.weight")
+        assert result2 == "blocks.7.norm2.weight"
+
+
+# ---------------------------------------------------------------------------
+# _distilled_scheduler_sigmas
+# ---------------------------------------------------------------------------
+
+
+class TestDistilledSchedulerSigmas:
+    def test_shape(self):
+        sigmas = _distilled_scheduler_sigmas()
+        assert sigmas.shape == (5,), "Expected 4 steps + terminal 0"
+
+    def test_terminal_zero(self):
+        sigmas = _distilled_scheduler_sigmas()
+        assert sigmas[-1].item() == pytest.approx(0.0)
+
+    def test_first_sigma_is_one(self):
+        sigmas = _distilled_scheduler_sigmas()
+        assert sigmas[0].item() == pytest.approx(1.0)
+
+    def test_strictly_decreasing(self):
+        sigmas = _distilled_scheduler_sigmas()
+        diffs = sigmas[:-1] - sigmas[1:]  # exclude terminal 0 from diff
+        assert (diffs > 0).all(), "Sigmas should be strictly decreasing"
+
+    def test_expected_values(self):
+        # Verified against LightX2V scheduler with sample_shift=5,
+        # denoising_step_list=[1000, 750, 500, 250]
+        sigmas = _distilled_scheduler_sigmas()
+        expected_timesteps = [1000.0, 937.5, 833.333, 625.0]
+        for i, t in enumerate(expected_timesteps):
+            assert sigmas[i].item() * 1000 == pytest.approx(t, rel=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# _DistilledWanScheduler
+# ---------------------------------------------------------------------------
+
+
+class TestDistilledWanScheduler:
+    @pytest.fixture
+    def scheduler(self):
+        return _DistilledWanScheduler()
+
+    def test_set_timesteps_produces_four_steps(self, scheduler):
+        scheduler.set_timesteps(4)
+        assert len(scheduler.timesteps) == 4
+
+    def test_num_inference_steps_is_ignored_by_schedule(self, scheduler):
+        # Passing any integer should still yield the same fixed 4 timesteps
+        scheduler.set_timesteps(4)
+        ts_4 = scheduler.timesteps.clone()
+        scheduler.set_timesteps(20)
+        ts_20 = scheduler.timesteps.clone()
+        assert torch.allclose(ts_4, ts_20), (
+            "Schedule must be fixed regardless of num_inference_steps"
+        )
+
+    def test_timesteps_match_expected(self, scheduler):
+        scheduler.set_timesteps(4)
+        expected = [1000.0, 937.5, 833.333, 625.0]
+        for i, t in enumerate(expected):
+            assert scheduler.timesteps[i].item() == pytest.approx(t, rel=1e-3)
+
+    def test_step_index_reset(self, scheduler):
+        scheduler.set_timesteps(4)
+        assert scheduler._step_index is None
+        assert scheduler._begin_index is None
+
+    def test_device_placement(self, scheduler):
+        scheduler.set_timesteps(4, device="cpu")
+        assert scheduler.sigmas.device.type == "cpu"
+        assert scheduler.timesteps.device.type == "cpu"
+
+    def test_uses_config_num_train_timesteps(self, scheduler):
+        # Timesteps should be sigmas * config.num_train_timesteps (default 1000)
+        scheduler.set_timesteps(4)
+        sigmas = _distilled_scheduler_sigmas()
+        expected = sigmas[:-1] * scheduler.config.num_train_timesteps
+        assert torch.allclose(scheduler.timesteps.cpu(), expected.cpu())
+
+
+# ---------------------------------------------------------------------------
+# _validate_args (via xFuserWan22DistilledI2VModel)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateArgs:
+    """Test _validate_args without instantiating the full model."""
+
+    @pytest.fixture
+    def call_validate(self):
+        """Return a callable that invokes _validate_args with a controlled config."""
+        from xfuser.model_executor.models.runner_models.wan import (
+            xFuserWan22DistilledI2VModel,
+        )
+        from unittest.mock import MagicMock, patch
+
+        # Minimal real subclass so super() works; __init__ bypassed entirely.
+        class _TestModel(xFuserWan22DistilledI2VModel):
+            def __init__(self):
+                pass
+
+        def _call(args, *, transformer_path="/fake/high.safetensors", transformer_2_path="/fake/low.safetensors"):
+            instance = _TestModel()
+            instance.config = MagicMock()
+            instance.config.distilled_transformer_path = transformer_path
+            instance.config.distilled_transformer_2_path = transformer_2_path
+            # Suppress the parent chain (requires distributed init)
+            with patch.object(
+                xFuserWan22DistilledI2VModel.__bases__[0],
+                "_validate_args",
+                lambda self, a: None,
+            ):
+                xFuserWan22DistilledI2VModel._validate_args(instance, args)
+
+        return _call
+
+    def test_accepts_four_steps(self, call_validate):
+        call_validate({"num_inference_steps": 4, "input_images": []})
+
+    def test_rejects_wrong_steps(self, call_validate):
+        with pytest.raises(ValueError, match="num_inference_steps must be 4"):
+            call_validate({"num_inference_steps": 20, "input_images": []})
+
+    def test_rejects_missing_transformer_path(self, call_validate):
+        with pytest.raises(ValueError, match="distilled_transformer_path"):
+            call_validate({"num_inference_steps": 4, "input_images": []}, transformer_path=None)
+
+    def test_rejects_missing_transformer_2_path(self, call_validate):
+        with pytest.raises(ValueError, match="distilled_transformer_2_path"):
+            call_validate({"num_inference_steps": 4, "input_images": []}, transformer_2_path=None)

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -159,7 +159,7 @@ class xFuserArgs:
     use_spargeattn_static_block_mask: bool = True
     spargeattn_simthreshold: float = 0.3
     spargeattn_cdfthreshold: float = 0.92
-    # Distilled model weight paths (e.g. LightX2V Wan2.2 4-step distilled)
+    # Distilled model weight paths
     distilled_transformer_path: Optional[str] = None
     distilled_transformer_2_path: Optional[str] = None
 
@@ -749,13 +749,13 @@ class xFuserArgs:
             "--distilled_transformer_path",
             type=nullable_str,
             default=None,
-            help="Path to the distilled transformer path. i.e. high-noise distilled transformer safetensors file (Wan2.2 Distilled I2V).",
+            help="Path to the distilled transformer path. i.e. high-noise distilled transformer safetensors file.",
         )
         parser.add_argument(
             "--distilled_transformer_2_path",
             type=nullable_str,
             default=None,
-            help="Path to the distilled transformer_2 path i.e. low-noise distilled transformer_2 safetensors file (Wan2.2 Distilled I2V).",
+            help="Path to the distilled transformer_2 path i.e. low-noise distilled transformer_2 safetensors file.",
         )
         return parser
 

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -755,7 +755,7 @@ class xFuserArgs:
             "--distilled_transformer_2_path",
             type=nullable_str,
             default=None,
-            help="Path to the distilled transformer_2 path i.e. low-noise distilled transformer_2 safetensors file.",
+            help="Path to the low-noise distilled transformer_2 safetensors file.",
         )
         return parser
 

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -749,7 +749,7 @@ class xFuserArgs:
             "--distilled_transformer_path",
             type=nullable_str,
             default=None,
-            help="Path to the distilled transformer path. i.e. high-noise distilled transformer safetensors file.",
+            help="Path to the high-noise distilled transformer safetensors file.",
         )
         parser.add_argument(
             "--distilled_transformer_2_path",

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -159,6 +159,9 @@ class xFuserArgs:
     use_spargeattn_static_block_mask: bool = True
     spargeattn_simthreshold: float = 0.3
     spargeattn_cdfthreshold: float = 0.92
+    # Distilled model weight paths (e.g. LightX2V Wan2.2 4-step distilled)
+    distilled_transformer_path: Optional[str] = None
+    distilled_transformer_2_path: Optional[str] = None
 
     @staticmethod
     def add_cli_args(parser: FlexibleArgumentParser):
@@ -741,6 +744,18 @@ class xFuserArgs:
             help="OR a static gilbert block-neighbor mask into the dynamic "
                  "Sparge block mask. Only meaningful when "
                  "--spargeattn_reorder_sequence is set. Use --no-use_spargeattn_static_block_mask to disable."
+        )
+        parser.add_argument(
+            "--distilled_transformer_path",
+            type=nullable_str,
+            default=None,
+            help="Path to the distilled transformer path. i.e. high-noise distilled transformer safetensors file (Wan2.2 Distilled I2V).",
+        )
+        parser.add_argument(
+            "--distilled_transformer_2_path",
+            type=nullable_str,
+            default=None,
+            help="Path to the distilled transformer_2 path i.e. low-noise distilled transformer_2 safetensors file (Wan2.2 Distilled I2V).",
         )
         return parser
 

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -121,6 +121,7 @@ class ModelCapabilities:
     cross_attention_backend: bool = False
     supports_sparse_attention_backends: bool = False
     supports_sparge_attention_backends: bool = False
+    supports_distilled_weights: bool = False
 
 @dataclass(frozen=True)
 class DefaultInputValues:
@@ -353,6 +354,11 @@ class xFuserModel(abc.ABC):
             if torch.nn.GroupNorm.__module__ == "aiter.ops.groupnorm":
                 log("AITER GroupNorm is not supported with parallel VAE. Reverting to torch GroupNorm.")
                 torch.nn.GroupNorm = _TORCH_GROUPNORM
+        
+        if config.distilled_transformer_path or config.distilled_transformer_2_path:
+            if not self.capabilities.supports_distilled_weights:
+                raise ValueError(f"Model {self.settings.model_name} does not support distilled_transformer_path or distilled_transformer_2_path params.")
+
 
 
     def _compile_model(self, input_args: dict) -> None:

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -335,6 +335,20 @@ class xFuserWan22DistilledI2VModel(xFuserWan22I2VModel):
     _BOUNDARY_RATIO = 0.9
     _BASE_MODEL = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
 
+    capabilities = ModelCapabilities(
+        ulysses_degree=True,
+        ring_degree=True,
+        fully_shard_degree=True,
+        use_fp8_gemms=True,
+        use_cfg_parallel=False,
+        use_fp4_gemms=True,
+        use_hybrid_attn_schedule=True,
+        use_parallel_vae=True,
+        use_parallel_vae_encoder=True,
+        cross_attention_backend=True,
+        supports_sparge_attention_backends=True,
+        supports_distilled_weights=True,
+    )
     default_input_values = DefaultInputValues(
         height=720,
         width=1280,
@@ -394,6 +408,9 @@ class xFuserWan22DistilledI2VModel(xFuserWan22I2VModel):
                 f"Wan2.2-Distilled-I2V uses a fixed 4-step schedule; "
                 f"num_inference_steps must be 4, got {steps}."
             )
+        guidance_scale = input_args.get("guidance_scale")
+        if guidance_scale != 1.0:
+            log(f"Using guidance_scale=1.0. Other guindance scale values are not supported with this model.")
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
         # Guidance is baked into the distilled weights. guidance_scale=1.0 keeps

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -376,6 +376,25 @@ class xFuserWan22DistilledI2VModel(xFuserWan22I2VModel):
         pipe.scheduler = _DistilledWanScheduler()
         return pipe
 
+    def _validate_args(self, input_args: dict) -> None:
+        super()._validate_args(input_args)
+        if not self.config.distilled_transformer_path:
+            raise ValueError(
+                "--distilled_transformer_path is required for Wan2.2-Distilled-I2V "
+                "(path to high-noise safetensors file)."
+            )
+        if not self.config.distilled_transformer_2_path:
+            raise ValueError(
+                "--distilled_transformer_2_path is required for Wan2.2-Distilled-I2V "
+                "(path to low-noise safetensors file)."
+            )
+        steps = input_args.get("num_inference_steps")
+        if steps != 4:
+            raise ValueError(
+                f"Wan2.2-Distilled-I2V uses a fixed 4-step schedule; "
+                f"num_inference_steps must be 4, got {steps}."
+            )
+
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
         # Guidance is baked into the distilled weights. guidance_scale=1.0 keeps
         # do_classifier_free_guidance=False, so negative_prompt has no effect.

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -3,8 +3,7 @@ import re
 import torch
 from typing import List
 from PIL import Image
-from typing import List
-from diffusers import WanPipeline
+from diffusers import FlowMatchEulerDiscreteScheduler, WanPipeline
 from diffusers.pipelines.pipeline_utils import DiffusionPipeline
 from diffusers import AutoencoderKLWan, WanVACEPipeline
 from diffusers.utils import load_image
@@ -131,6 +130,33 @@ def _load_distilled_weights(model: torch.nn.Module, path: str) -> None:
     raw = load_file(path, device="cpu")
     remapped = {_remap_lightx2v_to_diffusers(k): v for k, v in raw.items()}
     model.load_state_dict(remapped, strict=True)
+
+
+def _distilled_scheduler_sigmas() -> torch.Tensor:
+    """Sigmas (including terminal 0) for Wan2.2 I2V 4-step distilled schedule.
+
+    LightX2V distilled Wan2.2 uses sample_shift=5 and denoising_step_list=[1000, 750, 500, 250]:
+      σ_linear indices [0, 250, 500, 750] → shifted → [1.0, 0.9375, 0.8333, 0.625]
+      timesteps = σ * 1000               →           [1000, 937.5, 833.3, 625.0]
+    """
+    sample_shift = 5.0
+    sigma_linear = torch.linspace(1.0, 0.0, 1001)[:-1]
+    sigma_shifted = sample_shift * sigma_linear / (1.0 + (sample_shift - 1.0) * sigma_linear)
+    indices = [0, 250, 500, 750]  # 1000 - [1000, 750, 500, 250]
+    return torch.cat([sigma_shifted[indices], torch.zeros(1)])
+
+
+class _DistilledWanScheduler(FlowMatchEulerDiscreteScheduler):
+    """FlowMatchEulerDiscreteScheduler with fixed 4-step sigmas for LightX2V Wan2.2 distilled inference."""
+
+    def set_timesteps(self, num_inference_steps, device=None, **kwargs):
+        self.num_inference_steps = num_inference_steps
+        dev = torch.device(device) if device else torch.device("cpu")
+        sigmas = _distilled_scheduler_sigmas().to(dev)
+        self.sigmas = sigmas
+        self.timesteps = sigmas[:-1] * self.config.num_train_timesteps
+        self._step_index = None
+        self._begin_index = None
 
 
 @register_model("Wan-AI/Wan2.1-I2V-14B-720P-Diffusers")
@@ -300,12 +326,13 @@ class xFuserWan22DistilledI2VModel(xFuserWan22I2VModel):
     replaces the transformer weights from LightX2V BF16 distilled checkpoints.
 
     Required extra args (passed via xFuserArgs or runner config):
-        distilled_transformer_path:   path to high-noise .safetensors  (transformer)
-        distilled_transformer_2_path: path to low-noise  .safetensors  (transformer_2)
+        distilled_transformer_path:   path to high-noise .safetensors (transformer)
+        distilled_transformer_2_path: path to low-noise .safetensors (transformer_2)
     """
 
-    # boundary_step_index=2 out of 4 steps → t_boundary = 500 / 1000 = 0.5
-    _BOUNDARY_RATIO = 0.5
+    # LightX2V boundary_step_index=2 (step-index comparison) maps to a timestep threshold
+    # between shifted t[1]≈937 and t[2]≈833. 0.9 → threshold 900 correctly splits 2+2.
+    _BOUNDARY_RATIO = 0.9
     _BASE_MODEL = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
 
     default_input_values = DefaultInputValues(
@@ -313,10 +340,10 @@ class xFuserWan22DistilledI2VModel(xFuserWan22I2VModel):
         width=1280,
         num_frames=81,
         num_inference_steps=4,
-        guidance_scale=3.5,
-        guidance_scale_2=3.5,
-        flow_shift=5.0,
-        num_hybrid_attn_high_precision_steps=5,
+        guidance_scale=1.0,
+        guidance_scale_2=None,
+        flow_shift=5,
+        num_hybrid_attn_high_precision_steps=1,
     )
 
     def __init__(self, config: xFuserArgs) -> None:
@@ -346,7 +373,24 @@ class xFuserWan22DistilledI2VModel(xFuserWan22I2VModel):
             transformer_2=transformer_2,
             boundary_ratio=self._BOUNDARY_RATIO,
         )
+        pipe.scheduler = _DistilledWanScheduler()
         return pipe
+
+    def _run_pipe(self, input_args: dict) -> DiffusionOutput:
+        # Guidance is baked into the distilled weights. guidance_scale=1.0 keeps
+        # do_classifier_free_guidance=False, so negative_prompt has no effect.
+        output = self.pipe(
+            image=input_args["image"],
+            height=input_args["height"],
+            width=input_args["width"],
+            prompt=input_args["prompt"],
+            num_inference_steps=input_args["num_inference_steps"],
+            num_frames=input_args["num_frames"],
+            guidance_scale=1.0,
+            guidance_scale_2=None,
+            generator=torch.Generator(device="cuda").manual_seed(input_args["seed"]),
+        )
+        return DiffusionOutput(videos=output.frames, pipe_args=input_args)
 
 
 @register_model("Wan-AI/Wan2.1-T2V-14B-Diffusers")

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -1,4 +1,5 @@
 import copy
+import re
 import torch
 from typing import List
 from PIL import Image
@@ -7,6 +8,7 @@ from diffusers import WanPipeline
 from diffusers.pipelines.pipeline_utils import DiffusionPipeline
 from diffusers import AutoencoderKLWan, WanVACEPipeline
 from diffusers.utils import load_image
+from safetensors.torch import load_file
 
 from xfuser import xFuserArgs
 from xfuser.model_executor.models.transformers.transformer_wan import xFuserWanTransformer3DWrapper
@@ -94,6 +96,41 @@ def _setup_parallel_vae(vae, enable_parallel_encoder: bool = True) -> None:
         )
     except Exception as e:
         raise ValueError(f"Failed to patch VAE decoder. {e}")
+
+
+def _remap_lightx2v_to_diffusers(k: str) -> str:
+    """Remap a LightX2V-format state dict key to the diffusers WanTransformer3DModel naming."""
+    k = re.sub(r'\.self_attn\.q\.', '.attn1.to_q.', k)
+    k = re.sub(r'\.self_attn\.k\.', '.attn1.to_k.', k)
+    k = re.sub(r'\.self_attn\.v\.', '.attn1.to_v.', k)
+    k = re.sub(r'\.self_attn\.o\.', '.attn1.to_out.0.', k)
+    k = re.sub(r'\.self_attn\.norm_q\.', '.attn1.norm_q.', k)
+    k = re.sub(r'\.self_attn\.norm_k\.', '.attn1.norm_k.', k)
+    k = re.sub(r'\.cross_attn\.q\.', '.attn2.to_q.', k)
+    k = re.sub(r'\.cross_attn\.k\.', '.attn2.to_k.', k)
+    k = re.sub(r'\.cross_attn\.v\.', '.attn2.to_v.', k)
+    k = re.sub(r'\.cross_attn\.o\.', '.attn2.to_out.0.', k)
+    k = re.sub(r'\.cross_attn\.norm_q\.', '.attn2.norm_q.', k)
+    k = re.sub(r'\.cross_attn\.norm_k\.', '.attn2.norm_k.', k)
+    k = re.sub(r'\.ffn\.0\.', '.ffn.net.0.proj.', k)
+    k = re.sub(r'\.ffn\.2\.', '.ffn.net.2.', k)
+    k = re.sub(r'\.norm3\.', '.norm2.', k)
+    k = re.sub(r'(blocks\.\d+)\.modulation$', r'\1.scale_shift_table', k)
+    k = re.sub(r'^head\.head\.', 'proj_out.', k)
+    k = re.sub(r'^head\.modulation$', 'scale_shift_table', k)
+    k = re.sub(r'^text_embedding\.0\.', 'condition_embedder.text_embedder.linear_1.', k)
+    k = re.sub(r'^text_embedding\.2\.', 'condition_embedder.text_embedder.linear_2.', k)
+    k = re.sub(r'^time_embedding\.0\.', 'condition_embedder.time_embedder.linear_1.', k)
+    k = re.sub(r'^time_embedding\.2\.', 'condition_embedder.time_embedder.linear_2.', k)
+    k = re.sub(r'^time_projection\.1\.', 'condition_embedder.time_proj.', k)
+    return k
+
+
+def _load_distilled_weights(model: torch.nn.Module, path: str) -> None:
+    """Load a LightX2V distilled safetensors checkpoint into a diffusers WanTransformer3DModel."""
+    raw = load_file(path, device="cpu")
+    remapped = {_remap_lightx2v_to_diffusers(k): v for k, v in raw.items()}
+    model.load_state_dict(remapped, strict=True)
 
 
 @register_model("Wan-AI/Wan2.1-I2V-14B-720P-Diffusers")
@@ -253,6 +290,63 @@ class xFuserWan22I2VModel(xFuserWan21I2VModel):
         self.pipe.transformer_2 = torch.compile(self.pipe.transformer_2, mode="default")
         # Full cycle to warmup the torch compiler
         self._run_timed_pipe(input_args)
+
+
+@register_model("Wan2.2-Distilled-I2V")
+class xFuserWan22DistilledI2VModel(xFuserWan22I2VModel):
+    """Wan2.2 I2V with LightX2V 4-step distilled weights.
+
+    Loads the base diffusers architecture from Wan-AI/Wan2.2-I2V-A14B-Diffusers and
+    replaces the transformer weights from LightX2V BF16 distilled checkpoints.
+
+    Required extra args (passed via xFuserArgs or runner config):
+        distilled_transformer_path:   path to high-noise .safetensors  (transformer)
+        distilled_transformer_2_path: path to low-noise  .safetensors  (transformer_2)
+    """
+
+    # boundary_step_index=2 out of 4 steps → t_boundary = 500 / 1000 = 0.5
+    _BOUNDARY_RATIO = 0.5
+    _BASE_MODEL = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
+
+    default_input_values = DefaultInputValues(
+        height=720,
+        width=1280,
+        num_frames=81,
+        num_inference_steps=4,
+        guidance_scale=3.5,
+        guidance_scale_2=3.5,
+        flow_shift=5.0,
+        num_hybrid_attn_high_precision_steps=5,
+    )
+
+    def __init__(self, config: xFuserArgs) -> None:
+        self.settings.model_name = self._BASE_MODEL
+        self.settings.output_name = "wan2.2_distilled_i2v"
+        super().__init__(config)
+
+    def _load_model(self) -> DiffusionPipeline:
+        transformer = xFuserWanTransformer3DWrapper.from_pretrained(
+            pretrained_model_name_or_path=self._BASE_MODEL,
+            torch_dtype=torch.bfloat16,
+            subfolder="transformer",
+            attention_kwargs=_build_attention_kwargs(self.config),
+        )
+        transformer_2 = xFuserWanTransformer3DWrapper.from_pretrained(
+            pretrained_model_name_or_path=self._BASE_MODEL,
+            torch_dtype=torch.bfloat16,
+            subfolder="transformer_2",
+            attention_kwargs=_build_attention_kwargs(self.config),
+        )
+        _load_distilled_weights(transformer,   self.config.distilled_transformer_path)
+        _load_distilled_weights(transformer_2, self.config.distilled_transformer_2_path)
+        pipe = xFuserWanImageToVideoPipeline.from_pretrained(
+            pretrained_model_name_or_path=self._BASE_MODEL,
+            torch_dtype=torch.bfloat16,
+            transformer=transformer,
+            transformer_2=transformer_2,
+            boundary_ratio=self._BOUNDARY_RATIO,
+        )
+        return pipe
 
 
 @register_model("Wan-AI/Wan2.1-T2V-14B-Diffusers")

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -389,7 +389,7 @@ class xFuserWan22DistilledI2VModel(xFuserWan22I2VModel):
             transformer_2=transformer_2,
             boundary_ratio=self._BOUNDARY_RATIO,
         )
-        pipe.scheduler = _DistilledWanScheduler()
+        pipe.scheduler = _DistilledWanScheduler.from_config(pipe.scheduler.config)
         return pipe
 
     def _validate_args(self, input_args: dict) -> None:

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -371,12 +371,14 @@ class xFuserWan22DistilledI2VModel(xFuserWan22I2VModel):
             torch_dtype=torch.bfloat16,
             subfolder="transformer",
             attention_kwargs=_build_attention_kwargs(self.config),
+            low_cpu_mem_usage=True,
         )
         transformer_2 = xFuserWanTransformer3DWrapper.from_pretrained(
             pretrained_model_name_or_path=self._BASE_MODEL,
             torch_dtype=torch.bfloat16,
             subfolder="transformer_2",
             attention_kwargs=_build_attention_kwargs(self.config),
+            low_cpu_mem_usage=True,
         )
         _load_distilled_weights(transformer,   self.config.distilled_transformer_path)
         _load_distilled_weights(transformer_2, self.config.distilled_transformer_2_path)


### PR DESCRIPTION
## Summary

Adds support for `Wan2.2-Distilled-I2V`, a 4-step distilled version of Wan2.2 I2V using weights from [lightx2v/Wan2.2-Distill-Models](https://huggingface.co/lightx2v/Wan2.2-Distill-Models). The model produces full-quality 720p video in 4 denoising steps instead of 40. The model architecture is identical to Wan2.2-I2V with different scheduler, guidance baked into model and it works only with 4 steps. All existing xDiT parallelism strategies, attention and GEMM precision optimizations work with `Wan2.2-Distilled-I2V` if they are supported for Wan2.2.

## Design

The base architecture is identical to `Wan-AI/Wan2.2-I2V-A14B-Diffusers`. No new transformer code is needed. The integration required three non-trivial pieces:

**Weight remapping.** LightX2V and diffusers use different state dict key conventions (e.g. `blocks.N.self_attn.q.` -> `blocks.N.attn1.to_q.`). A pure regex remap function maps all 1095 keys bijectively and is verified with `strict=True` load.

**Fixed sigma schedule.** The distilled model uses a non-standard 4-step sigma schedule derived from `sample_shift=5.0` and
`denoising_step_list=[1000, 750, 500, 250]`. This is implemented as a `FlowMatchEulerDiscreteScheduler` subclass (`_DistilledWanScheduler`) that overrides `set_timesteps` to always use the fixed sigmas regardless of the `num_inference_steps` argument.

**MoE transformer routing.** The Wan2.2 MoE pipeline routes high-noise steps (t ≥ 900) to `transformer` and low-noise steps (t < 900) to `transformer_2` via the existing `boundary_ratio` mechanism. `boundary_ratio=0.9` puts the threshold between the shifted timesteps at step 1 (≈937) and step 2 (≈833), giving a 2+2 split. Guidance is baked into the distilled weights so `guidance_scale=1.0` is enforced internally.

## Files changed

| File | Change |
|---|---|
| `xfuser/model_executor/models/runner_models/wan.py` | New model class, remap function, weight loader, scheduler subclass |
| `xfuser/config/args.py` | Two new CLI args: `--distilled_transformer_path`, `--distilled_transformer_2_path` |
|  `xfuser/model_executor/models/runner_models/base_model.py` | New model capability `supports_distilled_weights` (default is False) |
| `tests/test_wan_distilled.py` | 41 CPU-only unit tests (key remapping, sigma schedule, scheduler, validation) |
| `README.md` | New model row in capabilities and diffusers version tables |
| `docs/runner/runner.md` | New model entry, model-specific args section, usage example |

## Test plan

- [x] `pytest tests/test_wan_distilled.py -v` — all 41 tests pass (CPU-only, no GPU required)
- [x] Single-GPU inference with correct weight order produces coherent video
- [x] Passing wrong `num_inference_steps` raises `ValueError` immediately
- [x] Omitting either weight path raises `ValueError` immediately
- [x] Multi-GPU (Ulysses) produces output matching single-GPU

## Usage

```bash
xdit --model Wan2.2-Distilled-I2V \
    --distilled_transformer_path   /path/to/wan2.2_i2v_A14b_high_noise_lightx2v_4step_720p_260412.safetensors \
    --distilled_transformer_2_path /path/to/wan2.2_i2v_A14b_low_noise_lightx2v_4step_720p_260412.safetensors \
    --input_images /path/to/image.jpg \
    --prompt "..." \
    --num_inference_steps 4 \
    --ulysses_degree 8
```
Argument order matters: 
- `--distilled_transformer_path` must be the high-noise file; 
- `--distilled_transformer_2_path` the low-noise file.
Swapping them produces severely corrupted output. The filenames from the HF repo contain high_noise/low_noise explicitly.

## Example video

https://github.com/user-attachments/assets/6c170ac9-bfa9-4d7b-ac7a-a455e55cb58d

