### PR TITLE
Flex block sparge

### DIFF
--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -975,7 +975,7 @@ def _aiter_sparge_v2_attn_call(query, key, value, dropout_p, is_causal, attentio
 
 @register_attention_function(AttentionBackendType.FLEX_BLOCK_SPARGE)
 def _flex_block_sparge_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs=None):
-    config = {"BLOCK_M": 128, "BLOCK_N": 128}
+    config = {"BLOCK_M": 256, "BLOCK_N": 256}
     q, k, v, state, block_mask, num_heads = _build_sparge_block_mask(
         query, key, value, is_causal, attention_kwargs, config, pad_block_divisible=True
     )

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -16,6 +16,7 @@ from xfuser.core.sparge_attention.sparge import (
     setup_sparge,
     compute_sparge_block_mask,
     restore_sparge_output,
+    mask_padded_kv_blocks,
 )
 
 ATTENTION_FUNCTION_REGISTRY = {}
@@ -399,6 +400,7 @@ class AttentionBackendType(Enum):
     AITER_SPARSE_SAGE_V2 = "AITER Sparse Sage V2"
     AITER_SPARGE = "AITER Sparge"
     AITER_SPARGE_V2 = "AITER Sparge V2"
+    FLEX_BLOCK_SPARGE = "Flex Block Sparge"
     AITER_FLYDSL = "AITER FlyDSL"
     NPU = "NPU"
 
@@ -920,7 +922,7 @@ def _read_sparge_kwargs(attention_kwargs):
         attn_kwargs.get("encoder_sequence_length", 0),
     )
 
-def _build_sparge_block_mask(query, key, value, is_causal, attention_kwargs, config):
+def _build_sparge_block_mask(query, key, value, is_causal, attention_kwargs, config, pad_block_divisible=False):
     simthreshd1, cdfthreshd, reorder, use_static, thw, esl = _read_sparge_kwargs(attention_kwargs)
     q, k, v, state, static_mask = setup_sparge(
         query, key, value,
@@ -930,6 +932,7 @@ def _build_sparge_block_mask(query, key, value, is_causal, attention_kwargs, con
         reorder_sequence=reorder,
         use_static_block_mask=use_static,
         block_m=config["BLOCK_M"], block_n=config["BLOCK_N"],
+        pad_block_divisible=pad_block_divisible,
     )
     block_mask = compute_sparge_block_mask(
         q, k,
@@ -937,9 +940,10 @@ def _build_sparge_block_mask(query, key, value, is_causal, attention_kwargs, con
         cdfthreshd=cdfthreshd,
         is_causal=is_causal,
         static_block_mask=static_mask,
-        text_len=state.text_len,
+        text_len=state.text_len + state.tail_pad,
         block_m=config["BLOCK_M"], block_n=config["BLOCK_N"],
     )
+    block_mask = mask_padded_kv_blocks(block_mask, state, config["BLOCK_N"])
     num_heads = q.shape[1]
     return q, k, v, state, block_mask, num_heads
 
@@ -966,6 +970,18 @@ def _aiter_sparge_v2_attn_call(query, key, value, dropout_p, is_causal, attentio
         q, k, v, causal=is_causal, block_lut=block_lut,
         layout="bhsd", hadamard_rotation=True,
         R=HADAMARD_MATRIX[query.device], config=config,
+    )
+    return restore_sparge_output(output, state), None
+
+@register_attention_function(AttentionBackendType.FLEX_BLOCK_SPARGE)
+def _flex_block_sparge_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs=None):
+    config = {"BLOCK_M": 128, "BLOCK_N": 128}
+    q, k, v, state, block_mask, num_heads = _build_sparge_block_mask(
+        query, key, value, is_causal, attention_kwargs, config, pad_block_divisible=True
+    )
+    output = flex_block_attn_op(
+        q.contiguous(), k.contiguous(), v.contiguous(),
+        config["BLOCK_M"], config["BLOCK_N"], block_mask,
     )
     return restore_sparge_output(output, state), None
 

--- a/xfuser/core/distributed/runtime_state.py
+++ b/xfuser/core/distributed/runtime_state.py
@@ -217,7 +217,8 @@ class RuntimeState(metaclass=ABCMeta):
                                  AttentionBackendType.AITER_SPARSE_SAGE_V2,
                                  AttentionBackendType.AITER_SPARGE_V2,
                                  AttentionBackendType.AITER_FLYDSL,
-                                 AttentionBackendType.FLEX_BLOCK_ATTN]:
+                                 AttentionBackendType.FLEX_BLOCK_ATTN,
+                                 AttentionBackendType.FLEX_BLOCK_SPARGE]:
             if self.parallel_config.ring_degree > 1:
                 raise RuntimeError("Selected attention backend does not support ring parallelism.")
         if attention_backend == AttentionBackendType.AITER_FP8:
