### PR TITLE
Sparge fixes

### DIFF
--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -30,16 +30,19 @@ logger = init_logger(__name__)
 class FlexibleArgumentParser(argparse.ArgumentParser):
     """ArgumentParser that allows both underscore and dash in names."""
 
-    @staticmethod
-    def _normalize_name(name: str) -> str:
-        # Preserve the leading "--" (and BooleanOptionalAction's "--no-"
-        # prefix); only normalize hyphens to underscores inside the actual
-        # argument name. Without this, "--no-foo" would be rewritten to
-        # "--no_foo" which doesn't match what BooleanOptionalAction
-        # registered ("--no-foo").
+    def _normalize_name(self, name: str) -> str:
+        # First, try the standard normalization (all hyphens to underscores)
+        fully_normalized = "--" + name[len("--"):].replace("-", "_")
+        if fully_normalized in self._option_string_actions:
+            return fully_normalized
+
+        # If not found, check if it's a BooleanOptionalAction (starts with --no-)
         if name.startswith("--no-"):
-            return "--no-" + name[len("--no-"):].replace("-", "_")
-        return "--" + name[len("--"):].replace("-", "_")
+            no_dash_normalized = "--no-" + name[len("--no-"):].replace("-", "_")
+            if no_dash_normalized in self._option_string_actions:
+                return no_dash_normalized
+
+        return fully_normalized
 
     def parse_args(self, args=None, namespace=None):
         if args is None:

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -30,20 +30,29 @@ logger = init_logger(__name__)
 class FlexibleArgumentParser(argparse.ArgumentParser):
     """ArgumentParser that allows both underscore and dash in names."""
 
+    @staticmethod
+    def _normalize_name(name: str) -> str:
+        # Preserve the leading "--" (and BooleanOptionalAction's "--no-"
+        # prefix); only normalize hyphens to underscores inside the actual
+        # argument name. Without this, "--no-foo" would be rewritten to
+        # "--no_foo" which doesn't match what BooleanOptionalAction
+        # registered ("--no-foo").
+        if name.startswith("--no-"):
+            return "--no-" + name[len("--no-"):].replace("-", "_")
+        return "--" + name[len("--"):].replace("-", "_")
+
     def parse_args(self, args=None, namespace=None):
         if args is None:
             args = sys.argv[1:]
 
-        # Convert underscores to dashes and vice versa in argument names
         processed_args = []
         for arg in args:
             if arg.startswith("--"):
                 if "=" in arg:
                     key, value = arg.split("=", 1)
-                    key = "--" + key[len("--") :].replace("-", "_")
-                    processed_args.append(f"{key}={value}")
+                    processed_args.append(f"{self._normalize_name(key)}={value}")
                 else:
-                    processed_args.append("--" + arg[len("--") :].replace("-", "_"))
+                    processed_args.append(self._normalize_name(arg))
             else:
                 processed_args.append(arg)
 

--- a/xfuser/core/distributed/runtime_state.py
+++ b/xfuser/core/distributed/runtime_state.py
@@ -212,8 +212,10 @@ class RuntimeState(metaclass=ABCMeta):
                                  AttentionBackendType.AITER_MLA,
                                  AttentionBackendType.AITER_SAGE,
                                  AttentionBackendType.AITER_SPARSE_SAGE,
+                                 AttentionBackendType.AITER_SPARGE,
                                  AttentionBackendType.AITER_SAGE_V2,
                                  AttentionBackendType.AITER_SPARSE_SAGE_V2,
+                                 AttentionBackendType.AITER_SPARGE_V2,
                                  AttentionBackendType.AITER_FLYDSL,
                                  AttentionBackendType.FLEX_BLOCK_ATTN]:
             if self.parallel_config.ring_degree > 1:

--- a/xfuser/core/sparge_attention/sparge.py
+++ b/xfuser/core/sparge_attention/sparge.py
@@ -62,12 +62,30 @@ def get_static_block_neighbor_mask(
     block_m: int, block_n: int,
     device: torch.device,
     gilbert_mapping: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+    *,
+    mapping_kind: str = "gilbert",
 ) -> torch.Tensor:
-    key = (tuple(thw), int(block_m), int(block_n), _device_key(device))
+    """Block-pair neighbour mask for the (thw, block_m, block_n) layout.
+
+    ``mapping_kind`` disambiguates the cache when the same shape is built
+    under different block layouts (Gilbert-reordered vs linear row-major).
+    For ``"linear"`` an identity ``linear_to_hilbert`` is built on demand
+    if no ``gilbert_mapping`` was supplied.
+    """
+    key = (
+        tuple(thw),
+        int(block_m),
+        int(block_n),
+        _device_key(device),
+        str(mapping_kind),
+    )
     cached = _STATIC_BLOCK_MASK_CACHE.get(key)
     if cached is not None:
         return cached
     t, h, w = thw
+    if mapping_kind == "linear" and gilbert_mapping is None:
+        identity = torch.arange(t * h * w, dtype=torch.int64, device=device)
+        gilbert_mapping = (identity, identity)
     mask = sliced_gilbert_block_neighbor_mapping(
         t, h, w, block_m, block_n, device, gilbert_mapping=gilbert_mapping,
     )
