### PR TITLE
fix: restore FlyDSL non-causal threshold fallback

### DIFF
--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -971,10 +971,15 @@ def _aiter_sparge_v2_attn_call(query, key, value, dropout_p, is_causal, attentio
 
 @register_attention_function(AttentionBackendType.AITER_FLYDSL)
 def _aiter_flydsl_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs=None):
-    # This kernel only supports causal self-attention; fall back for cross-attention
-    # and non-causal attention.
-    if not is_causal or query.shape[2] != key.shape[2]:
+    # Cross-attention is unsupported. For non-causal self-attention, this kernel raises
+    # when the seq_len padding ratio to align to 128 exceeds 0.5% (same check as the kernel).
+    if query.shape[2] != key.shape[2]:
         return _sdpa_flash_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs)
+    if not is_causal:
+        seq_len = query.shape[2]
+        pad = (-seq_len) % 128
+        if pad > 0 and pad / (seq_len + pad) > 0.005:
+            return _sdpa_flash_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs)
     query = torch.permute(query, [0, 2, 1, 3]).contiguous()
     key = torch.permute(key, [0, 2, 1, 3]).contiguous()
     value = torch.permute(value, [0, 2, 1, 3]).contiguous()

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -978,7 +978,7 @@ def _aiter_flydsl_attn_call(query, key, value, dropout_p, is_causal, attention_k
     if not is_causal:
         seq_len = query.shape[2]
         pad = (-seq_len) % 128
-        if pad > 0 and pad / (seq_len + pad) > 0.005:
+        if pad > 0 and 199 * pad > seq_len:
             return _sdpa_flash_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs)
     query = torch.permute(query, [0, 2, 1, 3]).contiguous()
     key = torch.permute(key, [0, 2, 1, 3]).contiguous()

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -978,6 +978,7 @@ def _aiter_flydsl_attn_call(query, key, value, dropout_p, is_causal, attention_k
     if not is_causal:
         seq_len = query.shape[2]
         pad = (-seq_len) % 128
+        # 199*pad > seq_len is pad/(seq_len+pad) > 0.005 (0.5%) in integer arithmetic.
         if pad > 0 and 199 * pad > seq_len:
             return _sdpa_flash_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs)
     query = torch.permute(query, [0, 2, 1, 3]).contiguous()


### PR DESCRIPTION
I over-corrected by falling back to `sdpa_flash` for all non-causal attention.

The kernel raises only when `seq_len` padding to 128 exceeds 0.5%, not for all non-causal attention. Padding is handled internally when below the threshold.

Tested by performing a full sweep across models and workloads. Speed gain is net positive as this reduces the number of fallback calls to `sdpa_flash`.