### PR TITLE
Aiter sage ring attention

### DIFF
--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -53,13 +53,14 @@ def _check_aiter_fp8_has_descale():
         AITER_FP8_HAS_DESCALE = False
     return AITER_FP8_HAS_DESCALE
 
-def _check_aiter_sage_has_return_lse():
+def _check_aiter_sage_supports_ring():
     try:
-        return inspect.signature(fav3_sage_wrapper_func).parameters.get("return_lse") is not None
+        parameters = inspect.signature(fav3_sage_wrapper_func).parameters
+        return "return_lse" in parameters and "smooth_k" in parameters
     except (NameError, ImportError, AttributeError, TypeError):
         return False
 
-def _check_aiter_sage_v2_has_return_lse():
+def _check_aiter_sage_v2_supports_ring():
     try:
         return inspect.signature(fav3_sage_mxfp4_wrapper).parameters.get("return_lse") is not None
     except (NameError, ImportError, AttributeError, TypeError):
@@ -336,8 +337,8 @@ if env_info["has_aiter"]:
     AITER_FP8_STATIC_SCALE_WITH_DESCALE, AITER_FP8_STATIC_SCALE_NO_DESCALE, AITER_SAGE_V2_BLOCK_R = _setup_aiter_environment_variables()
     AITER_HAS_ROUND_MODE, HOW_V3_BF16_CVT = _check_aiter_round_mode()
     AITER_FP8_HAS_DESCALE = _check_aiter_fp8_has_descale()
-    AITER_SAGE_HAS_RETURN_LSE = _check_aiter_sage_has_return_lse()
-    AITER_SAGE_V2_HAS_RETURN_LSE = _check_aiter_sage_v2_has_return_lse()
+    AITER_SAGE_SUPPORTS_RING = _check_aiter_sage_supports_ring()
+    AITER_SAGE_V2_SUPPORTS_RING = _check_aiter_sage_v2_supports_ring()
     HADAMARD_MATRIX = _aiter_sage_v2_hadamard_matrix(AITER_SAGE_V2_BLOCK_R)
     _TRITON_SSTA_BLOCK_SIZE = 128
     
@@ -771,8 +772,8 @@ def npu_flash_attn_call(query, key, value, dropout_p, is_causal, attention_kwarg
 @register_attention_function(AttentionBackendType.AITER_SAGE)
 def _aiter_sage_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs=None):
     # Pass layout="bhsd" to avoid permutation
-    if AITER_SAGE_HAS_RETURN_LSE and get_ring_parallel_world_size() > 1:
-        attn_fn = functools.partial(fav3_sage_wrapper_func, layout="bhsd", return_lse=True)
+    if AITER_SAGE_SUPPORTS_RING and get_ring_parallel_world_size() > 1:
+        attn_fn = functools.partial(fav3_sage_wrapper_func, layout="bhsd", return_lse=True, smooth_k=True)
         output, softmax_lse = attn_fn(query, key, value)
     else:
         attn_fn = functools.partial(fav3_sage_wrapper_func, layout="bhsd")
