### PR TITLE
Remove FLUX.2 text encoder vision tower auto CPU offloading

### DIFF
--- a/xfuser/model_executor/models/runner_models/flux.py
+++ b/xfuser/model_executor/models/runner_models/flux.py
@@ -270,10 +270,6 @@ class xFuserFlux2Model(xFuserModel):
 
     def _post_load_and_state_initialization(self, input_args: dict) -> None:
         super()._post_load_and_state_initialization(input_args)
-        te = self.pipe.text_encoder
-        # vision_tower is never called for FLUX.2 text-only embedding; keep on CPU.
-        if hasattr(te, "model") and hasattr(te.model, "vision_tower"):
-            te.model.vision_tower = te.model.vision_tower.cpu()
         if self.config.use_parallel_vae:
             _setup_parallel_vae(self.pipe.vae)
 


### PR DESCRIPTION
# What?
PR #707 further enhanced the FSDP functionality of xDiT. 
This PR removes the small automatic CPU offloading of unused text encoder vision tower due to it breaking the non-FSDP path:
```
 RuntimeError: Expected all tensors to be on the same device, but got index is on cpu, different from other tensors on cuda:0 (when checking argument in method wrapper_CUDA__index_select)
```

# Why?
While this vision tower is never used in xDiT configurations and therefore could live on CPU, it's also used by the pipeline to check what device to use for the text encoder inputs (due to the way diffusers checks this). This breaks the non-FSDP path, as the text encoder lives on GPU, but now the inputs would be on CPU.

When using FSDP to conserve memory, it's already auto-loaded to CPU due to FSDP offload policy. When using 1 GPU + sequential cpu offload, it's offloaded to CPU permanently. So the only case where this should be automatically on CPU is 1 GPU + no sequential offload. 


