### PR TITLE
feat: FP8 block-scale GEMMs via AITER for RDNA4 (gfx1200+)

### DIFF
--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -11,7 +11,7 @@ from xfuser.envs import _is_cuda, _is_hip
 logger = logging.getLogger(__name__)
 
 
-def _use_aiter_fp8_path() -> bool:
+def _use_aiter_fp8_rdna4() -> bool:
     """True on ROCm gfx1200 (Navi 44) or gfx1201 (Navi 48) with AITER present."""
     if not _is_hip():
         return False

--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -323,9 +323,7 @@ def quantize_linear_layers_to_fp8_blockscale(
                 device=module.weight.device,
                 dtype=module.weight.dtype,
             )
-            fp8_layer.load_and_quantize_weights(module.weight, module.bias)
-            if device is not None:
-                fp8_layer.to(device)
+            fp8_layer.load_and_quantize_weights(module.weight, module.bias, device=device)
             setattr(model, name, fp8_layer)
         elif next(module.children(), None) is not None:
             quantize_linear_layers_to_fp8_blockscale(module, device=device)

--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -325,7 +325,7 @@ def quantize_linear_layers_to_fp8_blockscale(
                 device=weight.device,
                 dtype=weight.dtype,
             )
-            # Free BF16 weight before FP32 quant copy to halve peak memory per layer
+            # Free BF16 weight before quantization to avoid holding two copies on GPU
             module.weight = None
             if module.bias is not None:
                 module.bias = None