@@ -788,7 +789,7 @@ def _aiter_sage_v2_attn_call(query, key, value, dropout_p, is_causal, attention_
     query = query.contiguous()
     key = key.contiguous()
     value = value.contiguous()
-    if AITER_SAGE_V2_HAS_RETURN_LSE and get_ring_parallel_world_size() > 1:
+    if AITER_SAGE_V2_SUPPORTS_RING and get_ring_parallel_world_size() > 1:
         attn_fn = functools.partial(fav3_sage_mxfp4_wrapper, layout="bhsd", hadamard_rotation=True, R=HADAMARD_MATRIX[query.device], return_lse=True)
         output, softmax_lse = attn_fn(query, key, value, causal=is_causal)
     else:

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -59,6 +59,12 @@ def _check_aiter_sage_has_return_lse():
     except (NameError, ImportError, AttributeError, TypeError):
         return False
 
+def _check_aiter_sage_v2_has_return_lse():
+    try:
+        return inspect.signature(fav3_sage_mxfp4_wrapper).parameters.get("return_lse") is not None
+    except (NameError, ImportError, AttributeError, TypeError):
+        return False
+
 def _aiter_sage_v2_hadamard_matrix(block_r):
     hadamard_matrix = {}
     try:
@@ -331,6 +337,7 @@ if env_info["has_aiter"]:
     AITER_HAS_ROUND_MODE, HOW_V3_BF16_CVT = _check_aiter_round_mode()
     AITER_FP8_HAS_DESCALE = _check_aiter_fp8_has_descale()
     AITER_SAGE_HAS_RETURN_LSE = _check_aiter_sage_has_return_lse()
+    AITER_SAGE_V2_HAS_RETURN_LSE = _check_aiter_sage_v2_has_return_lse()
     HADAMARD_MATRIX = _aiter_sage_v2_hadamard_matrix(AITER_SAGE_V2_BLOCK_R)
     _TRITON_SSTA_BLOCK_SIZE = 128
     
@@ -781,9 +788,13 @@ def _aiter_sage_v2_attn_call(query, key, value, dropout_p, is_causal, attention_
     query = query.contiguous()
     key = key.contiguous()
     value = value.contiguous()
-    softmax_lse = None
-    attn_fn = functools.partial(fav3_sage_mxfp4_wrapper, layout="bhsd", hadamard_rotation=True, R=HADAMARD_MATRIX[query.device])
-    output = attn_fn(query, key, value, causal=is_causal)
+    if AITER_SAGE_V2_HAS_RETURN_LSE and get_ring_parallel_world_size() > 1:
+        attn_fn = functools.partial(fav3_sage_mxfp4_wrapper, layout="bhsd", hadamard_rotation=True, R=HADAMARD_MATRIX[query.device], return_lse=True)
+        output, softmax_lse = attn_fn(query, key, value, causal=is_causal)
+    else:
+        attn_fn = functools.partial(fav3_sage_mxfp4_wrapper, layout="bhsd", hadamard_rotation=True, R=HADAMARD_MATRIX[query.device])
+        output = attn_fn(query, key, value, causal=is_causal)
+        softmax_lse = None
     return output, softmax_lse
 
 

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -11,7 +11,7 @@ from xfuser.core.distributed.ssta import (
     untile_ssta_output,
     expand_block_mask,
 )
-from xfuser.core.distributed import get_ulysses_parallel_world_size
+from xfuser.core.distributed import get_ulysses_parallel_world_size, get_ring_parallel_world_size
 from xfuser.core.sparge_attention.sparge import (
     setup_sparge,
     compute_sparge_block_mask,
@@ -764,7 +764,7 @@ def npu_flash_attn_call(query, key, value, dropout_p, is_causal, attention_kwarg
 @register_attention_function(AttentionBackendType.AITER_SAGE)
 def _aiter_sage_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs=None):
     # Pass layout="bhsd" to avoid permutation
-    if AITER_SAGE_HAS_RETURN_LSE:
+    if AITER_SAGE_HAS_RETURN_LSE and get_ring_parallel_world_size() > 1:
         attn_fn = functools.partial(fav3_sage_wrapper_func, layout="bhsd", return_lse=True)
         output, softmax_lse = attn_fn(query, key, value)
     else:

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -53,6 +53,12 @@ def _check_aiter_fp8_has_descale():
         AITER_FP8_HAS_DESCALE = False
     return AITER_FP8_HAS_DESCALE
 
+def _check_aiter_sage_has_return_lse():
+    try:
+        return inspect.signature(fav3_sage_wrapper_func).parameters.get("return_lse") is not None
+    except (NameError, ImportError, AttributeError, TypeError):
+        return False
+
 def _aiter_sage_v2_hadamard_matrix(block_r):
     hadamard_matrix = {}
     try:
@@ -324,6 +330,7 @@ if env_info["has_aiter"]:
     AITER_FP8_STATIC_SCALE_WITH_DESCALE, AITER_FP8_STATIC_SCALE_NO_DESCALE, AITER_SAGE_V2_BLOCK_R = _setup_aiter_environment_variables()
     AITER_HAS_ROUND_MODE, HOW_V3_BF16_CVT = _check_aiter_round_mode()
     AITER_FP8_HAS_DESCALE = _check_aiter_fp8_has_descale()
+    AITER_SAGE_HAS_RETURN_LSE = _check_aiter_sage_has_return_lse()
     HADAMARD_MATRIX = _aiter_sage_v2_hadamard_matrix(AITER_SAGE_V2_BLOCK_R)
     _TRITON_SSTA_BLOCK_SIZE = 128
     
@@ -757,8 +764,13 @@ def npu_flash_attn_call(query, key, value, dropout_p, is_causal, attention_kwarg
 @register_attention_function(AttentionBackendType.AITER_SAGE)
 def _aiter_sage_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs=None):
     # Pass layout="bhsd" to avoid permutation
-    attn_fn = functools.partial(fav3_sage_wrapper_func, layout="bhsd", return_lse=True)
-    output, softmax_lse = attn_fn(query, key, value)
+    if AITER_SAGE_HAS_RETURN_LSE:
+        attn_fn = functools.partial(fav3_sage_wrapper_func, layout="bhsd", return_lse=True)
+        output, softmax_lse = attn_fn(query, key, value)
+    else:
+        attn_fn = functools.partial(fav3_sage_wrapper_func, layout="bhsd")
+        output = attn_fn(query, key, value)
+        softmax_lse = None
     return output, softmax_lse
 
 @register_attention_function(AttentionBackendType.AITER_SAGE_V2)

--- a/xfuser/core/distributed/runtime_state.py
+++ b/xfuser/core/distributed/runtime_state.py
@@ -231,6 +231,17 @@ class RuntimeState(metaclass=ABCMeta):
                         raise RuntimeError("AITER Sage attention does not support return_lse, please update AITER")
                     if not has_smooth_k:
                         raise RuntimeError("AITER Sage attention is missing the smooth_k LSE correction required for ring parallelism, please update AITER")
+                elif attention_backend == AttentionBackendType.AITER_SAGE_V2:
+                    try:
+                        from aiter.ops.triton.attention.fav3_sage_attention_mxfp4_wrapper import fav3_sage_mxfp4_wrapper
+                    except ImportError:
+                        raise RuntimeError("AITER Sage V2 attention is not available, please update AITER") from None
+                    try:
+                        has_lse = inspect.signature(fav3_sage_mxfp4_wrapper).parameters.get("return_lse") is not None
+                    except (AttributeError, TypeError):
+                        has_lse = False
+                    if not has_lse:
+                        raise RuntimeError("AITER Sage V2 attention does not support return_lse, please update AITER")
                 else:
                     raise RuntimeError("Selected attention backend does not support ring parallelism.")
         if attention_backend == AttentionBackendType.AITER_FP8:

--- a/xfuser/core/distributed/runtime_state.py
+++ b/xfuser/core/distributed/runtime_state.py
@@ -214,7 +214,19 @@ class RuntimeState(metaclass=ABCMeta):
                                  AttentionBackendType.AITER_SPARSE_SAGE_V2,
                                  AttentionBackendType.FLEX_BLOCK_ATTN]:
             if self.parallel_config.ring_degree > 1:
-                raise RuntimeError("Selected attention backend does not support ring parallelism.")
+                if attention_backend == AttentionBackendType.AITER_SAGE:
+                    try:
+                        from aiter.ops.triton.attention.fav3_sage import fav3_sage_wrapper_func
+                    except ImportError:
+                        raise RuntimeError("AITER Sage attention is not available, please update AITER") from None
+                    try:
+                        has_lse = inspect.signature(fav3_sage_wrapper_func).parameters.get("return_lse") is not None
+                    except (AttributeError, TypeError):
+                        has_lse = False
+                    if not has_lse:
+                        raise RuntimeError("AITER Sage attention does not support return_lse, please update AITER")
+                else:
+                    raise RuntimeError("Selected attention backend does not support ring parallelism.")
         if attention_backend == AttentionBackendType.AITER_FP8:
             try:
                 from aiter import flash_attn_fp8_pertensor_func

--- a/xfuser/core/distributed/runtime_state.py
+++ b/xfuser/core/distributed/runtime_state.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta
+import importlib
 import inspect
 import random
 from typing import List, Optional
@@ -214,36 +215,40 @@ class RuntimeState(metaclass=ABCMeta):
                                  AttentionBackendType.AITER_SPARSE_SAGE_V2,
                                  AttentionBackendType.FLEX_BLOCK_ATTN]:
             if self.parallel_config.ring_degree > 1:
+                # Ring parallelism merges per-rank attention outputs via LSE, so
+                # the wrapper must expose return_lse (and, for AITER_SAGE,
+                # smooth_k -- shipped with the LSE-correction fix needed for
+                # correct merging). Pick (module, symbol, required params)
+                # for the selected backend and validate the wrapper's signature.
                 if attention_backend == AttentionBackendType.AITER_SAGE:
-                    try:
-                        from aiter.ops.triton.attention.fav3_sage import fav3_sage_wrapper_func
-                    except ImportError:
-                        raise RuntimeError("AITER Sage attention is not available, please update AITER") from None
-                    try:
-                        has_lse = inspect.signature(fav3_sage_wrapper_func).parameters.get("return_lse") is not None
-                        # Check if the function has a smooth_k parameter, this parameter was shipped with a fix for the lse computation, 
-                        # needed for correct ring-attention merging.
-                        has_smooth_k = inspect.signature(fav3_sage_wrapper_func).parameters.get("smooth_k") is not None
-                    except (AttributeError, TypeError):
-                        has_lse = False
-                        has_smooth_k = False
-                    if not has_lse:
-                        raise RuntimeError("AITER Sage attention does not support return_lse, please update AITER")
-                    if not has_smooth_k:
-                        raise RuntimeError("AITER Sage attention is missing the smooth_k LSE correction required for ring parallelism, please update AITER")
+                    module_path = "aiter.ops.triton.attention.fav3_sage"
+                    symbol = "fav3_sage_wrapper_func"
+                    required = ("return_lse", "smooth_k")
                 elif attention_backend == AttentionBackendType.AITER_SAGE_V2:
-                    try:
-                        from aiter.ops.triton.attention.fav3_sage_attention_mxfp4_wrapper import fav3_sage_mxfp4_wrapper
-                    except ImportError:
-                        raise RuntimeError("AITER Sage V2 attention is not available, please update AITER") from None
-                    try:
-                        has_lse = inspect.signature(fav3_sage_mxfp4_wrapper).parameters.get("return_lse") is not None
-                    except (AttributeError, TypeError):
-                        has_lse = False
-                    if not has_lse:
-                        raise RuntimeError("AITER Sage V2 attention does not support return_lse, please update AITER")
+                    module_path = "aiter.ops.triton.attention.fav3_sage_attention_mxfp4_wrapper"
+                    symbol = "fav3_sage_mxfp4_wrapper"
+                    required = ("return_lse",)
                 else:
-                    raise RuntimeError("Selected attention backend does not support ring parallelism.")
+                    raise RuntimeError(
+                        "Selected attention backend does not support ring parallelism."
+                    )
+                try:
+                    fn = getattr(importlib.import_module(module_path), symbol)
+                except ImportError:
+                    raise RuntimeError(
+                        f"{attention_backend.value} attention is not available, "
+                        "please update AITER"
+                    ) from None
+                try:
+                    params = inspect.signature(fn).parameters
+                except (AttributeError, TypeError):
+                    params = {}
+                missing = [p for p in required if p not in params]
+                if missing:
+                    raise RuntimeError(
+                        f"{attention_backend.value} attention is missing {missing} "
+                        "required for ring parallelism, please update AITER"
+                    )
         if attention_backend == AttentionBackendType.AITER_FP8:
             try:
                 from aiter import flash_attn_fp8_pertensor_func

--- a/xfuser/core/distributed/runtime_state.py
+++ b/xfuser/core/distributed/runtime_state.py
@@ -217,7 +217,7 @@ class RuntimeState(metaclass=ABCMeta):
             if self.parallel_config.ring_degree > 1:
                 # Ring parallelism merges per-rank attention outputs via LSE, so
                 # the wrapper must expose return_lse (and, for AITER_SAGE,
-                # smooth_k -- shipped with the LSE-correction fix needed for
+                # smooth_k, shipped with the LSE-correction fix needed for
                 # correct merging). Pick (module, symbol, required params)
                 # for the selected backend and validate the wrapper's signature.
                 if attention_backend == AttentionBackendType.AITER_SAGE:

--- a/xfuser/core/distributed/runtime_state.py
+++ b/xfuser/core/distributed/runtime_state.py
@@ -221,10 +221,16 @@ class RuntimeState(metaclass=ABCMeta):
                         raise RuntimeError("AITER Sage attention is not available, please update AITER") from None
                     try:
                         has_lse = inspect.signature(fav3_sage_wrapper_func).parameters.get("return_lse") is not None
+                        # Check if the function has a smooth_k parameter, this parameter was shipped with a fix for the lse computation, 
+                        # needed for correct ring-attention merging.
+                        has_smooth_k = inspect.signature(fav3_sage_wrapper_func).parameters.get("smooth_k") is not None
                     except (AttributeError, TypeError):
                         has_lse = False
+                        has_smooth_k = False
                     if not has_lse:
                         raise RuntimeError("AITER Sage attention does not support return_lse, please update AITER")
+                    if not has_smooth_k:
+                        raise RuntimeError("AITER Sage attention is missing the smooth_k LSE correction required for ring parallelism, please update AITER")
                 else:
                     raise RuntimeError("Selected attention backend does not support ring parallelism.")
         if attention_backend == AttentionBackendType.AITER_FP8:


### PR DESCRIPTION
This pull request enhances support for ring parallelism in the AITER SAGE and SAGE V2 attention backends. It introduces runtime checks to ensure that required features are present in the underlying attention functions, and updates the attention call logic to use new capabilities when available.

**Ring parallelism and feature support checks:**

* Added runtime checks in `_check_if_backend_compatible_with_current_configuration` to ensure that, when using ring parallelism, the `fav3_sage_wrapper_func` (for AITER SAGE) and `fav3_sage_mxfp4_wrapper` (for AITER SAGE V2) support the `return_lse` parameter, and that AITER SAGE also supports the `smooth_k` parameter for correct LSE computation. If these are missing, a clear error message is raised instructing the user to update AITER.

**Attention backend function enhancements:**

* Added utility functions `_check_aiter_sage_has_return_lse` and `_check_aiter_sage_v2_has_return_lse` to programmatically check for the presence of the `return_lse` parameter in the respective attention functions.
* In both `_aiter_sage_attn_call` and `_aiter_sage_v2_attn_call`, updated logic to pass `return_lse=True` and handle the returned `softmax_lse` only if the underlying function supports it and ring parallelism is enabled; otherwise, defaults to previous behavior.

**Imports and dependencies:**

* Imported `get_ring_parallel_world_size` to enable ring parallelism checks in the attention backend.