@@ -281,7 +282,8 @@ class RuntimeState(metaclass=ABCMeta):
                 from aiter.ops.flydsl import flydsl_flash_attn_func
             except ImportError:
                 raise RuntimeError("AITER FlyDSL attention is not available, please update AITER") from None
-        elif attention_backend == AttentionBackendType.FLEX_BLOCK_ATTN:
+        elif attention_backend in (AttentionBackendType.FLEX_BLOCK_ATTN,
+                                   AttentionBackendType.FLEX_BLOCK_SPARGE):
             if not env_info["has_flex_block_attn"]:
                 raise RuntimeError("Flex Block Attention is not available, please install Flex Block Attention.")
 

--- a/xfuser/core/sparge_attention/sparge.py
+++ b/xfuser/core/sparge_attention/sparge.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Optional, Tuple
 
 import torch
+import torch.nn.functional as F
 
 from xfuser.core.sparge_attention.block_mask import get_block_map_meansim
 from xfuser.core.sparge_attention.gilbert import (
@@ -41,6 +42,9 @@ class SpargeState:
     d: int
     dtype: torch.dtype
     device: torch.device
+    image_len: int = 0
+    img_pad: int = 0
+    tail_pad: int = 0
 
 
 # ── Cache builders ───────────────────────────────────────────────────────────
@@ -129,6 +133,7 @@ def setup_sparge(
     use_static_block_mask: bool = False,
     block_m: int = 128,
     block_n: int = 128,
+    pad_block_divisible: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor,
            SpargeState, Optional[torch.Tensor]]:
 
@@ -210,6 +215,26 @@ def setup_sparge(
         image_k = image_k.index_select(dim=2, index=fwd_perm)
         image_v = image_v.index_select(dim=2, index=fwd_perm)
 
+    _a, _b = block_m, block_n
+    while _b:
+        _a, _b = _b, _a % _b
+    align = block_m * block_n // _a
+    image_len = image_q.shape[2]
+    need_image_pad = pad_block_divisible or text_len_post_deint > 0
+    img_pad = (-image_len) % align if need_image_pad else 0
+    if img_pad > 0:
+        image_q = F.pad(image_q, (0, 0, 0, img_pad))
+        image_k = F.pad(image_k, (0, 0, 0, img_pad))
+        image_v = F.pad(image_v, (0, 0, 0, img_pad))
+        if static_mask is not None:
+            n_iq = (image_len + img_pad) // block_m
+            n_ik = (image_len + img_pad) // block_n
+            padded_static = torch.zeros(
+                (n_iq, n_ik), dtype=static_mask.dtype, device=static_mask.device
+            )
+            padded_static[: static_mask.shape[0], : static_mask.shape[1]] = static_mask
+            static_mask = padded_static
+
     # Re-concatenate text tail.
     if text_q is not None:
         q_out = torch.cat([image_q, text_q], dim=2)
@@ -219,6 +244,13 @@ def setup_sparge(
         q_out = image_q
         k_out = image_k
         v_out = image_v
+
+    total_len = q_out.shape[2]
+    tail_pad = (-total_len) % align if pad_block_divisible else 0
+    if tail_pad > 0:
+        q_out = F.pad(q_out, (0, 0, 0, tail_pad))
+        k_out = F.pad(k_out, (0, 0, 0, tail_pad))
+        v_out = F.pad(v_out, (0, 0, 0, tail_pad))
 
     state = SpargeState(
         sp_pad_len=sp_pad_len,
@@ -230,6 +262,9 @@ def setup_sparge(
         d=d,
         dtype=query.dtype,
         device=query.device,
+        image_len=image_len,
+        img_pad=img_pad,
+        tail_pad=tail_pad,
     )
     return q_out, k_out, v_out, state, static_mask
 
@@ -293,12 +328,18 @@ def compute_sparge_block_mask(
 
 
 def restore_sparge_output(o: torch.Tensor, state: SpargeState) -> torch.Tensor:
+    if state.tail_pad > 0:
+        o = o[:, :, : o.shape[2] - state.tail_pad, :]
+
     if state.text_len > 0:
-        image_o = o[:, :, :-state.text_len, :]
         text_o = o[:, :, -state.text_len:, :]
+        image_o = o[:, :, : o.shape[2] - state.text_len, :]
     else:
         image_o = o
         text_o = None
+
+    if state.img_pad > 0:
+        image_o = image_o[:, :, : image_o.shape[2] - state.img_pad, :]
 
     if state.inv_perm is not None:
         image_o = image_o.index_select(dim=2, index=state.inv_perm)
@@ -320,3 +361,24 @@ def restore_sparge_output(o: torch.Tensor, state: SpargeState) -> torch.Tensor:
         # sp_size); pass per-rank text length to _reinterleave.
         out = _reinterleave(out, state.sp_size, state.text_len // state.sp_size)
     return out
+
+
+def mask_padded_kv_blocks(
+    block_mask: torch.Tensor, state: SpargeState, block_n: int
+) -> torch.Tensor:
+    if state.img_pad == 0 and state.tail_pad == 0:
+        return block_mask
+
+    image_padded = state.image_len + state.img_pad
+    n_ik = image_padded // block_n
+    first_img_pad = (state.image_len + block_n - 1) // block_n
+    if first_img_pad < n_ik:
+        block_mask[:, :, :, first_img_pad:n_ik] = False
+
+    if state.tail_pad > 0:
+        n_tk = (state.text_len + state.tail_pad + block_n - 1) // block_n
+        first_txt_pad = (state.text_len + block_n - 1) // block_n
+        if first_txt_pad < n_tk:
+            block_mask[:, :, :, n_ik + first_txt_pad : n_ik + n_tk] = False
+
+    return block_mask

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -67,6 +67,7 @@ _SPARSE_ATTENTION_BACKENDS = frozenset({
 _SPARGE_ATTENTION_BACKENDS = frozenset({
     AttentionBackendType.AITER_SPARGE,
     AttentionBackendType.AITER_SPARGE_V2,
+    AttentionBackendType.FLEX_BLOCK_SPARGE,
 })
 
 


### PR DESCRIPTION
The `FLEX_BLOCK_SPARGE` work adds a new flex-attention sparse backend that reuses the existing sparge mask/reorder machinery: in `attention_backend.py` it registers the backend and shares the `_build_sparge_block_mask` path with aiter_sparge (sparge setup → mean-sim dynamic mask OR'd with the static block-neighbor mask → padded-KV-block masking), then runs flex block attention via `flex_block_attn_op`, using square 256×256 blocks (BLOCK_M = BLOCK_N = 256) rather than aiter_sparge's 256×128, since flex's rectangular-block path is slower/broken. It calls the shared sparge setup with `pad_block_divisible=True` so the query/key sequences are padded up to align = `lcm(block_m, block_n)` (computed inline via the Euclidean gcd to avoid a torch.compile graph break) to satisfy the flex kernel's divisibility requirements, with fully-padded key blocks zeroed out by mask_padded_kv_blocks and the padding stripped back off in `restore_sparge_output`; the new `pad_block_divisible `flag defaults to False so the AITER backends are unaffected. `runtime_state.py` wires up recognition/availability of the new backend, and `base_model.py` gates all sparge backends (flex included) to Wan only with cross-attention disallowed, so `text_len `is effectively zero in the supported config, the net result being a flex-based sparse backend that mirrors the sparge masking.