### PR TITLE
Solve Hunyuan+AITER Sage regression with FX pass solution

### DIFF
--- a/xfuser/compile/__init__.py
+++ b/xfuser/compile/__init__.py
@@ -1,0 +1,3 @@
+from xfuser.compile.inductor_passes import install as install_inductor_passes
+
+__all__ = ["install_inductor_passes"]

--- a/xfuser/compile/inductor_passes.py
+++ b/xfuser/compile/inductor_passes.py
@@ -11,11 +11,6 @@ Currently provides:
 The pass is pattern-matched on the FX graph and is a no-op when the bad
 pattern is not present, so it is safe to install globally; non-matching
 configurations are untouched.
-
-This pass does NOT introduce a graph break. ``torch.library.custom_op`` is
-an Inductor opacity barrier (the op is treated as opaque for fusion purposes),
-not a Dynamo bailout: the FX graph stays connected as a single compiled
-subgraph and the AOT segment count is unchanged.
 """
 
 from __future__ import annotations

--- a/xfuser/compile/inductor_passes.py
+++ b/xfuser/compile/inductor_passes.py
@@ -150,19 +150,17 @@ def fix_sage_joint_cat_fusion(graph: fx.Graph) -> fx.Graph:
 
         num_matches += 1
 
-    # Always log diagnostics so we can tell whether the pass ran at all.
-    logger.info(
-        "fix_sage_joint_cat_fusion: scanned graph: %d cat nodes total, "
-        "%d with multiple users, %d with reduction user, %d matches inserted. "
-        "Sample cat-user targets: %s",
-        num_cat_nodes,
-        num_cat_with_multi_users,
-        num_cat_with_reduction,
-        num_matches,
-        " | ".join(sample_user_targets) if sample_user_targets else "(none)",
-    )
-
     if num_matches > 0:
+        logger.info(
+            "fix_sage_joint_cat_fusion: scanned graph: %d cat nodes total, "
+            "%d with multiple users, %d with reduction user, %d matches inserted. "
+            "Sample cat-user targets: %s",
+            num_cat_nodes,
+            num_cat_with_multi_users,
+            num_cat_with_reduction,
+            num_matches,
+            " | ".join(sample_user_targets) if sample_user_targets else "(none)",
+        )
         graph.lint()
 
     return graph

--- a/xfuser/compile/inductor_passes.py
+++ b/xfuser/compile/inductor_passes.py
@@ -1,0 +1,211 @@
+"""
+Custom Inductor post-grad passes for working around scheduler issues.
+
+Currently provides:
+
+- ``fix_sage_joint_cat_fusion``: defeats a bad Inductor scheduling decision
+  where a ``cat``-then-reduction pattern (used by AITER ``sage_quant`` in
+  Hunyuan's asymmetric joint attention path) gets inlined into a strided-
+  gather reduction kernel, causing a large per-call slowdown.
+
+The pass is pattern-matched on the FX graph and is a no-op when the bad
+pattern is not present, so it is safe to install globally; non-matching
+configurations are untouched.
+
+This pass does NOT introduce a graph break. ``torch.library.custom_op`` is
+an Inductor opacity barrier (the op is treated as opaque for fusion purposes),
+not a Dynamo bailout: the FX graph stays connected as a single compiled
+subgraph and the AOT segment count is unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+import torch.fx as fx
+
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Realize marker custom op
+# ---------------------------------------------------------------------------
+# Inductor treats torch.library.custom_op calls as opaque kernels: their
+# inputs must be materialized in real buffers, their outputs are realized
+# buffers, and the op is not fused with neighbours. We use it here only as
+# a marker, inserted by the pass below between an aten.cat node and its
+# reduction consumers, to break a specific fusion that Inductor's scheduler
+# handles badly.
+#
+# The op itself is semantically a clone. In the unlikely event that the
+# pass fires outside torch.compile (eager fallback), it still produces a
+# correct result; the cost is one extra clone.
+
+_REALIZE_OP_NAME = "xfuser::_realize_for_inductor"
+
+
+def _maybe_register_realize_op() -> None:
+    """Register the realize marker once. Safe to call multiple times."""
+    ns, name = _REALIZE_OP_NAME.split("::")
+    if hasattr(torch.ops, ns) and hasattr(getattr(torch.ops, ns), name):
+        return
+
+    @torch.library.custom_op(_REALIZE_OP_NAME, mutates_args=())
+    def _realize_for_inductor(x: torch.Tensor) -> torch.Tensor:
+        return x.clone()
+
+    @_realize_for_inductor.register_fake
+    def _(x: torch.Tensor) -> torch.Tensor:
+        return torch.empty_like(x)
+
+
+# ---------------------------------------------------------------------------
+# Post-grad pass
+# ---------------------------------------------------------------------------
+
+def _is_reduction_target(target) -> bool:
+    """Targets that participate in the bad fusion as cat consumers.
+
+    Sage's ``v.abs().amax(dim=2)`` lowers via ``aten.abs.default`` followed
+    by ``aten.amax.default``; Sage's ``k.mean(dim=2, keepdim=True)`` lowers
+    via ``aten.mean.dim``. We match on the immediate consumer of the cat,
+    so the relevant targets are ``aten.abs.default`` and ``aten.mean.dim``.
+    """
+    return target in {
+        torch.ops.aten.abs.default,
+        torch.ops.aten.mean.dim,
+    }
+
+
+def fix_sage_joint_cat_fusion(graph: fx.Graph) -> fx.Graph:
+    """Insert an opaque realize marker between an ``aten.cat`` node and its
+    reduction consumers, only when the cat is also consumed by an opaque
+    Triton kernel (``triton_kernel_wrapper_mutation``, used by sage_quant).
+
+    This is the precise FX pattern produced by xDiT's asymmetric joint
+    attention path (``_concat_joint_tensor`` after Ulysses all-to-all) when
+    combined with the AITER Sage backend. In that pattern, Inductor's
+    scheduler picks "re-derive the cat from sources" for the reduction
+    consumer, producing a strided-gather kernel over the post-A2A view
+    chain. With this pass, the reduction consumer is forced through an opaque op,
+    so Inductor must use the materialized cat buffer 
+    (which it is already producing for the sage kernel) and emits a coalesced read.
+
+    The pass is a no-op for graphs that don't contain the pattern.
+    """
+    _maybe_register_realize_op()
+
+    cat_target = torch.ops.aten.cat.default
+    realize_target = torch.ops.xfuser._realize_for_inductor.default
+
+    # Diagnostic counters
+    num_cat_nodes = 0
+    num_cat_with_reduction = 0
+    num_cat_with_multi_users = 0
+    num_matches = 0
+    sample_user_targets: list[str] = []
+
+    for node in list(graph.nodes):
+        if node.op != "call_function" or node.target != cat_target:
+            continue
+
+        num_cat_nodes += 1
+        users = list(node.users.keys())
+
+        # Diagnostic: record the targets of the first few cat nodes' users
+        if len(sample_user_targets) < 7:
+            user_target_strs = [
+                f"{u.op}:{getattr(u.target, '__qualname__', repr(u.target))}"
+                for u in users
+            ]
+            sample_user_targets.append(
+                f"cat#{num_cat_nodes}(n_users={len(users)}) users={user_target_strs}"
+            )
+
+        reduction_users = [
+            u for u in users
+            if u.op == "call_function" and _is_reduction_target(u.target)
+        ]
+        if reduction_users:
+            num_cat_with_reduction += 1
+        if len(users) >= 2:
+            num_cat_with_multi_users += 1
+
+        # Match the bad pattern: cat is consumed by a reduction (sage's eager
+        # v.abs().amax() or k.mean()) AND has at least one other user (the
+        # view chain that feeds the sage kernel's V_Input/K_Input). When both
+        # are true, Inductor inlines the cat into the reduction kernel instead
+        # of reusing the cat buffer that's being materialized for the other
+        # consumer path.
+        if not reduction_users or len(users) < 2:
+            continue
+
+        # Pattern matched: insert realize marker between cat and reduction users.
+        with graph.inserting_after(node):
+            realize_node = graph.call_function(realize_target, args=(node,))
+            if "val" in node.meta:
+                realize_node.meta["val"] = node.meta["val"]
+            if "tensor_meta" in node.meta:
+                realize_node.meta["tensor_meta"] = node.meta["tensor_meta"]
+
+        for ru in reduction_users:
+            ru.replace_input_with(node, realize_node)
+
+        num_matches += 1
+
+    # Always log diagnostics so we can tell whether the pass ran at all.
+    logger.warning(
+        "fix_sage_joint_cat_fusion: scanned graph: %d cat nodes total, "
+        "%d with multiple users, %d with reduction user, %d matches inserted. "
+        "Sample cat-user targets: %s",
+        num_cat_nodes,
+        num_cat_with_multi_users,
+        num_cat_with_reduction,
+        num_matches,
+        " | ".join(sample_user_targets) if sample_user_targets else "(none)",
+    )
+
+    if num_matches > 0:
+        graph.lint()
+
+    return graph
+
+
+# ---------------------------------------------------------------------------
+# Installation
+# ---------------------------------------------------------------------------
+
+def install() -> None:
+    """Register :func:`fix_sage_joint_cat_fusion` as Inductor's post-grad
+    custom_post_pass.
+
+    Safe to call multiple times: re-registering with the same function is a
+    no-op. If a *different* ``post_grad_custom_post_pass`` is already set
+    (e.g., installed by another component), this will replace it and log a
+    warning; Inductor only supports a single hook in that slot, and composing
+    multiple hooks correctly is the caller's responsibility.
+
+    Must be called before :func:`torch.compile` so the hook is in place when
+    Inductor lowers any subsequent graph.
+    """
+    import torch._inductor.config as inductor_config
+
+    _maybe_register_realize_op()
+
+    existing = getattr(inductor_config, "post_grad_custom_post_pass", None)
+    if existing is fix_sage_joint_cat_fusion:
+        return
+
+    if existing is not None:
+        logger.warning(
+            "post_grad_custom_post_pass is already set to %r; replacing with "
+            "fix_sage_joint_cat_fusion. Compose manually if both are needed.",
+            existing,
+        )
+
+    inductor_config.post_grad_custom_post_pass = fix_sage_joint_cat_fusion
+    logger.warning(
+        "fix_sage_joint_cat_fusion: registered as post_grad_custom_post_pass"
+    )

--- a/xfuser/compile/inductor_passes.py
+++ b/xfuser/compile/inductor_passes.py
@@ -76,8 +76,8 @@ def _is_reduction_target(target) -> bool:
 
 def fix_sage_joint_cat_fusion(graph: fx.Graph) -> fx.Graph:
     """Insert an opaque realize marker between an ``aten.cat`` node and its
-    reduction consumers, only when the cat is also consumed by an opaque
-    Triton kernel (``triton_kernel_wrapper_mutation``, used by sage_quant).
+    reduction consumers, only when the cat has >= 2 users and at least one
+    is ``aten.abs.default`` or ``aten.mean.dim``.
 
     This is the precise FX pattern produced by xDiT's asymmetric joint
     attention path (``_concat_joint_tensor`` after Ulysses all-to-all) when
@@ -151,7 +151,7 @@ def fix_sage_joint_cat_fusion(graph: fx.Graph) -> fx.Graph:
         num_matches += 1
 
     # Always log diagnostics so we can tell whether the pass ran at all.
-    logger.warning(
+    logger.info(
         "fix_sage_joint_cat_fusion: scanned graph: %d cat nodes total, "
         "%d with multiple users, %d with reduction user, %d matches inserted. "
         "Sample cat-user targets: %s",
@@ -176,11 +176,15 @@ def install() -> None:
     """Register :func:`fix_sage_joint_cat_fusion` as Inductor's post-grad
     custom_post_pass.
 
-    Safe to call multiple times: re-registering with the same function is a
-    no-op. If a *different* ``post_grad_custom_post_pass`` is already set
-    (e.g., installed by another component), this will replace it and log a
-    warning; Inductor only supports a single hook in that slot, and composing
-    multiple hooks correctly is the caller's responsibility.
+    Idempotent and compositional:
+
+    - If nothing is registered, installs ``fix_sage_joint_cat_fusion`` directly.
+    - If another pass is already registered, installs a wrapper that runs the
+      existing pass first and then ``fix_sage_joint_cat_fusion``. The existing
+      pass's behavior is preserved.
+    - If a chain we previously created (or ``fix_sage_joint_cat_fusion`` itself)
+      is already installed, this call is a no-op — re-installing does not grow
+      the chain across repeated ``_compile_model`` invocations.
 
     Must be called before :func:`torch.compile` so the hook is in place when
     Inductor lowers any subsequent graph.
@@ -194,13 +198,26 @@ def install() -> None:
         return
 
     if existing is not None:
+        if getattr(existing, "_xfuser_composed", False):
+            return
+
+        def composed_pass(graph: fx.Graph) -> fx.Graph:
+            result = existing(graph)
+            # FX passes may mutate in-place and return None.
+            # Normalize so our pass always receives a Graph.
+            if result is None:
+                result = graph
+            return fix_sage_joint_cat_fusion(result)
+
+        composed_pass._xfuser_composed = True
+        inductor_config.post_grad_custom_post_pass = composed_pass
         logger.warning(
-            "post_grad_custom_post_pass is already set to %r; replacing with "
-            "fix_sage_joint_cat_fusion. Compose manually if both are needed.",
+            "post_grad_custom_post_pass is already set to %r; chained "
+            "fix_sage_joint_cat_fusion with it.",
             existing,
         )
-
-    inductor_config.post_grad_custom_post_pass = fix_sage_joint_cat_fusion
-    logger.warning(
-        "fix_sage_joint_cat_fusion: registered as post_grad_custom_post_pass"
-    )
+    else:
+        inductor_config.post_grad_custom_post_pass = fix_sage_joint_cat_fusion
+        logger.warning(
+            "fix_sage_joint_cat_fusion: registered as post_grad_custom_post_pass"
+        )

--- a/xfuser/model_executor/models/runner_models/hunyuan.py
+++ b/xfuser/model_executor/models/runner_models/hunyuan.py
@@ -82,6 +82,12 @@ class xFuserHunyuanvideoModel(xFuserModel):
 
     def _compile_model(self, input_args: dict) -> None:
         """ Compile the model using torch.compile """
+        # Install Inductor post-grad pass that defeats a scheduler bug in the
+        # asymmetric joint attention path with the AITER Sage backend. The pass
+        # is pattern-matched on the FX graph and is a no-op for configurations
+        # that don't produce the bad pattern (non-sage backends, symmetric SP).
+        from xfuser.compile import install_inductor_passes
+        install_inductor_passes()
         torch._inductor.config.reorder_for_compute_comm_overlap = True
         self.pipe.transformer.compile()
 
@@ -180,6 +186,13 @@ class xFuserHunyuanvideo15Model(xFuserModel):
 
     def _compile_model(self, input_args: dict) -> None:
         """ Compile the model using torch.compile """
+        # Install Inductor post-grad pass that defeats a scheduler bug in the
+        # asymmetric joint attention path with the AITER Sage backend. The pass
+        # is pattern-matched on the FX graph and is a no-op for configurations
+        # that don't produce the bad pattern (e.g., symmetric SP, non-sage
+        # backends, models without the post-A2A joint cat).
+        from xfuser.compile import install_inductor_passes
+        install_inductor_passes()
         torch._inductor.config.reorder_for_compute_comm_overlap = True
         self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
 

--- a/xfuser/model_executor/models/runner_models/hunyuan.py
+++ b/xfuser/model_executor/models/runner_models/hunyuan.py
@@ -25,6 +25,7 @@ from xfuser.core.utils.runner_utils import (
     fix_llama_tokenizer_pretokenizer,
 )
 from xfuser.envs import PACKAGES_CHECKER
+from xfuser.compile import install_inductor_passes
 
 @register_model("tencent/HunyuanVideo")
 @register_model("HunyuanVideo")
@@ -86,7 +87,6 @@ class xFuserHunyuanvideoModel(xFuserModel):
         # asymmetric joint attention path with the AITER Sage backend. The pass
         # is pattern-matched on the FX graph and is a no-op for configurations
         # that don't produce the bad pattern (non-sage backends, symmetric SP).
-        from xfuser.compile import install_inductor_passes
         install_inductor_passes()
         torch._inductor.config.reorder_for_compute_comm_overlap = True
         self.pipe.transformer.compile()
@@ -191,7 +191,6 @@ class xFuserHunyuanvideo15Model(xFuserModel):
         # is pattern-matched on the FX graph and is a no-op for configurations
         # that don't produce the bad pattern (e.g., symmetric SP, non-sage
         # backends, models without the post-A2A joint cat).
-        from xfuser.compile import install_inductor_passes
         install_inductor_passes()
         torch._inductor.config.reorder_for_compute_comm_overlap = True
         self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")


### PR DESCRIPTION
## What

Defeats an Inductor scheduler cost-model bug that regresses Hunyuan video (HV and HV1.5) on Ulysses SP with the AITER Sage attention backend when the encoder length isn't divisible by the SP world size (asymmetric joint attention path).

In that configuration, USP cats the encoder K/V onto the latent K/V *after* the all-to-all, then feeds the result into AITER's `sage_quant`. Sage exposes its quantization-scale computations as eager Python reductions (`v.abs().amax(dim=2)`, `k.mean(dim=2)`). Inductor materializes the cat once for the sage Triton kernel's `V_Input`/`K_Input`, but for the reduction consumers it chooses to **re-derive** the cat from sources, fusing the entire post-A2A view chain into the reduction. The cost model doesn't price stride patterns, so it doesn't see that re-derivation is a strided gather, producing a ~9.5 ms/call kernel (`triton_red_fused__unsafe_view_abs_amax_cat_clone_permute_slice_split_with_sizes_transpose_view_*`).

## How

A custom Inductor post-grad FX pass (`fix_sage_joint_cat_fusion`) that:

1. Defines an opaque marker custom op `xfuser::_realize_for_inductor` (semantically `x.clone()`).
2. Walks each compiled subgraph for `aten.cat.default` nodes that have ≥2 users with at least one being `aten.abs.default` or `aten.mean.dim` — the unique FX signature of the bad pattern.
3. Inserts the marker between the cat and its reduction consumer and rewires the reduction to read from the marker.

Because the marker is a custom op, Inductor cannot inline through it. The reduction reads coalesced from the materialized cat buffer instead of strided-gathering over the view chain.

## Scope

- Pass is installed only from `xFuserHunyuanvideoModel._compile_model` and `xFuserHunyuanvideo15Model._compile_model` → other models (Flux, Wan, etc.) never register the hook.
- Pattern only matches the specific cat→reduction shape produced by sage's eager scales → Hunyuan + non-sage backends and Hunyuan symmetric joint compile to no-op.
- No change to model code, USP, AITER, or attention backends.

## Files

- **Added** `xfuser/compile/__init__.py`, `xfuser/compile/inductor_passes.py` — custom op + pass + `install()`.
- **Modified** `xfuser/model_executor/models/runner_models/hunyuan.py` — call `install_inductor_passes()` at top of `_compile_model` for HV and HV1.5.

## Reversibility

Comment out `install_inductor_passes()` in `_compile_model` and clear `/tmp/torchinductor_*` → reverts to default Inductor scheduling. Two-line revert.

## Follow-ups

- File an upstream PyTorch issue with a minimal repro so the cost-model bug can be fixed and this pass eventually retired.