@@ -130,17 +148,19 @@ def setup_sparge(
     static_mask: Optional[torch.Tensor] = None
     sp_pad_len = 0
 
-    # Static mask is defined in Gilbert-permuted block space; meaningless
-    # without reorder. Match upstream's invariant and silently drop it.
-    if use_static_block_mask and not reorder_sequence:
+    # Both reorder and the static mask operate on the spatial (thw) layout,
+    # so they both need thw and they both need SP padding to be stripped
+    # off so the block grid lines up with the (t, h, w) cuboid.
+    if use_static_block_mask and thw is None:
         use_static_block_mask = False
 
-    if reorder_sequence:
-        if thw is None:
-            raise ValueError(
-                "Sparge with reorder_sequence=True requires "
-                "`attention_kwargs['thw']` to be published by the model wrapper."
-            )
+    if reorder_sequence and thw is None:
+        raise ValueError(
+            "Sparge with reorder_sequence=True requires "
+            "`attention_kwargs['thw']` to be published by the model wrapper."
+        )
+
+    if thw is not None and (reorder_sequence or use_static_block_mask):
         spatial_len = thw[0] * thw[1] * thw[2]
         sp_pad_len = image_len_post_deint - spatial_len
         if sp_pad_len < 0:
@@ -150,11 +170,22 @@ def setup_sparge(
                 f"({spatial_len}). Mismatch between attention_kwargs['thw'] "
                 f"and the input sequence."
             )
+
+    if reorder_sequence:
         fwd_perm, inv_perm = get_gilbert_perm(thw, query.device)
         if use_static_block_mask:
             static_mask = get_static_block_neighbor_mask(
-                thw, block_m, block_n, query.device, gilbert_mapping=(inv_perm, fwd_perm)
+                thw, block_m, block_n, query.device,
+                gilbert_mapping=(inv_perm, fwd_perm),
+                mapping_kind="gilbert",
             )
+    elif use_static_block_mask:
+        # Linear (row-major) order: feed the neighbour builder an identity
+        # linear_to_hilbert so it emits a *linear*-block neighbour mask.
+        static_mask = get_static_block_neighbor_mask(
+            thw, block_m, block_n, query.device,
+            mapping_kind="linear",
+        )
 
     # Split off image part (without SP padding) and text part.
     if text_len_post_deint > 0:

--- a/xfuser/core/sparge_attention/sparge.py
+++ b/xfuser/core/sparge_attention/sparge.py
@@ -118,7 +118,7 @@ def setup_sparge(
 
     text_len_post_deint = encoder_sequence_length * sp_size
 
-    # 1) Ulysses de-interleave (no-op when text_len == 0 or sp_size == 1).
+    # Ulysses de-interleave (no-op when text_len == 0 or sp_size == 1).
     if text_len_post_deint > 0 and sp_size > 1:
         query = _deinterleave(query, sp_size, encoder_sequence_length)
         key = _deinterleave(key, sp_size, encoder_sequence_length)
@@ -130,12 +130,16 @@ def setup_sparge(
     static_mask: Optional[torch.Tensor] = None
     sp_pad_len = 0
 
-    if reorder_sequence or use_static_block_mask:
+    # Static mask is defined in Gilbert-permuted block space; meaningless
+    # without reorder. Match upstream's invariant and silently drop it.
+    if use_static_block_mask and not reorder_sequence:
+        use_static_block_mask = False
+
+    if reorder_sequence:
         if thw is None:
             raise ValueError(
-                "Sparge with reorder_sequence=True or "
-                "use_static_block_mask=True requires `attention_kwargs['thw']` "
-                "to be published by the model wrapper."
+                "Sparge with reorder_sequence=True requires "
+                "`attention_kwargs['thw']` to be published by the model wrapper."
             )
         spatial_len = thw[0] * thw[1] * thw[2]
         sp_pad_len = image_len_post_deint - spatial_len
@@ -146,14 +150,13 @@ def setup_sparge(
                 f"({spatial_len}). Mismatch between attention_kwargs['thw'] "
                 f"and the input sequence."
             )
-        if reorder_sequence:
-            fwd_perm, inv_perm = get_gilbert_perm(thw, query.device)
+        fwd_perm, inv_perm = get_gilbert_perm(thw, query.device)
         if use_static_block_mask:
             static_mask = get_static_block_neighbor_mask(
                 thw, block_m, block_n, query.device, gilbert_mapping=(inv_perm, fwd_perm)
             )
 
-    # 2) Split off image part (without SP padding) and text part.
+    # Split off image part (without SP padding) and text part.
     if text_len_post_deint > 0:
         image_q = query[:, :, :image_len_post_deint, :]
         image_k = key[:, :, :image_len_post_deint, :]
@@ -171,13 +174,12 @@ def setup_sparge(
         image_k = image_k[:, :, :spatial_len, :]
         image_v = image_v[:, :, :spatial_len, :]
 
-    # 3) Gilbert permute on the image part.
     if fwd_perm is not None:
         image_q = image_q.index_select(dim=2, index=fwd_perm)
         image_k = image_k.index_select(dim=2, index=fwd_perm)
         image_v = image_v.index_select(dim=2, index=fwd_perm)
 
-    # 4) Re-concatenate text tail.
+    # Re-concatenate text tail.
     if text_q is not None:
         q_out = torch.cat([image_q, text_q], dim=2)
         k_out = torch.cat([image_k, text_k], dim=2)


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes related to argument parsing and the handling of block neighbor masks and sequence reordering in the Sparge attention module. 

**Argument Parsing Improvements:**

* Added a static method `_normalize_name` in `FlexibleArgumentParser` to correctly handle argument names with both underscores and dashes, especially for boolean flags (e.g., `--no-foo`), preventing mismatches with argparse's internal registration.

**Sparge Attention Enhancements:**

* Modified `get_static_block_neighbor_mask` to accept a `mapping_kind` parameter, allowing disambiguation between different block layouts (Gilbert-reordered vs. linear row-major), and to build an identity mapping on demand for linear layouts.
* Refactored `setup_sparge` to:
  - Distinguish between when to use static block masks and/or reorder sequences, with clearer error handling and logic separation.
  - Support both Gilbert and linear block neighbor masks, and ensure correct handling of spatial padding and permutation.
  - Improve comments and code clarity around sequence permutation and mask application.