--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -316,14 +316,21 @@ def quantize_linear_layers_to_fp8_blockscale(
 
     for name, module in list(model.named_children()):
         if isinstance(module, torch.nn.Linear):
+            weight = module.weight.data
+            bias = module.bias.data if module.bias is not None else None
             fp8_layer = xFuserFP8BlockScaleLinear(
                 module.in_features,
                 module.out_features,
-                bias=(module.bias is not None),
-                device=module.weight.device,
-                dtype=module.weight.dtype,
+                bias=(bias is not None),
+                device=weight.device,
+                dtype=weight.dtype,
             )
-            fp8_layer.load_and_quantize_weights(module.weight, module.bias, device=device)
+            # Free BF16 weight before FP32 quant copy to halve peak memory per layer
+            module.weight = None
+            if module.bias is not None:
+                module.bias = None
+            fp8_layer.load_and_quantize_weights(weight, bias, device=device)
+            del weight, bias
             setattr(model, name, fp8_layer)
         elif next(module.children(), None) is not None:
             quantize_linear_layers_to_fp8_blockscale(module, device=device)

--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -6,9 +6,32 @@ import functools
 import numpy as np
 from PIL.Image import Image
 from typing import Callable, Optional
-from xfuser.envs import _is_cuda
+from xfuser.envs import _is_cuda, _is_hip
 
 logger = logging.getLogger(__name__)
+
+
+def _use_aiter_fp8_path() -> bool:
+    """True on ROCm RDNA4+ (gfx1200+) with AITER present.
+
+    Restricted to gfx1200+ (RDNA4: R9700, etc.) where our AITER block-128
+    path has been validated and torchao/hipBLASLt FP8 is unavailable (ROCm 7.2.3).
+    CDNA3+ (MI300/MI350, gfx940-999) has battle-tested torchao FP8 and falls
+    through to that path instead.
+    """
+    if not _is_hip():
+        return False
+    try:
+        import aiter  # noqa: F401
+    except ImportError:
+        return False
+    import re
+    arch = torch.cuda.get_device_properties(0).gcnArchName.split(":")[0]
+    m = re.match(r"gfx(\d+)", arch)
+    if not m:
+        return False
+    n = int(m.group(1))
+    return n >= 1200
 
 def log(message: str, debug=False, log_from_all_processes: bool = False) -> None:
     """Log message. By default, only from the last process to avoid duplicates."""
@@ -278,6 +301,42 @@ def quantize_linear_layers_to_fp8(module_or_module_list_to_quantize: torch.nn.Mo
             filter_fn=filter_fn,
             device=device
         )
+
+
+def quantize_linear_layers_to_fp8_blockscale(
+    model: torch.nn.Module,
+    parent_name: str = "",
+    device: Optional[torch.device] = None,
+) -> None:
+    """Replace nn.Linear layers with xFuserFP8BlockScaleLinear (AITER gemm_a8w8_blockscale).
+
+    Mirrors quantize_linear_layers_to_fp4 structure: recursive tree walk, in-place
+    setattr replacement. Pre-quantizes weights to FP8 block-128 at call time.
+    """
+    from xfuser.model_executor.layers.fp8_linear import xFuserFP8BlockScaleLinear
+
+    for name, module in list(model.named_children()):
+        if isinstance(module, torch.nn.Linear):
+            fp8_layer = xFuserFP8BlockScaleLinear(
+                module.in_features,
+                module.out_features,
+                bias=(module.bias is not None),
+                device=module.weight.device,
+                dtype=module.weight.dtype,
+            )
+            with torch.no_grad():
+                fp8_layer.load_and_quantize_weights(module.weight, module.bias)
+            if device is not None:
+                if fp8_layer.weight_fp8 is not None:
+                    fp8_layer.weight_fp8 = fp8_layer.weight_fp8.to(device)
+                if fp8_layer.weight_scale is not None:
+                    fp8_layer.weight_scale = fp8_layer.weight_scale.to(device)
+                if fp8_layer.bias is not None:
+                    fp8_layer.bias.data = fp8_layer.bias.data.to(device)
+            setattr(model, name, fp8_layer)
+        elif len(list(module.children())) > 0:
+            full_name = f"{parent_name}.{name}" if parent_name else name
+            quantize_linear_layers_to_fp8_blockscale(module, full_name, device=device)
 
 
 def load_dataset_prompts(dataset_path: str) -> list[str]:

--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 def _use_aiter_fp8_path() -> bool:
-    """True on ROCm gfx1200+ (RDNA4) with AITER present."""
+    """True on ROCm gfx1200 (Navi 44) or gfx1201 (Navi 48) with AITER present."""
     if not _is_hip():
         return False
     try:
@@ -25,7 +25,7 @@ def _use_aiter_fp8_path() -> bool:
     if not m:
         return False
     n = int(m.group(1))
-    return n >= 1200
+    return n in {1200, 1201}
 
 def log(message: str, debug=False, log_from_all_processes: bool = False) -> None:
     """Log message. By default, only from the last process to avoid duplicates."""

--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -12,13 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 def _use_aiter_fp8_path() -> bool:
-    """True on ROCm RDNA4+ (gfx1200+) with AITER present.
-
-    Restricted to gfx1200+ (RDNA4: R9700, etc.) where our AITER block-128
-    path has been validated and torchao/hipBLASLt FP8 is unavailable (ROCm 7.2.3).
-    CDNA3+ (MI300/MI350, gfx940-999) has battle-tested torchao FP8 and falls
-    through to that path instead.
-    """
+    """True on ROCm gfx1200+ (RDNA4) with AITER present."""
     if not _is_hip():
         return False
     try:

--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -323,12 +323,11 @@ def quantize_linear_layers_to_fp8_blockscale(
                 device=module.weight.device,
                 dtype=module.weight.dtype,
             )
-            with torch.no_grad():
-                fp8_layer.load_and_quantize_weights(module.weight, module.bias)
+            fp8_layer.load_and_quantize_weights(module.weight, module.bias)
             if device is not None:
                 fp8_layer.to(device)
             setattr(model, name, fp8_layer)
-        elif len(list(module.children())) > 0:
+        elif next(module.children(), None) is not None:
             quantize_linear_layers_to_fp8_blockscale(module, device=device)
 
 

--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -6,7 +6,7 @@ import functools
 import numpy as np
 from PIL.Image import Image
 from typing import Callable, Optional
-from xfuser.envs import _is_cuda, _is_hip
+from xfuser.envs import _is_cuda, _is_hip, PACKAGES_CHECKER
 
 logger = logging.getLogger(__name__)
 
@@ -19,13 +19,7 @@ def _use_aiter_fp8_rdna4() -> bool:
         import aiter  # noqa: F401
     except ImportError:
         return False
-    import re
-    arch = torch.cuda.get_device_properties(0).gcnArchName.split(":")[0]
-    m = re.match(r"gfx(\d+)", arch)
-    if not m:
-        return False
-    n = int(m.group(1))
-    return n in {1200, 1201}
+    return PACKAGES_CHECKER._on_rdna4()
 
 def log(message: str, debug=False, log_from_all_processes: bool = False) -> None:
     """Log message. By default, only from the last process to avoid duplicates."""

--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -305,7 +305,6 @@ def quantize_linear_layers_to_fp8(module_or_module_list_to_quantize: torch.nn.Mo
 
 def quantize_linear_layers_to_fp8_blockscale(
     model: torch.nn.Module,
-    parent_name: str = "",
     device: Optional[torch.device] = None,
 ) -> None:
     """Replace nn.Linear layers with xFuserFP8BlockScaleLinear (AITER gemm_a8w8_blockscale).
@@ -327,16 +326,10 @@ def quantize_linear_layers_to_fp8_blockscale(
             with torch.no_grad():
                 fp8_layer.load_and_quantize_weights(module.weight, module.bias)
             if device is not None:
-                if fp8_layer.weight_fp8 is not None:
-                    fp8_layer.weight_fp8 = fp8_layer.weight_fp8.to(device)
-                if fp8_layer.weight_scale is not None:
-                    fp8_layer.weight_scale = fp8_layer.weight_scale.to(device)
-                if fp8_layer.bias is not None:
-                    fp8_layer.bias.data = fp8_layer.bias.data.to(device)
+                fp8_layer.to(device)
             setattr(model, name, fp8_layer)
         elif len(list(module.children())) > 0:
-            full_name = f"{parent_name}.{name}" if parent_name else name
-            quantize_linear_layers_to_fp8_blockscale(module, full_name, device=device)
+            quantize_linear_layers_to_fp8_blockscale(module, device=device)
 
 
 def load_dataset_prompts(dataset_path: str) -> list[str]:

--- a/xfuser/envs.py
+++ b/xfuser/envs.py
@@ -395,7 +395,7 @@ class PackagesEnvChecker:
     def _on_rdna4(self):
         device = torch.cuda.current_device()
         gcn_arch_name = torch.cuda.get_device_properties(device).gcnArchName
-        return "gfx1201" in gcn_arch_name
+        return any(arch in gcn_arch_name for arch in ["gfx1200", "gfx1201"])
 
 
 PACKAGES_CHECKER = PackagesEnvChecker()

--- a/xfuser/model_executor/layers/__init__.py
+++ b/xfuser/model_executor/layers/__init__.py
@@ -6,6 +6,7 @@ from .conv import xFuserConv2dWrapper
 from .embeddings import xFuserPatchEmbedWrapper
 from .feedforward import xFuserFeedForwardWrapper
 from .mxfp4_linear import xFuserMXFP4Linear
+from .fp8_linear import xFuserFP8BlockScaleLinear
 
 __all__ = [
     "xFuserLayerWrappersRegister",
@@ -16,4 +17,5 @@ __all__ = [
     "xFuserPatchEmbedWrapper",
     "xFuserFeedForwardWrapper",
     "xFuserMXFP4Linear",
+    "xFuserFP8BlockScaleLinear",
 ]

--- a/xfuser/model_executor/layers/fp8_linear.py
+++ b/xfuser/model_executor/layers/fp8_linear.py
@@ -34,6 +34,16 @@ def _(
     return torch.empty(M, N, dtype=torch.bfloat16, device=a_q.device)
 
 
+def _pad_to_multiple(t: torch.Tensor, block: int) -> tuple[torch.Tensor, bool]:
+    """Pad last two dims to multiples of block. Returns (padded, was_padded)."""
+    rows, cols = t.shape[-2], t.shape[-1]
+    r_pad = (-rows) % block
+    c_pad = (-cols) % block
+    if r_pad == 0 and c_pad == 0:
+        return t, False
+    return torch.nn.functional.pad(t, (0, c_pad, 0, r_pad)), True
+
+
 class xFuserFP8BlockScaleLinear(nn.Module):
     """
     Drop-in nn.Linear replacement using AITER gemm_a8w8_blockscale (block-128 FP8 w8a8).
@@ -50,68 +60,55 @@ class xFuserFP8BlockScaleLinear(nn.Module):
 
     def __init__(self, in_features: int, out_features: int, bias: bool = True,
                  device=None, dtype=None):
-        factory_kwargs = {"device": device, "dtype": dtype}
         super().__init__()
         self.in_features = in_features
         self.out_features = out_features
-
-        self.weight = nn.Parameter(
-            torch.empty(out_features, in_features, **factory_kwargs)
-        )
+        # weight is not allocated here — buffers are registered by load_and_quantize_weights
+        self.register_parameter("weight", None)
         if bias:
-            self.bias = nn.Parameter(torch.empty(out_features, **factory_kwargs))
+            self.bias = nn.Parameter(
+                torch.empty(out_features, device=device, dtype=dtype)
+            )
         else:
             self.register_parameter("bias", None)
 
     def load_and_quantize_weights(
-        self, weights: torch.Tensor, bias: Optional[torch.Tensor] = None
+        self, weight: torch.Tensor, bias: Optional[torch.Tensor] = None
     ) -> None:
-        with torch.no_grad():
-            self.weight.data.copy_(weights.data)
-            if bias is not None and self.bias is not None:
-                self.bias.data.copy_(bias.data)
-        self._quantize_weights()
+        self._quantize_weights(weight)
+        if bias is not None and self.bias is not None:
+            self.bias.data.copy_(bias.data)
 
-    def _quantize_weights(self) -> None:
-        if self.weight is None:
-            raise RuntimeError(
-                "Cannot quantize: weight is None. Call load_and_quantize_weights() first."
-            )
-        N, K = self.weight.shape
+    def _quantize_weights(self, weight: torch.Tensor) -> None:
+        N, K = weight.shape
         n_blocks = math.ceil(N / _FP8_BLOCK)
         k_blocks = math.ceil(K / _FP8_BLOCK)
-        N_pad = n_blocks * _FP8_BLOCK
-        K_pad = k_blocks * _FP8_BLOCK
 
-        w = self.weight.to(torch.float32)
-        if N_pad != N or K_pad != K:
-            w_padded = torch.zeros(N_pad, K_pad, dtype=torch.float32, device=w.device)
-            w_padded[:N, :K] = w
-        else:
-            w_padded = w
+        w = weight.to(torch.float32)
+        w_padded, was_padded = _pad_to_multiple(w, _FP8_BLOCK)
 
-        # [n_blocks, _FP8_BLOCK, k_blocks, _FP8_BLOCK] -> amax per [n_blocks, k_blocks]
         w_blocks = w_padded.reshape(n_blocks, _FP8_BLOCK, k_blocks, _FP8_BLOCK)
         w_amax = w_blocks.abs().amax(dim=(1, 3)).clamp(min=1e-12)  # [n_blocks, k_blocks]
         w_scale = (w_amax / _FP8_MAX).float()
 
         w_q = (w_blocks / w_amax[:, None, :, None] * _FP8_MAX).clamp(-_FP8_MAX, _FP8_MAX)
-        w_q = w_q.to(torch.float8_e4m3fn).reshape(N_pad, K_pad)[:N, :K].contiguous()
+        w_q = w_q.to(torch.float8_e4m3fn).reshape(w_padded.shape[0], w_padded.shape[1])
+        if was_padded:
+            w_q = w_q[:N, :K].contiguous()
 
-        delattr(self, "weight")
-        self.register_parameter("weight", None)
         self.register_buffer("weight_fp8", w_q, persistent=True)
         self.register_buffer("weight_scale", w_scale, persistent=True)
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         if not hasattr(self, "weight_fp8"):
-            self._quantize_weights()
+            raise RuntimeError(
+                "weight_fp8 not initialized. Call load_and_quantize_weights() first."
+            )
 
         original_shape = input.shape
         x = input.view(-1, self.in_features)
         M, K = x.shape
         k_blocks = math.ceil(K / _FP8_BLOCK)
-        K_pad = k_blocks * _FP8_BLOCK
 
         # aiter.get_hip_quant(aiter.QuantType.per_1x128) is the natural API here —
         # fused HIP kernel matching MXFP4's per_1x32 pattern — but module_quant JIT
@@ -119,17 +116,16 @@ class xFuserFP8BlockScaleLinear(nn.Module):
         #   __builtin_amdgcn_raw_ptr_buffer_load_lds needs vmem-to-lds-load-insts
         # Manual block-128 quant; torch.compile/Inductor fuses these into ~2 kernels.
         x_f32 = x.float()
-        if K_pad != K:
-            x_padded = torch.zeros(M, K_pad, dtype=torch.float32, device=x_f32.device)
-            x_padded[:, :K] = x_f32
-        else:
-            x_padded = x_f32
+        x_padded, needs_pad = _pad_to_multiple(x_f32, _FP8_BLOCK)
+        K_pad = x_padded.shape[1]
 
         x_blocks = x_padded.reshape(M, k_blocks, _FP8_BLOCK)
         x_amax = x_blocks.abs().amax(dim=-1).clamp(min=1e-12)  # [M_flat, k_blocks]
         x_scale = (x_amax / _FP8_MAX).float()
         x_q = (x_blocks / x_amax.unsqueeze(-1) * _FP8_MAX).clamp(-_FP8_MAX, _FP8_MAX)
-        x_q = x_q.to(torch.float8_e4m3fn).reshape(M, K_pad)[:, :K].contiguous()
+        x_q = x_q.to(torch.float8_e4m3fn).reshape(M, K_pad)
+        if needs_pad:
+            x_q = x_q[:, :K].contiguous()
 
         output = torch.ops.mylib.fp8_blockscale_gemm(
             x_q, x_scale, self.weight_fp8, self.weight_scale,

--- a/xfuser/model_executor/layers/fp8_linear.py
+++ b/xfuser/model_executor/layers/fp8_linear.py
@@ -73,18 +73,22 @@ class xFuserFP8BlockScaleLinear(nn.Module):
             self.register_parameter("bias", None)
 
     def load_and_quantize_weights(
-        self, weight: torch.Tensor, bias: Optional[torch.Tensor] = None
+        self, weight: torch.Tensor, bias: Optional[torch.Tensor] = None,
+        device: Optional[torch.device] = None,
     ) -> None:
-        self._quantize_weights(weight)
+        self._quantize_weights(weight, device=device)
         if bias is not None and self.bias is not None:
-            self.bias.data.copy_(bias.data)
+            target = device if device is not None else bias.device
+            self.bias = torch.nn.Parameter(bias.to(device=target, dtype=bias.dtype).detach())
 
-    def _quantize_weights(self, weight: torch.Tensor) -> None:
+    def _quantize_weights(self, weight: torch.Tensor, device: Optional[torch.device] = None) -> None:
         N, K = weight.shape
         n_blocks = math.ceil(N / _FP8_BLOCK)
         k_blocks = math.ceil(K / _FP8_BLOCK)
 
-        w = weight.to(torch.float32)
+        # Move to target device before quantization — avoids slow CPU math
+        target = device if device is not None else weight.device
+        w = weight.to(device=target, dtype=torch.float32)
         w_padded, was_padded = _pad_to_multiple(w, _FP8_BLOCK)
 
         w_blocks = w_padded.reshape(n_blocks, _FP8_BLOCK, k_blocks, _FP8_BLOCK)

--- a/xfuser/model_executor/layers/fp8_linear.py
+++ b/xfuser/model_executor/layers/fp8_linear.py
@@ -101,8 +101,12 @@ class xFuserFP8BlockScaleLinear(nn.Module):
         w_amax = w_blocks.abs().amax(dim=(1, 3)).clamp(min=1e-12)  # [n_blocks, k_blocks]
         w_scale = (w_amax.float() / _FP8_MAX)
 
-        w_q = (w_blocks / w_amax[:, None, :, None] * _FP8_MAX).clamp(-_FP8_MAX, _FP8_MAX)
-        w_q = w_q.to(torch.float8_e4m3fn).reshape(n_blocks * _FP8_BLOCK, k_blocks * _FP8_BLOCK)
+        # Process one row-block at a time to avoid a full BF16 intermediate alongside the weight.
+        # Peak: BF16 weight + FP8 output + one 128-row BF16 chunk (~0.75 MB for K=3072).
+        w_q = torch.empty_like(w_blocks, dtype=torch.float8_e4m3fn)
+        for i in range(n_blocks):
+            w_q[i] = (w_blocks[i] / w_amax[i][None, :, None] * _FP8_MAX).clamp(-_FP8_MAX, _FP8_MAX).to(torch.float8_e4m3fn)
+        w_q = w_q.reshape(n_blocks * _FP8_BLOCK, k_blocks * _FP8_BLOCK)
         if was_padded:
             w_q = w_q[:N, :K].contiguous()
 

--- a/xfuser/model_executor/layers/fp8_linear.py
+++ b/xfuser/model_executor/layers/fp8_linear.py
@@ -34,14 +34,12 @@ def _(
     return torch.empty(M, N, dtype=torch.bfloat16, device=a_q.device)
 
 
-def _pad_to_multiple(t: torch.Tensor, block: int) -> tuple[torch.Tensor, bool]:
-    """Pad last two dims to multiples of block. Returns (padded, was_padded)."""
-    rows, cols = t.shape[-2], t.shape[-1]
-    r_pad = (-rows) % block
-    c_pad = (-cols) % block
-    if r_pad == 0 and c_pad == 0:
+def _pad_cols_to_multiple(t: torch.Tensor, block: int) -> tuple[torch.Tensor, bool]:
+    """Pad last dim (cols) to a multiple of block. Returns (padded, was_padded)."""
+    c_pad = (-t.shape[-1]) % block
+    if c_pad == 0:
         return t, False
-    return torch.nn.functional.pad(t, (0, c_pad, 0, r_pad)), True
+    return torch.nn.functional.pad(t, (0, c_pad)), True
 
 
 class xFuserFP8BlockScaleLinear(nn.Module):
@@ -86,17 +84,25 @@ class xFuserFP8BlockScaleLinear(nn.Module):
         n_blocks = math.ceil(N / _FP8_BLOCK)
         k_blocks = math.ceil(K / _FP8_BLOCK)
 
-        # Move to target device before quantization — avoids slow CPU math
+        # Move to target device; stay in BF16 — FP8 cast (3 mantissa bits) dominates error,
+        # not BF16 intermediates (7 bits). Only w_amax is cast to FP32 for the stored scale.
         target = device if device is not None else weight.device
-        w = weight.to(device=target, dtype=torch.float32)
-        w_padded, was_padded = _pad_to_multiple(w, _FP8_BLOCK)
+        w = weight.to(device=target)
+        # Pad both dims for the [n_blocks, 128, k_blocks, 128] reshape
+        r_pad = (-N) % _FP8_BLOCK
+        c_pad = (-K) % _FP8_BLOCK
+        if r_pad or c_pad:
+            w = torch.nn.functional.pad(w, (0, c_pad, 0, r_pad))
+            was_padded = True
+        else:
+            was_padded = False
 
-        w_blocks = w_padded.reshape(n_blocks, _FP8_BLOCK, k_blocks, _FP8_BLOCK)
+        w_blocks = w.reshape(n_blocks, _FP8_BLOCK, k_blocks, _FP8_BLOCK)
         w_amax = w_blocks.abs().amax(dim=(1, 3)).clamp(min=1e-12)  # [n_blocks, k_blocks]
-        w_scale = (w_amax / _FP8_MAX).float()
+        w_scale = (w_amax.float() / _FP8_MAX)
 
         w_q = (w_blocks / w_amax[:, None, :, None] * _FP8_MAX).clamp(-_FP8_MAX, _FP8_MAX)
-        w_q = w_q.to(torch.float8_e4m3fn).reshape(w_padded.shape[0], w_padded.shape[1])
+        w_q = w_q.to(torch.float8_e4m3fn).reshape(n_blocks * _FP8_BLOCK, k_blocks * _FP8_BLOCK)
         if was_padded:
             w_q = w_q[:N, :K].contiguous()
 
@@ -119,13 +125,12 @@ class xFuserFP8BlockScaleLinear(nn.Module):
         # fails to build on gfx1201 with ROCm 7.2.3:
         #   __builtin_amdgcn_raw_ptr_buffer_load_lds needs vmem-to-lds-load-insts
         # Manual block-128 quant; torch.compile/Inductor fuses these into ~2 kernels.
-        x_f32 = x.float()
-        x_padded, needs_pad = _pad_to_multiple(x_f32, _FP8_BLOCK)
+        x_padded, needs_pad = _pad_cols_to_multiple(x, _FP8_BLOCK)
         K_pad = x_padded.shape[1]
 
         x_blocks = x_padded.reshape(M, k_blocks, _FP8_BLOCK)
-        x_amax = x_blocks.abs().amax(dim=-1).clamp(min=1e-12)  # [M_flat, k_blocks]
-        x_scale = (x_amax / _FP8_MAX).float()
+        x_amax = x_blocks.abs().amax(dim=-1).clamp(min=1e-12)  # [M, k_blocks]
+        x_scale = (x_amax.float() / _FP8_MAX)
         x_q = (x_blocks / x_amax.unsqueeze(-1) * _FP8_MAX).clamp(-_FP8_MAX, _FP8_MAX)
         x_q = x_q.to(torch.float8_e4m3fn).reshape(M, K_pad)
         if needs_pad:

--- a/xfuser/model_executor/layers/fp8_linear.py
+++ b/xfuser/model_executor/layers/fp8_linear.py
@@ -78,8 +78,8 @@ class xFuserFP8BlockScaleLinear(nn.Module):
 
     def _quantize_weights(self, weight: torch.Tensor, device: Optional[torch.device] = None) -> None:
         N, K = weight.shape
-        n_blocks = math.ceil(N / _FP8_BLOCK)
-        k_blocks = math.ceil(K / _FP8_BLOCK)
+        n_blocks = (N + _FP8_BLOCK - 1) // _FP8_BLOCK
+        k_blocks = (K + _FP8_BLOCK - 1) // _FP8_BLOCK
 
         target = device if device is not None else weight.device
         w = weight.to(device=target)

--- a/xfuser/model_executor/layers/fp8_linear.py
+++ b/xfuser/model_executor/layers/fp8_linear.py
@@ -110,7 +110,9 @@ class xFuserFP8BlockScaleLinear(nn.Module):
         if was_padded:
             w_q = w_q[:N, :K].contiguous()
 
-        self.register_buffer("weight_fp8", w_q, persistent=True)
+        # weight_fp8 as Parameter (not buffer) so FSDP2 shards it across ranks.
+        # requires_grad=False: inference only, no gradient needed.
+        self.weight_fp8 = nn.Parameter(w_q, requires_grad=False)
         self.register_buffer("weight_scale", w_scale, persistent=True)
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:

--- a/xfuser/model_executor/layers/fp8_linear.py
+++ b/xfuser/model_executor/layers/fp8_linear.py
@@ -133,7 +133,7 @@ class xFuserFP8BlockScaleLinear(nn.Module):
 
         output = torch.ops.mylib.fp8_blockscale_gemm(
             x_q, x_scale, self.weight_fp8, self.weight_scale,
-        )
+        ).to(input.dtype)
         if self.bias is not None:
             output = output + self.bias
         return output.view(*original_shape[:-1], self.out_features)

--- a/xfuser/model_executor/layers/fp8_linear.py
+++ b/xfuser/model_executor/layers/fp8_linear.py
@@ -46,10 +46,8 @@ class xFuserFP8BlockScaleLinear(nn.Module):
     """
     Drop-in nn.Linear replacement using AITER gemm_a8w8_blockscale (block-128 FP8 w8a8).
 
-    Weights pre-quantized at load time to float8_e4m3fn with per-block-128 scales
-    stored as persistent buffers (FSDP2-compatible, no Float8Tensor subclass or patches).
-    Activations block-quantized dynamically in forward() — ops are visible to
-    torch.compile/Inductor for fusion into ~2 kernels (reduction + elementwise).
+    Weights pre-quantized at load time to float8_e4m3fn. Activations block-quantized
+    dynamically in forward() — ops are visible to torch.compile/Inductor for fusion.
 
     Scale shapes:
         weight_scale: [ceil(N/128), ceil(K/128)]
@@ -61,7 +59,6 @@ class xFuserFP8BlockScaleLinear(nn.Module):
         super().__init__()
         self.in_features = in_features
         self.out_features = out_features
-        # weight is not allocated here — buffers are registered by load_and_quantize_weights
         self.register_parameter("weight", None)
         if bias:
             self.bias = nn.Parameter(
@@ -84,8 +81,6 @@ class xFuserFP8BlockScaleLinear(nn.Module):
         n_blocks = math.ceil(N / _FP8_BLOCK)
         k_blocks = math.ceil(K / _FP8_BLOCK)
 
-        # Move to target device; stay in BF16 — FP8 cast (3 mantissa bits) dominates error,
-        # not BF16 intermediates (7 bits). Only w_amax is cast to FP32 for the stored scale.
         target = device if device is not None else weight.device
         w = weight.to(device=target)
         # Pad both dims for the [n_blocks, 128, k_blocks, 128] reshape
@@ -101,8 +96,7 @@ class xFuserFP8BlockScaleLinear(nn.Module):
         w_amax = w_blocks.abs().amax(dim=(1, 3)).clamp(min=1e-12)  # [n_blocks, k_blocks]
         w_scale = (w_amax.float() / _FP8_MAX)
 
-        # Process one row-block at a time to avoid a full BF16 intermediate alongside the weight.
-        # Peak: BF16 weight + FP8 output + one 128-row BF16 chunk (~0.75 MB for K=3072).
+        # One row-block at a time: avoids a full BF16 intermediate alongside the weight.
         w_q = torch.empty_like(w_blocks, dtype=torch.float8_e4m3fn)
         for i in range(n_blocks):
             w_q[i] = (w_blocks[i] / w_amax[i][None, :, None] * _FP8_MAX).clamp(-_FP8_MAX, _FP8_MAX).to(torch.float8_e4m3fn)

--- a/xfuser/model_executor/layers/fp8_linear.py
+++ b/xfuser/model_executor/layers/fp8_linear.py
@@ -1,0 +1,145 @@
+import math
+import torch
+import torch.nn as nn
+from typing import Optional
+
+try:
+    import aiter
+except ImportError:
+    pass  # Error raised in base_model.py if fp8 enabled without AITER.
+
+_FP8_MAX = 448.0  # torch.finfo(torch.float8_e4m3fn).max
+_FP8_BLOCK = 128
+
+
+@torch.library.custom_op("mylib::fp8_blockscale_gemm", mutates_args=())
+def _fp8_blockscale_gemm(
+    a_q: torch.Tensor,
+    a_scale: torch.Tensor,
+    w_fp8: torch.Tensor,
+    w_scale: torch.Tensor,
+) -> torch.Tensor:
+    return aiter.gemm_a8w8_blockscale(a_q, w_fp8, a_scale, w_scale)
+
+
+@_fp8_blockscale_gemm.register_fake
+def _(
+    a_q: torch.Tensor,
+    a_scale: torch.Tensor,
+    w_fp8: torch.Tensor,
+    w_scale: torch.Tensor,
+) -> torch.Tensor:
+    M = a_q.shape[0]
+    N = w_fp8.shape[0]
+    return torch.empty(M, N, dtype=torch.bfloat16, device=a_q.device)
+
+
+class xFuserFP8BlockScaleLinear(nn.Module):
+    """
+    Drop-in nn.Linear replacement using AITER gemm_a8w8_blockscale (block-128 FP8 w8a8).
+
+    Weights pre-quantized at load time to float8_e4m3fn with per-block-128 scales
+    stored as persistent buffers (FSDP2-compatible, no Float8Tensor subclass or patches).
+    Activations block-quantized dynamically in forward() — ops are visible to
+    torch.compile/Inductor for fusion into ~2 kernels (reduction + elementwise).
+
+    Scale shapes:
+        weight_scale: [ceil(N/128), ceil(K/128)]
+        x_scale (runtime): [M, ceil(K/128)]
+    """
+
+    def __init__(self, in_features: int, out_features: int, bias: bool = True,
+                 device=None, dtype=None):
+        factory_kwargs = {"device": device, "dtype": dtype}
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+
+        self.weight = nn.Parameter(
+            torch.empty(out_features, in_features, **factory_kwargs)
+        )
+        if bias:
+            self.bias = nn.Parameter(torch.empty(out_features, **factory_kwargs))
+        else:
+            self.register_parameter("bias", None)
+
+    def load_and_quantize_weights(
+        self, weights: torch.Tensor, bias: Optional[torch.Tensor] = None
+    ) -> None:
+        with torch.no_grad():
+            self.weight.data.copy_(weights.data)
+            if bias is not None and self.bias is not None:
+                self.bias.data.copy_(bias.data)
+        self._quantize_weights()
+
+    def _quantize_weights(self) -> None:
+        if self.weight is None:
+            raise RuntimeError(
+                "Cannot quantize: weight is None. Call load_and_quantize_weights() first."
+            )
+        N, K = self.weight.shape
+        n_blocks = math.ceil(N / _FP8_BLOCK)
+        k_blocks = math.ceil(K / _FP8_BLOCK)
+        N_pad = n_blocks * _FP8_BLOCK
+        K_pad = k_blocks * _FP8_BLOCK
+
+        w = self.weight.to(torch.float32)
+        if N_pad != N or K_pad != K:
+            w_padded = torch.zeros(N_pad, K_pad, dtype=torch.float32, device=w.device)
+            w_padded[:N, :K] = w
+        else:
+            w_padded = w
+
+        # [n_blocks, _FP8_BLOCK, k_blocks, _FP8_BLOCK] -> amax per [n_blocks, k_blocks]
+        w_blocks = w_padded.reshape(n_blocks, _FP8_BLOCK, k_blocks, _FP8_BLOCK)
+        w_amax = w_blocks.abs().amax(dim=(1, 3)).clamp(min=1e-12)  # [n_blocks, k_blocks]
+        w_scale = (w_amax / _FP8_MAX).float()
+
+        w_q = (w_blocks / w_amax[:, None, :, None] * _FP8_MAX).clamp(-_FP8_MAX, _FP8_MAX)
+        w_q = w_q.to(torch.float8_e4m3fn).reshape(N_pad, K_pad)[:N, :K].contiguous()
+
+        delattr(self, "weight")
+        self.register_parameter("weight", None)
+        self.register_buffer("weight_fp8", w_q, persistent=True)
+        self.register_buffer("weight_scale", w_scale, persistent=True)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        if not hasattr(self, "weight_fp8"):
+            self._quantize_weights()
+
+        original_shape = input.shape
+        x = input.view(-1, self.in_features)
+        M, K = x.shape
+        k_blocks = math.ceil(K / _FP8_BLOCK)
+        K_pad = k_blocks * _FP8_BLOCK
+
+        # aiter.get_hip_quant(aiter.QuantType.per_1x128) is the natural API here —
+        # fused HIP kernel matching MXFP4's per_1x32 pattern — but module_quant JIT
+        # fails to build on gfx1201 with ROCm 7.2.3:
+        #   __builtin_amdgcn_raw_ptr_buffer_load_lds needs vmem-to-lds-load-insts
+        # Manual block-128 quant; torch.compile/Inductor fuses these into ~2 kernels.
+        x_f32 = x.float()
+        if K_pad != K:
+            x_padded = torch.zeros(M, K_pad, dtype=torch.float32, device=x_f32.device)
+            x_padded[:, :K] = x_f32
+        else:
+            x_padded = x_f32
+
+        x_blocks = x_padded.reshape(M, k_blocks, _FP8_BLOCK)
+        x_amax = x_blocks.abs().amax(dim=-1).clamp(min=1e-12)  # [M_flat, k_blocks]
+        x_scale = (x_amax / _FP8_MAX).float()
+        x_q = (x_blocks / x_amax.unsqueeze(-1) * _FP8_MAX).clamp(-_FP8_MAX, _FP8_MAX)
+        x_q = x_q.to(torch.float8_e4m3fn).reshape(M, K_pad)[:, :K].contiguous()
+
+        output = torch.ops.mylib.fp8_blockscale_gemm(
+            x_q, x_scale, self.weight_fp8, self.weight_scale,
+        )
+        if self.bias is not None:
+            output = output + self.bias
+        return output.view(*original_shape[:-1], self.out_features)
+
+    def extra_repr(self):
+        return (
+            f"in_features={self.in_features}, out_features={self.out_features}, "
+            f"bias={self.bias is not None}"
+        )

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -573,28 +573,25 @@ class xFuserModel(abc.ABC):
             offload_requested = (
                 self.config.enable_model_cpu_offload or self.config.enable_sequential_cpu_offload
             )
+            # AITER FP8: quantizes layer-by-layer CPU→GPU individually before pipe.to(cuda).
+            # All other quant paths (FP4, torchao FP8) need weights on GPU first.
+            if self.config.use_fp8_gemms and _use_aiter_fp8_path():
+                for module_name in self.settings.fp8_gemm_module_list:
+                    log(f"Quantizing {module_name} to FP8 block-scale (AITER)...")
+                    quantize_linear_layers_to_fp8_blockscale(
+                        rgetattr(self.pipe, module_name), device=f"cuda:{local_rank}"
+                    )
             if not offload_requested:
                 self.pipe = self.pipe.to(f"cuda:{local_rank}")
-            elif self.config.use_fp8_gemms or self.config.use_fp4_gemms:
-                log("WARNING: FP8/FP4 quantization with CPU offload enabled. "
-                    "Quantized weights will be paged between CPU and GPU on every forward call. "
-                    "Consider removing --enable_model_cpu_offload when using quantization.")
             if self.config.use_fp4_gemms:
                 if _is_cuda():
                     self._setup_nvfp4_gemms(local_rank=local_rank)
                 else:
                     self._setup_mxfp4_gemms(local_rank=local_rank)
-            elif self.config.use_fp8_gemms:
+            if self.config.use_fp8_gemms and not _use_aiter_fp8_path():
                 for module_name in self.settings.fp8_gemm_module_list:
-                    module = rgetattr(self.pipe, module_name)
-                    if _use_aiter_fp8_path():
-                        log(f"Quantizing {module_name} to FP8 block-scale (AITER)...")
-                        quantize_linear_layers_to_fp8_blockscale(
-                            module, device=f"cuda:{local_rank}"
-                        )
-                    else:
-                        log(f"Quantizing {module_name} to FP8 (torchao)...")
-                        quantize_linear_layers_to_fp8(module, device=f"cuda:{local_rank}")
+                    log(f"Quantizing {module_name} to FP8 (torchao)...")
+                    quantize_linear_layers_to_fp8(rgetattr(self.pipe, module_name), device=f"cuda:{local_rank}")
 
         if self.config.use_hybrid_attn_schedule:
             self._setup_hybrid_attn_schedule(input_args)

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -28,7 +28,7 @@ from xfuser.core.utils.runner_utils import (
     quantize_linear_layers_to_fp4,
     quantize_linear_layers_to_nvfp4,
     convert_model_convs_to_channels_last,
-    _use_aiter_fp8_path,
+    _use_aiter_fp8_rdna4,
     rgetattr,
 )
 
@@ -575,7 +575,7 @@ class xFuserModel(abc.ABC):
             )
             # AITER FP8: quantizes layer-by-layer CPU→GPU individually before pipe.to(cuda).
             # All other quant paths (FP4, torchao FP8) need weights on GPU first.
-            if self.config.use_fp8_gemms and _use_aiter_fp8_path():
+            if self.config.use_fp8_gemms and _use_aiter_fp8_rdna4():
                 for module_name in self.settings.fp8_gemm_module_list:
                     log(f"Quantizing {module_name} to FP8 block-scale (AITER)...")
                     quantize_linear_layers_to_fp8_blockscale(
@@ -588,7 +588,7 @@ class xFuserModel(abc.ABC):
                     self._setup_nvfp4_gemms(local_rank=local_rank)
                 else:
                     self._setup_mxfp4_gemms(local_rank=local_rank)
-            if self.config.use_fp8_gemms and not _use_aiter_fp8_path():
+            if self.config.use_fp8_gemms and not _use_aiter_fp8_rdna4():
                 for module_name in self.settings.fp8_gemm_module_list:
                     log(f"Quantizing {module_name} to FP8 (torchao)...")
                     quantize_linear_layers_to_fp8(rgetattr(self.pipe, module_name), device=f"cuda:{local_rank}")
@@ -719,7 +719,7 @@ class xFuserModel(abc.ABC):
                         device=device,
                     )
             else:
-                if _use_aiter_fp8_path():
+                if _use_aiter_fp8_rdna4():
                     quantize_linear_layers_to_fp8_blockscale(block, device=device)
                 else:
                     quantize_linear_layers_to_fp8(block, device=device)

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -570,8 +570,15 @@ class xFuserModel(abc.ABC):
         if self.config.fully_shard_degree > 1:
             self._shard_model_with_fsdp()
         else:
-            if not (self.config.enable_model_cpu_offload or self.config.enable_sequential_cpu_offload):
+            offload_requested = (
+                self.config.enable_model_cpu_offload or self.config.enable_sequential_cpu_offload
+            )
+            if not offload_requested:
                 self.pipe = self.pipe.to(f"cuda:{local_rank}")
+            elif self.config.use_fp8_gemms or self.config.use_fp4_gemms:
+                log("WARNING: FP8/FP4 quantization with CPU offload enabled. "
+                    "Quantized weights will be paged between CPU and GPU on every forward call. "
+                    "Consider removing --enable_model_cpu_offload when using quantization.")
             if self.config.use_fp4_gemms:
                 if _is_cuda():
                     self._setup_nvfp4_gemms(local_rank=local_rank)

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -631,8 +631,8 @@ class xFuserModel(abc.ABC):
                     memory_efficient_init=self.config.memory_efficient_sharding,
                     offload_policy=offload_policy,
                     # All ranks load from the same checkpoint so states are already
-                    # identical. Skip the GPU broadcast to avoid OOM on large encoders.
-                    sync_module_states=offload_policy != "cpu",
+                    # identical. No broadcast needed regardless of offload policy.
+                    sync_module_states=False,
                 )
                 setattr(self.pipe, component_name, fsdp_object)
                 torch.cuda.empty_cache()

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -24,9 +24,11 @@ from xfuser.core.utils.runner_utils import (
     log,
     load_dataset_prompts,
     quantize_linear_layers_to_fp8,
+    quantize_linear_layers_to_fp8_blockscale,
     quantize_linear_layers_to_fp4,
     quantize_linear_layers_to_nvfp4,
     convert_model_convs_to_channels_last,
+    _use_aiter_fp8_path,
     rgetattr,
 )
 
@@ -577,9 +579,15 @@ class xFuserModel(abc.ABC):
                     self._setup_mxfp4_gemms(local_rank=local_rank)
             elif self.config.use_fp8_gemms:
                 for module_name in self.settings.fp8_gemm_module_list:
-                    log(f"Quantizing linear layers in {module_name} to FP8...")
                     module = rgetattr(self.pipe, module_name)
-                    quantize_linear_layers_to_fp8(module, device=f"cuda:{local_rank}")
+                    if _use_aiter_fp8_path():
+                        log(f"Quantizing {module_name} to FP8 block-scale (AITER)...")
+                        quantize_linear_layers_to_fp8_blockscale(
+                            module, device=f"cuda:{local_rank}"
+                        )
+                    else:
+                        log(f"Quantizing {module_name} to FP8 (torchao)...")
+                        quantize_linear_layers_to_fp8(module, device=f"cuda:{local_rank}")
 
         if self.config.use_hybrid_attn_schedule:
             self._setup_hybrid_attn_schedule(input_args)
@@ -593,7 +601,7 @@ class xFuserModel(abc.ABC):
 
     def _shard_model_with_fsdp(self) -> None:
         """ Shard the model with FSDP based on settings """
-        if self.config.use_fp8_gemms:
+        if self.config.use_fp8_gemms and _is_cuda():
             from xfuser.core.utils.runner_utils import _TORCHAO_FLOAT8_FSDP2_PATCHES
             assert _TORCHAO_FLOAT8_FSDP2_PATCHES, (
                 "FSDP2 + FP8 requires torchao Float8Tensor patches but they failed to apply at "
@@ -707,7 +715,10 @@ class xFuserModel(abc.ABC):
                         device=device,
                     )
             else:
-                quantize_linear_layers_to_fp8(block, device=device)
+                if _use_aiter_fp8_path():
+                    quantize_linear_layers_to_fp8_blockscale(block, device=device)
+                else:
+                    quantize_linear_layers_to_fp8(block, device=device)
 
         return quantize_fn
 

--- a/xfuser/model_executor/models/runner_models/hunyuan.py
+++ b/xfuser/model_executor/models/runner_models/hunyuan.py
@@ -36,7 +36,8 @@ class xFuserHunyuanvideoModel(xFuserModel):
         ring_degree=True,
         enable_slicing=True,
         enable_tiling=True,
-        use_hybrid_attn_schedule=True
+        use_hybrid_attn_schedule=True,
+        use_fp8_gemms=True,
     )
     default_input_values = DefaultInputValues(
         height=720,
@@ -51,6 +52,7 @@ class xFuserHunyuanvideoModel(xFuserModel):
         output_name="hunyuan_video",
         model_output_type="video",
         fps=24,
+        fp8_gemm_module_list=["transformer.transformer_blocks", "transformer.single_transformer_blocks"],
     )
 
     def _load_model(self) -> DiffusionPipeline:
@@ -111,6 +113,7 @@ class xFuserHunyuanvideo15Model(xFuserModel):
         ring_degree=True,
         enable_slicing=True,
         enable_tiling=True,
+        use_fp8_gemms=True,
     )
     default_input_values = DefaultInputValues(
         height=720,
@@ -122,6 +125,7 @@ class xFuserHunyuanvideo15Model(xFuserModel):
         output_name="hunyuan_video_1_5",
         model_output_type="video",
         fps=24,
+        fp8_gemm_module_list=["transformer.transformer_blocks"],
         mod_value=16,
         valid_tasks=["i2v", "t2v"],
     )

--- a/xfuser/model_executor/models/runner_models/ltx.py
+++ b/xfuser/model_executor/models/runner_models/ltx.py
@@ -222,6 +222,7 @@ class xFuserLTX2VideoModel(xFuserModel):
         model_name="Lightricks/LTX-2",
         output_name="ltx_2_video",
         model_output_type="video",
+        fp8_gemm_module_list=["transformer.transformer_blocks"],
         fps=24,
         resolution_divisor=64,
     )
@@ -230,6 +231,7 @@ class xFuserLTX2VideoModel(xFuserModel):
         ring_degree=True,
         enable_tiling=True,
         enable_slicing=True,
+        use_fp8_gemms=True,
     )
 
     def _load_model(self) -> DiffusionPipeline:

--- a/xfuser/model_executor/models/runner_models/qwen.py
+++ b/xfuser/model_executor/models/runner_models/qwen.py
@@ -107,6 +107,7 @@ class xFuserQwenImageModel(xFuserModel):
         fully_shard_degree=True,
         enable_tiling=True,
         enable_slicing=True,
+        use_fp8_gemms=True,
     )
     default_input_values = DefaultInputValues(
         height=928,
@@ -118,6 +119,7 @@ class xFuserQwenImageModel(xFuserModel):
         model_name="Qwen/Qwen-Image",
         output_name="qwen_image",
         model_output_type="image",
+        fp8_gemm_module_list=["transformer.transformer_blocks"],
         fsdp_strategy={
             "transformer": {
                 "wrap_attrs": ["transformer_blocks"],

--- a/xfuser/model_executor/models/runner_models/qwen.py
+++ b/xfuser/model_executor/models/runner_models/qwen.py
@@ -105,8 +105,6 @@ class xFuserQwenImageModel(xFuserModel):
         ulysses_degree=True,
         ring_degree=True,
         fully_shard_degree=True,
-        enable_tiling=True,
-        enable_slicing=True,
         use_fp8_gemms=True,
     )
     default_input_values = DefaultInputValues(

--- a/xfuser/model_executor/models/runner_models/stable_diffusion.py
+++ b/xfuser/model_executor/models/runner_models/stable_diffusion.py
@@ -23,6 +23,7 @@ class xFuserStableDiffusionModel(xFuserModel):
         enable_tiling=True,
         enable_slicing=True,
         fully_shard_degree=True,
+        use_fp8_gemms=True,
     )
     default_input_values = DefaultInputValues(
         height=1024,
@@ -42,6 +43,7 @@ class xFuserStableDiffusionModel(xFuserModel):
                 "wrap_attrs": ["encoder.block"],
             },
         },
+        fp8_gemm_module_list=["transformer.transformer_blocks"],
     )
 
     def _load_model(self) -> DiffusionPipeline:

--- a/xfuser/model_executor/models/runner_models/z_image.py
+++ b/xfuser/model_executor/models/runner_models/z_image.py
@@ -57,6 +57,7 @@ class xFuserZImageModel(xFuserModel):
         enable_tiling=True,
         enable_slicing=True,
         fully_shard_degree=True,
+        use_fp8_gemms=True,
     )
     settings = ModelSettings(
         model_name="Tongyi-MAI/Z-Image",
@@ -70,6 +71,7 @@ class xFuserZImageModel(xFuserModel):
                 "wrap_attrs": ["model.language_model.layers"],
             },
         },
+        fp8_gemm_module_list=["transformer.layers", "transformer.noise_refiner", "transformer.context_refiner"],
     )
 
     def _load_model(self) -> DiffusionPipeline:

--- a/xfuser/model_executor/models/runner_models/z_image.py
+++ b/xfuser/model_executor/models/runner_models/z_image.py
@@ -108,6 +108,7 @@ class xFuserZImageTurboModel(xFuserModel):
     capabilities = ModelCapabilities(
         enable_tiling=True,
         enable_slicing=True,
+        use_fp8_gemms=True,
     )
     default_input_values = DefaultInputValues(
         height=1024,
@@ -130,6 +131,7 @@ class xFuserZImageTurboModel(xFuserModel):
                 "wrap_attrs": ["model.language_model.layers"],
             },
         },
+        fp8_gemm_module_list=["transformer.layers", "transformer.noise_refiner", "transformer.context_refiner"],
     )
 
     def _load_model(self) -> DiffusionPipeline:

--- a/xfuser/model_executor/models/runner_models/z_image.py
+++ b/xfuser/model_executor/models/runner_models/z_image.py
@@ -106,8 +106,6 @@ class xFuserZImageModel(xFuserModel):
 class xFuserZImageTurboModel(xFuserModel):
 
     capabilities = ModelCapabilities(
-        enable_tiling=True,
-        enable_slicing=True,
         use_fp8_gemms=True,
     )
     default_input_values = DefaultInputValues(


### PR DESCRIPTION
## Summary

Adds true FP8 GEMM execution for transformer linear layers on AMD RDNA4 GPUs (gfx1200+, e.g. AI Pro R9700), using AITER's `gemm_a8w8_blockscale` Triton kernel which hits native FP8 WMMA hardware.

### Why not torchao?

torchao's `Float8DynamicActivationFloat8WeightConfig` is currently gated to CUDA>=9.0 and MI300+. Test patching this path resulted in very slow inference. It dispatches through `torch._scaled_mm` to hipBLASLt. On ROCm 7.2.3, gfx1201 is not in hipBLASLt's FP8 whitelist and the GEMM silently falls back to FP32. AITER's Triton kernel auto-compiles to native `v_wmma_f32_16x16x16` instructions and is confirmed working on gfx1201.

### Implementation

**`xFuserFP8BlockScaleLinear`** is a drop-in `nn.Module` replacement for `nn.Linear`:
- Weights pre-quantized at load time to FP8 e4m3fn with block-128 scaling; stored as persistent FSDP2-compatible buffers
- Activations quantized per-forward using manual block-128 quant (reshape -> amax -> scale -> cast); placed **outside** the custom_op boundary so Inductor can fuse the quant ops into ~2 kernels
- The bare `aiter.gemm_a8w8_blockscale` call is wrapped in `torch.library.custom_op` + `register_fake` for `torch.compile` compatibility
- Bias added after the GEMM (kernel has no native bias support)

**Gate**: `_use_aiter_fp8_path()` restricts to gfx1200+ (RDNA4 only).

### Models enabled

All models available through the runner: FLUX.1-dev, FLUX.1-Kontext, FLUX.2, FLUX.2-klein, HunyuanVideo, HunyuanVideo-1.5, LTX-2, Qwen-Image, Qwen-Image-Edit, StableDiffusion-3.5, Wan2.1, Wan2.2, Z-Image.

The `fp8_gemm_module_list` in each model's `ModelSettings` controls which submodules are quantized (e.g. `transformer.transformer_blocks`).

### Usage

```bash
torchrun ... --use_fp8_gemms
```