### PR TITLE
[Model] Add Cosmos3-Super/Nano support

### DIFF
--- a/xfuser/model_executor/models/runner_models/cosmos3.py
+++ b/xfuser/model_executor/models/runner_models/cosmos3.py
@@ -1,0 +1,244 @@
+import copy
+import json
+import torch
+from diffusers import UniPCMultistepScheduler
+from diffusers.pipelines.pipeline_utils import DiffusionPipeline
+
+from xfuser import xFuserArgs
+from xfuser.model_executor.models.transformers.transformer_cosmos3 import (
+    get_cosmos3_transformer_wrapper_class,
+)
+from xfuser.model_executor.pipelines.pipeline_cosmos3_omni import (
+    get_cosmos3_pipeline_class,
+)
+from xfuser.model_executor.models.runner_models.base_model import (
+    ModelSettings,
+    xFuserModel,
+    register_model,
+    ModelCapabilities,
+    DefaultInputValues,
+    DiffusionOutput,
+    _parse_attention_backend,
+)
+from xfuser.core.distributed.parallel_state import get_vae_parallel_group
+from xfuser.core.distributed.attention_backend import AttentionBackendType
+from xfuser.core.utils.runner_utils import log, resize_and_crop_image
+
+# Only full-precision attention backends produce correct results on Cosmos3.
+# Quantized backends (FP8, MXFP4, MLA) cause >50% relative error per layer
+# due to extreme K/V dynamic range mismatch in the MoT attention.
+_COSMOS3_SUPPORTED_ATTN_BACKENDS = frozenset({
+    AttentionBackendType.AITER,
+    AttentionBackendType.SDPA,
+    AttentionBackendType.SDPA_MATH,
+    AttentionBackendType.SDPA_EFFICIENT,
+    AttentionBackendType.SDPA_FLASH,
+    AttentionBackendType.FLASH,
+    AttentionBackendType.FLASH_3,
+    AttentionBackendType.FLASH_4,
+})
+
+
+COSMOS3_FSDP_STRATEGY = {
+    "transformer": {
+        "wrap_attrs": ["layers"],
+        "dtype": torch.bfloat16,
+    },
+}
+
+
+def _setup_parallel_vae(vae, enable_parallel_encoder=True):
+    if enable_parallel_encoder:
+        try:
+            from distvae.modules.adapters.vae.encoder_adapters import WanEncoderAdapter
+            # scale_factor_spatial includes patch_size (e.g. 16 = 8x from encoder + 2x
+            # from patching). The encoder adapter needs just the encoder's own
+            # downsampling ratio, excluding the patching step.
+            vae_scale_factor = getattr(vae.config, 'scale_factor_spatial', 8)
+            patch_size = getattr(vae.config, 'patch_size', None)
+            if patch_size and patch_size > 1:
+                vae_scale_factor = vae_scale_factor // patch_size
+            patched_encoder = WanEncoderAdapter(
+                vae.encoder,
+                vae_group=get_vae_parallel_group().device_group,
+                vae_scale_factor=vae_scale_factor,
+            ).to(vae.device)
+            vae.encoder = patched_encoder
+            log("Parallel VAE encoder enabled.")
+        except ImportError:
+            log("DistVAE not available for encoder. Defaulting to single-rank.")
+        except Exception as e:
+            raise ValueError(f"Failed to patch VAE encoder: {e}")
+    try:
+        from distvae.modules.adapters.vae.decoder_adapters import WanDecoderAdapter
+        patched_decoder = WanDecoderAdapter(
+            vae.decoder, vae_group=get_vae_parallel_group().device_group
+        ).to(vae.device)
+        # Cosmos3 VAE has patch_size=2 (extra 2x spatial upsampling from
+        # unpatching). The decoder adapter's scale_factor defaults to 1 in
+        # its Patchify, which is correct for Wan (patch_size=None). For
+        # Cosmos3 we need to account for the extra factor so that the
+        # narrow in _forward crops to the right size.
+        patch_size = getattr(vae.config, 'patch_size', None)
+        if patch_size and patch_size > 1:
+            patched_decoder.patchify.scale_factor = patch_size
+        vae.decoder = patched_decoder
+        log("Parallel VAE decoder enabled.")
+    except ImportError:
+        log("DistVAE not available for decoder. Defaulting to single-rank.")
+    except Exception as e:
+        raise ValueError(f"Failed to patch VAE decoder: {e}")
+
+
+@register_model("nvidia/Cosmos3-Super")
+@register_model("Cosmos3-Super")
+class xFuserCosmos3SuperModel(xFuserModel):
+
+    capabilities = ModelCapabilities(
+        ulysses_degree=True,
+        ring_degree=True,
+        fully_shard_degree=True,
+        use_cfg_parallel=True,
+        use_parallel_vae=True,
+        use_parallel_vae_encoder=True,
+        use_fp8_gemms=True,
+        use_fp4_gemms=True,
+        enable_slicing=True,
+        enable_tiling=True,
+    )
+    default_input_values = DefaultInputValues(
+        height=720,
+        width=1280,
+        num_frames=189,
+        num_inference_steps=35,
+        guidance_scale=6.0,
+        flow_shift=10.0,
+    )
+    settings = ModelSettings(
+        model_name="nvidia/Cosmos3-Super",
+        output_name="cosmos3_super",
+        model_output_type="video",
+        fps=24,
+        mod_value=16,
+        fp8_gemm_module_list=["transformer.layers"],
+        fp4_gemm_module_list=["transformer.layers"],
+        fp8_precision_overrides=tuple(
+            f"{i}." for i in list(range(10)) + list(range(54, 64))
+        ),
+        fsdp_strategy=COSMOS3_FSDP_STRATEGY,
+    )
+
+    def _validate_config(self, config) -> None:
+        super()._validate_config(config)
+        backend = _parse_attention_backend(config.attention_backend, "attention backend")
+        if backend is not None and backend not in _COSMOS3_SUPPORTED_ATTN_BACKENDS:
+            supported = ", ".join(sorted(b.name for b in _COSMOS3_SUPPORTED_ATTN_BACKENDS))
+            raise ValueError(
+                f"Cosmos3 does not support --attention_backend {backend.name}. "
+                f"Quantized attention backends produce >50% relative error on this "
+                f"model due to extreme K/V dynamic range mismatch in the MoT attention. "
+                f"Supported backends: {supported}"
+            )
+
+    def _load_model(self) -> DiffusionPipeline:
+        xFuserCosmos3OmniTransformerWrapper = get_cosmos3_transformer_wrapper_class()
+
+        transformer = xFuserCosmos3OmniTransformerWrapper.from_pretrained(
+            self.settings.model_name,
+            torch_dtype=torch.bfloat16,
+            subfolder="transformer",
+        )
+
+        xFuserCosmos3OmniPipeline = get_cosmos3_pipeline_class()
+
+        pipe = xFuserCosmos3OmniPipeline.from_pretrained(
+            pretrained_model_name_or_path=self.settings.model_name,
+            transformer=transformer,
+            torch_dtype=torch.bfloat16,
+            enable_safety_checker=False,
+        )
+        return pipe
+
+    def _run_pipe(self, input_args: dict) -> DiffusionOutput:
+        prompt = input_args.get("prompt", "")
+        negative_prompt = input_args.get("negative_prompt", "")
+        if isinstance(prompt, list):
+            prompt = prompt[0] if prompt else ""
+        if isinstance(negative_prompt, list):
+            negative_prompt = negative_prompt[0] if negative_prompt else ""
+
+        # Cosmos3 expects JSON-formatted prompts for best quality.
+        # If prompt is a path to a .json file, load and serialize it.
+        if isinstance(prompt, str) and prompt.endswith(".json"):
+            with open(prompt, "r", encoding="utf-8") as f:
+                prompt = json.dumps(json.load(f))
+        if isinstance(negative_prompt, str) and negative_prompt.endswith(".json"):
+            with open(negative_prompt, "r", encoding="utf-8") as f:
+                negative_prompt = json.dumps(json.load(f))
+
+        kwargs = dict(
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            height=input_args["height"],
+            width=input_args["width"],
+            num_frames=input_args["num_frames"],
+            num_inference_steps=input_args["num_inference_steps"],
+            guidance_scale=input_args["guidance_scale"],
+            fps=float(self.settings.fps),
+            enable_sound=False,
+            generator=torch.Generator(device="cuda").manual_seed(input_args["seed"]),
+            output_type="np",
+            add_resolution_template=False,
+            add_duration_template=False,
+        )
+        if "image" in input_args and input_args["image"] is not None:
+            kwargs["image"] = input_args["image"]
+        output = self.pipe(**kwargs)
+        return DiffusionOutput(videos=output.video, pipe_args=input_args)
+
+    def _preprocess_args_images(self, input_args: dict) -> dict:
+        input_args = super()._preprocess_args_images(input_args)
+        images = input_args.get("input_images", [])
+        if images:
+            image = images[0]
+            width, height = input_args["width"], input_args["height"]
+            if input_args.get("resize_input_images", False):
+                image = resize_and_crop_image(image, width, height, self.settings.mod_value)
+            input_args["image"] = image
+        return input_args
+
+    def _compile_model(self, input_args: dict) -> None:
+        torch._inductor.config.reorder_for_compute_comm_overlap = True
+        self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
+        compile_args = copy.deepcopy(input_args)
+        compile_args["num_inference_steps"] = 2
+        self._run_timed_pipe(compile_args)
+
+    def _post_load_and_state_initialization(self, input_args: dict) -> None:
+        super()._post_load_and_state_initialization(input_args)
+        flow_shift = input_args.get("flow_shift", 10.0)
+        self.pipe.scheduler = UniPCMultistepScheduler.from_config(
+            self.pipe.scheduler.config, flow_shift=flow_shift
+        )
+        log(f"Scheduler set to UniPCMultistepScheduler with flow_shift={flow_shift}")
+        if self.config.fully_shard_degree > 1:
+            if hasattr(self.pipe.transformer, '_patch_time_embedder_for_fsdp'):
+                self.pipe.transformer._patch_time_embedder_for_fsdp()
+        if self.config.use_parallel_vae:
+            _setup_parallel_vae(self.pipe.vae, self.capabilities.use_parallel_vae_encoder)
+
+
+@register_model("nvidia/Cosmos3-Nano")
+@register_model("Cosmos3-Nano")
+class xFuserCosmos3NanoModel(xFuserCosmos3SuperModel):
+
+    settings = ModelSettings(
+        model_name="nvidia/Cosmos3-Nano",
+        output_name="cosmos3_nano",
+        model_output_type="video",
+        fps=24,
+        mod_value=16,
+        fp8_gemm_module_list=["transformer.layers"],
+        fp4_gemm_module_list=["transformer.layers"],
+        fsdp_strategy=COSMOS3_FSDP_STRATEGY,
+    )

--- a/xfuser/model_executor/models/transformers/transformer_cosmos3.py
+++ b/xfuser/model_executor/models/transformers/transformer_cosmos3.py
@@ -1,0 +1,425 @@
+import math
+import torch
+from torch.nn.functional import scaled_dot_product_attention as sdpa
+from typing import Optional
+
+from xfuser.model_executor.layers.usp import USP, attention
+from xfuser.core.distributed import (
+    get_sequence_parallel_world_size,
+    get_sequence_parallel_rank,
+    get_sp_group,
+    get_runtime_state,
+)
+
+
+class xFuserCosmos3AttnProcessor:
+    """Replaces Cosmos3AttnProcessor with USP-parallel attention for the generation (DM) pathway.
+
+    Mirrors the stock Cosmos3AttnProcessor exactly (same RoPE, same tensor layout)
+    but uses USP for distributed attention when SP is active.
+    """
+
+    def __call__(self, attn, und_seq, gen_seq, rotary_emb):
+        cos_und, sin_und, cos_gen, sin_gen = rotary_emb
+
+        # Per-pathway projections: [S, H, D]
+        q_und = attn.to_q(und_seq).view(-1, attn.num_attention_heads, attn.head_dim)
+        k_und = attn.to_k(und_seq).view(-1, attn.num_key_value_heads, attn.head_dim)
+        v_und = attn.to_v(und_seq).view(-1, attn.num_key_value_heads, attn.head_dim)
+        q_gen = attn.add_q_proj(gen_seq).view(-1, attn.num_attention_heads, attn.head_dim)
+        k_gen = attn.add_k_proj(gen_seq).view(-1, attn.num_key_value_heads, attn.head_dim)
+        v_gen = attn.add_v_proj(gen_seq).view(-1, attn.num_key_value_heads, attn.head_dim)
+
+        q_und = attn.norm_q(q_und)
+        k_und = attn.norm_k(k_und)
+        q_gen = attn.norm_added_q(q_gen)
+        k_gen = attn.norm_added_k(k_gen)
+
+        # RoPE: same _rotate_half convention as stock processor
+        cos_und = cos_und.unsqueeze(1)
+        sin_und = sin_und.unsqueeze(1)
+        q_und = q_und * cos_und + _rotate_half(q_und) * sin_und
+        k_und = k_und * cos_und + _rotate_half(k_und) * sin_und
+        cos_gen = cos_gen.unsqueeze(1)
+        sin_gen = sin_gen.unsqueeze(1)
+        q_gen = q_gen * cos_gen + _rotate_half(q_gen) * sin_gen
+        k_gen = k_gen * cos_gen + _rotate_half(k_gen) * sin_gen
+
+        try:
+            sp_world_size = get_sequence_parallel_world_size()
+        except AssertionError:
+            sp_world_size = 1
+
+        if sp_world_size > 1:
+            # gen_seq is pre-chunked (S/P tokens per rank).
+            # USP all-to-all redistributes: [S/P, H, D] → [S, H/P, D]
+            # so attention sees full gen sequence with fewer heads.
+            # und tokens are replicated (not chunked); we pre-concat
+            # them to gen KV so they go through the all-to-all too
+            # (small overhead, ~50 tokens).
+
+            # Transpose to BHSD for USP: [S, H, D] -> [1, H, S, D]
+            q_und_b = q_und.unsqueeze(0).transpose(1, 2)
+            k_und_b = k_und.unsqueeze(0).transpose(1, 2)
+            v_und_b = v_und.unsqueeze(0).transpose(1, 2)
+            q_gen_b = q_gen.unsqueeze(0).transpose(1, 2)
+            k_gen_b = k_gen.unsqueeze(0).transpose(1, 2)
+            v_gen_b = v_gen.unsqueeze(0).transpose(1, 2)
+
+            # AR pathway: causal self-attention (no SP, und tokens are short)
+            causal_out = attention(q_und_b, k_und_b, v_und_b, dropout_p=0.0, is_causal=True)
+
+            # DM pathway: gen_q × [und_kv; gen_kv]
+            # Pre-concat und KV to gen KV. USP's all-to-all will
+            # redistribute the combined KV (splitting heads, gathering
+            # sequence). The output has the same seq dim as gen_q input.
+            k_full_b = torch.cat([k_und_b, k_gen_b], dim=2)
+            v_full_b = torch.cat([v_und_b, v_gen_b], dim=2)
+            full_out = USP(
+                q_gen_b, k_full_b, v_full_b,
+                dropout_p=0.0, is_causal=False,
+            )
+            causal_out = causal_out.squeeze(0).transpose(0, 1).flatten(-2, -1)
+            full_out = full_out.squeeze(0).transpose(0, 1).flatten(-2, -1)
+        else:
+            # Non-distributed: use SDPA with GQA head expansion in BHSD layout.
+            # Input tensors are [S, H, D]. SDPA on ROCm requires BHSD [B, H, S, D]
+            # for cross-attention with different Q/KV sequence lengths.
+            num_kv_groups = attn.num_key_value_groups
+
+            k_und_exp = k_und.repeat_interleave(num_kv_groups, dim=1)
+            v_und_exp = v_und.repeat_interleave(num_kv_groups, dim=1)
+            # [S, H, D] -> [1, H, S, D] (BHSD)
+            causal_out = sdpa(
+                q_und.unsqueeze(0).transpose(1, 2),
+                k_und_exp.unsqueeze(0).transpose(1, 2),
+                v_und_exp.unsqueeze(0).transpose(1, 2),
+                is_causal=True,
+            ).transpose(1, 2).squeeze(0).flatten(-2, -1)
+
+            all_k = torch.cat([k_und, k_gen], dim=0)
+            all_v = torch.cat([v_und, v_gen], dim=0)
+            all_k_exp = all_k.repeat_interleave(num_kv_groups, dim=1)
+            all_v_exp = all_v.repeat_interleave(num_kv_groups, dim=1)
+            full_out = sdpa(
+                q_gen.unsqueeze(0).transpose(1, 2),
+                all_k_exp.unsqueeze(0).transpose(1, 2),
+                all_v_exp.unsqueeze(0).transpose(1, 2),
+                is_causal=False,
+            ).transpose(1, 2).squeeze(0).flatten(-2, -1)
+
+        und_out = attn.to_out(causal_out)
+        gen_out = attn.to_add_out(full_out)
+        return und_out, gen_out
+
+
+def _rotate_half(x):
+    half = x.shape[-1] // 2
+    return torch.cat((-x[..., half:], x[..., :half]), dim=-1)
+
+
+def _make_xfuser_cosmos3_transformer_wrapper():
+    """Lazily create the wrapper class to avoid import errors when diffusers < 0.37.1."""
+    from diffusers.models.transformers.transformer_cosmos3 import (
+        Cosmos3OmniTransformer,
+        Cosmos3PackedMoTAttention,
+    )
+
+    class _AutoCastWrapper(torch.nn.Module):
+        """Wraps a module to auto-cast inputs to match parameter dtype."""
+        def __init__(self, module):
+            super().__init__()
+            self.module = module
+
+        def forward(self, sample, *args, **kwargs):
+            param_dtype = next(self.module.parameters()).dtype
+            return self.module(sample.to(param_dtype), *args, **kwargs)
+
+        def parameters(self, *args, **kwargs):
+            return self.module.parameters(*args, **kwargs)
+
+    class xFuserCosmos3OmniTransformerWrapper(Cosmos3OmniTransformer):
+
+        def _install_xfuser_processors(self):
+            for layer in self.layers:
+                layer.self_attn.processor = xFuserCosmos3AttnProcessor()
+
+        def _patch_time_embedder_for_fsdp(self):
+            """Wrap time_embedder with auto-cast, fixing FSDP dtype mismatch."""
+            self.time_embedder = _AutoCastWrapper(self.time_embedder)
+
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            model = super().from_pretrained(*args, **kwargs)
+            model.__class__ = cls
+            model._install_xfuser_processors()
+            return model
+
+        def _chunk_and_pad_sequence(self, x, sp_rank, sp_size, pad_amount, dim):
+            if pad_amount > 0:
+                if dim < 0:
+                    dim = x.ndim + dim
+                pad_shape = list(x.shape)
+                pad_shape[dim] = pad_amount
+                x = torch.cat([x, torch.zeros(pad_shape, dtype=x.dtype, device=x.device)], dim=dim)
+            return torch.chunk(x, sp_size, dim=dim)[sp_rank]
+
+        def _gather_and_unpad(self, x, pad_amount, dim):
+            x = get_sp_group().all_gather(x, dim=dim)
+            size = x.size(dim)
+            return x.narrow(dim=dim, start=0, length=size - pad_amount)
+
+        def forward(
+            self,
+            input_ids,
+            text_indexes,
+            position_ids,
+            und_len,
+            sequence_length,
+            vision_tokens,
+            vision_token_shapes,
+            vision_sequence_indexes,
+            vision_mse_loss_indexes,
+            vision_timesteps,
+            vision_noisy_frame_indexes,
+            sound_tokens=None,
+            sound_token_shapes=None,
+            sound_sequence_indexes=None,
+            sound_mse_loss_indexes=None,
+            sound_timesteps=None,
+            sound_noisy_frame_indexes=None,
+            action_tokens=None,
+            action_token_shapes=None,
+            action_sequence_indexes=None,
+            action_mse_loss_indexes=None,
+            action_timesteps=None,
+            action_noisy_frame_indexes=None,
+            action_domain_ids=None,
+        ):
+            try:
+                get_runtime_state().increment_step_counter()
+                sp_rank = get_sequence_parallel_rank()
+                sp_size = get_sequence_parallel_world_size()
+            except AssertionError:
+                sp_rank = 0
+                sp_size = 1
+
+            if sp_size <= 1:
+                # No sequence parallelism — delegate to parent forward.
+                # Our xFuserCosmos3AttnProcessor handles the attention
+                # correctly with USP (which falls through to direct attention
+                # when sp_size == 1).
+                return Cosmos3OmniTransformer.forward(
+                    self,
+                    input_ids=input_ids,
+                    text_indexes=text_indexes,
+                    position_ids=position_ids,
+                    und_len=und_len,
+                    sequence_length=sequence_length,
+                    vision_tokens=vision_tokens,
+                    vision_token_shapes=vision_token_shapes,
+                    vision_sequence_indexes=vision_sequence_indexes,
+                    vision_mse_loss_indexes=vision_mse_loss_indexes,
+                    vision_timesteps=vision_timesteps,
+                    vision_noisy_frame_indexes=vision_noisy_frame_indexes,
+                    sound_tokens=sound_tokens,
+                    sound_token_shapes=sound_token_shapes,
+                    sound_sequence_indexes=sound_sequence_indexes,
+                    sound_mse_loss_indexes=sound_mse_loss_indexes,
+                    sound_timesteps=sound_timesteps,
+                    sound_noisy_frame_indexes=sound_noisy_frame_indexes,
+                    action_tokens=action_tokens,
+                    action_token_shapes=action_token_shapes,
+                    action_sequence_indexes=action_sequence_indexes,
+                    action_mse_loss_indexes=action_mse_loss_indexes,
+                    action_timesteps=action_timesteps,
+                    action_noisy_frame_indexes=action_noisy_frame_indexes,
+                    action_domain_ids=action_domain_ids,
+                )
+
+            # SP path: chunk gen_seq across ranks so MLPs/norms run on 1/P
+            # of the sequence. USP handles the all-to-all inside attention.
+            has_sound = sound_tokens is not None and sound_sequence_indexes is not None
+            has_action = action_tokens is not None and action_sequence_indexes is not None
+
+            # Replicate parent's setup: embed, patchify, build joint sequence
+            packed_text_embedding = self.embed_tokens(input_ids)
+            target_dtype = packed_text_embedding.dtype
+            hidden_states = packed_text_embedding.new_zeros(
+                size=(sequence_length, self.config.hidden_size)
+            )
+            hidden_states[text_indexes] = packed_text_embedding
+
+            packed_tokens_vision, original_latent_shapes = (
+                self._patchify_and_pack_latents(vision_tokens)
+            )
+            packed_tokens_vision = self.proj_in(packed_tokens_vision)
+            timesteps_vision = vision_timesteps * self.config.timestep_scale
+            packed_timestep_embeds_vision = self.time_embedder(
+                self.time_proj(timesteps_vision)
+            ).to(target_dtype)
+            packed_tokens_vision = self._apply_timestep_embeds_to_noisy_tokens(
+                packed_tokens=packed_tokens_vision,
+                packed_timestep_embeds=packed_timestep_embeds_vision,
+                noisy_frame_indexes=vision_noisy_frame_indexes,
+                token_shapes=vision_token_shapes,
+            )
+            hidden_states[vision_sequence_indexes] = packed_tokens_vision
+
+            if has_sound:
+                packed_tokens_sound = self._pack_sound_latents(
+                    sound_tokens, sound_token_shapes
+                ).to(target_dtype)
+                packed_tokens_sound = (
+                    self.audio_proj_in(packed_tokens_sound)
+                    + self.audio_modality_embed
+                )
+                timesteps_sound = sound_timesteps * self.config.timestep_scale
+                packed_timestep_embeds_sound = self.time_embedder(
+                    self.time_proj(timesteps_sound)
+                ).to(target_dtype)
+                packed_tokens_sound = self._apply_timestep_embeds_to_noisy_tokens(
+                    packed_tokens=packed_tokens_sound,
+                    packed_timestep_embeds=packed_timestep_embeds_sound,
+                    noisy_frame_indexes=sound_noisy_frame_indexes,
+                    token_shapes=sound_token_shapes,
+                )
+                hidden_states[sound_sequence_indexes] = packed_tokens_sound
+
+            if has_action:
+                packed_tokens_action, per_token_domain_ids = (
+                    self._pack_action_latents(
+                        action_tokens, action_token_shapes, action_domain_ids
+                    )
+                )
+                packed_tokens_action = packed_tokens_action.to(target_dtype)
+                per_token_domain_ids = per_token_domain_ids.to(
+                    device=packed_tokens_action.device
+                )
+                packed_tokens_action = self.action_proj_in(
+                    packed_tokens_action, per_token_domain_ids
+                )
+                packed_tokens_action = (
+                    packed_tokens_action + self.action_modality_embed
+                )
+                if action_mse_loss_indexes.numel() > 0:
+                    timesteps_action = (
+                        action_timesteps * self.config.timestep_scale
+                    )
+                    packed_timestep_embeds_action = self.time_embedder(
+                        self.time_proj(timesteps_action)
+                    ).to(target_dtype)
+                    packed_tokens_action = (
+                        self._apply_timestep_embeds_to_noisy_tokens(
+                            packed_tokens=packed_tokens_action,
+                            packed_timestep_embeds=packed_timestep_embeds_action,
+                            noisy_frame_indexes=action_noisy_frame_indexes,
+                            token_shapes=action_token_shapes,
+                        )
+                    )
+                hidden_states[action_sequence_indexes] = packed_tokens_action
+
+            # Rotary embeddings for the full joint sequence
+            cos, sin = self.rotary_emb(
+                position_ids=(
+                    position_ids.unsqueeze(0)
+                    if position_ids.ndim == 1
+                    else position_ids.unsqueeze(1)
+                ),
+                device=hidden_states.device,
+                dtype=hidden_states.dtype,
+            )
+            cos = cos.squeeze(0)
+            sin = sin.squeeze(0)
+
+            # Split into und (AR, replicated) and gen (DM, to be chunked)
+            und_seq = hidden_states[:und_len]
+            gen_seq = hidden_states[und_len:]
+
+            und_cos = cos[:und_len]
+            und_sin = sin[:und_len]
+            gen_cos = cos[und_len:]
+            gen_sin = sin[und_len:]
+
+            # Chunk gen_seq and gen rotary embeddings across SP ranks
+            gen_len = gen_seq.shape[0]
+            pad_amount = (sp_size - (gen_len % sp_size)) % sp_size
+            gen_seq = self._chunk_and_pad_sequence(
+                gen_seq, sp_rank, sp_size, pad_amount, dim=0
+            )
+            gen_cos = self._chunk_and_pad_sequence(
+                gen_cos, sp_rank, sp_size, pad_amount, dim=0
+            )
+            gen_sin = self._chunk_and_pad_sequence(
+                gen_sin, sp_rank, sp_size, pad_amount, dim=0
+            )
+
+            rotary_emb_chunked = (und_cos, und_sin, gen_cos, gen_sin)
+
+            # Run decoder layers on chunked gen_seq
+            for decoder_layer in self.layers:
+                und_seq, gen_seq = decoder_layer(
+                    und_seq, gen_seq, rotary_emb_chunked
+                )
+
+            # Gather gen_seq back to full length
+            gen_seq = self._gather_and_unpad(gen_seq, pad_amount, dim=0)
+
+            # Final norms and output projections
+            und_out = self.norm(und_seq)
+            gen_out = self.norm_moe_gen(gen_seq)
+            last_hidden_state = torch.cat([und_out, gen_out], dim=0)
+
+            preds_vision_packed = self.proj_out(
+                last_hidden_state[vision_mse_loss_indexes]
+            )
+            preds_vision = self._unpatchify_and_unpack_latents(
+                preds_vision_packed,
+                token_shapes_vision=vision_token_shapes,
+                noisy_frame_indexes_vision=vision_noisy_frame_indexes,
+                original_latent_shapes=original_latent_shapes,
+            )
+
+            preds_sound = None
+            if has_sound:
+                preds_sound_packed = self.audio_proj_out(
+                    last_hidden_state[sound_mse_loss_indexes]
+                )
+                preds_sound = self._unpack_sound_latents(
+                    preds_sound_packed, sound_token_shapes,
+                    sound_noisy_frame_indexes,
+                )
+
+            preds_action = None
+            if has_action:
+                per_noisy_domain_ids = [
+                    domain_id.reshape(1).expand(len(noisy_idxs))
+                    for domain_id, noisy_idxs in zip(
+                        action_domain_ids, action_noisy_frame_indexes
+                    )
+                ]
+                per_noisy_domain_ids = torch.cat(
+                    per_noisy_domain_ids, dim=0
+                ).to(device=last_hidden_state.device)
+                preds_action_packed = self.action_proj_out(
+                    last_hidden_state[action_mse_loss_indexes],
+                    per_noisy_domain_ids,
+                )
+                preds_action = self._unpack_action_latents(
+                    preds_action_packed, action_token_shapes,
+                    action_noisy_frame_indexes,
+                )
+
+            return preds_vision, preds_sound, preds_action
+
+    return xFuserCosmos3OmniTransformerWrapper
+
+
+# Lazy singleton
+_wrapper_cls = None
+
+def get_cosmos3_transformer_wrapper_class():
+    global _wrapper_cls
+    if _wrapper_cls is None:
+        _wrapper_cls = _make_xfuser_cosmos3_transformer_wrapper()
+    return _wrapper_cls

--- a/xfuser/model_executor/pipelines/pipeline_cosmos3_omni.py
+++ b/xfuser/model_executor/pipelines/pipeline_cosmos3_omni.py
@@ -1,0 +1,361 @@
+"""xFuser-wrapped Cosmos3OmniPipeline with CFG parallelism.
+
+When cfg_parallel_size == 2, each GPU rank runs either the conditional or
+unconditional transformer pass. Velocity predictions are gathered across
+the CFG group and combined before the scheduler step.
+"""
+
+import copy
+import os
+from typing import Any, Callable, Optional, Union
+
+import torch
+from diffusers.callbacks import PipelineCallback, MultiPipelineCallbacks
+
+from xfuser.core.distributed import (
+    get_classifier_free_guidance_rank,
+    get_classifier_free_guidance_world_size,
+    get_cfg_group,
+)
+
+try:
+    from cosmos_guardrail import CosmosSafetyChecker
+except ImportError:
+    CosmosSafetyChecker = None
+
+
+def _make_xfuser_cosmos3_pipeline_class():
+    from diffusers.pipelines.cosmos.pipeline_cosmos3_omni import (
+        Cosmos3OmniPipeline,
+        Cosmos3OmniPipelineOutput,
+    )
+
+    class xFuserCosmos3OmniPipeline(Cosmos3OmniPipeline):
+
+        @torch.no_grad()
+        def __call__(self, *args, **kwargs):
+            try:
+                cfg_rank = get_classifier_free_guidance_rank()
+                cfg_world_size = get_classifier_free_guidance_world_size()
+            except (AssertionError, RuntimeError):
+                cfg_rank = 0
+                cfg_world_size = 1
+
+            guidance_scale = kwargs.get("guidance_scale", 6.0)
+            do_cfg_parallel = (guidance_scale != 1.0) and cfg_world_size == 2
+
+            if not do_cfg_parallel:
+                return super().__call__(*args, **kwargs)
+
+            return self._call_with_cfg_parallel(*args, cfg_rank=cfg_rank, **kwargs)
+
+        def _call_with_cfg_parallel(
+            self,
+            prompt,
+            negative_prompt=None,
+            image=None,
+            num_frames=None,
+            height=None,
+            width=None,
+            fps=24.0,
+            num_inference_steps=35,
+            guidance_scale=6.0,
+            enable_sound=False,
+            generator=None,
+            latents=None,
+            sound_latents=None,
+            action_latents=None,
+            action=None,
+            output_type="pil",
+            return_dict=True,
+            use_system_prompt=True,
+            callback_on_step_end=None,
+            callback_on_step_end_tensor_inputs=["latents"],
+            add_resolution_template=True,
+            add_duration_template=True,
+            enable_safety_check=True,
+            cfg_rank=0,
+        ):
+            """Full pipeline with CFG parallelism injected into the denoising loop.
+
+            Rank 0 runs the unconditional pass, rank 1 runs the conditional pass.
+            After each step, velocity predictions are gathered and combined.
+            """
+            if isinstance(callback_on_step_end, (PipelineCallback, MultiPipelineCallbacks)):
+                callback_on_step_end_tensor_inputs = callback_on_step_end.tensor_inputs
+
+            if action is None:
+                if num_frames is None:
+                    num_frames = 189
+                if height is None:
+                    height = 720
+                if width is None:
+                    width = 1280
+
+            self.check_inputs(
+                prompt, negative_prompt, image, height, width, num_frames,
+                guidance_scale, enable_sound, callback_on_step_end_tensor_inputs, action,
+            )
+
+            action_mode = action.mode if action is not None else None
+            if action is not None:
+                from diffusers.video_processor import VideoProcessor
+                from diffusers.pipelines.cosmos.pipeline_cosmos3_omni import _ACTION_RESOLUTION_BINS
+                num_frames = action.chunk_size + 1
+                conditioning_clip = [action.image] if action.image is not None else action.video
+                probe = self.video_processor.preprocess_video(conditioning_clip)
+                source_h, source_w = int(probe.shape[-2]), int(probe.shape[-1])
+                resolution_key = str(action.resolution_tier)
+                height, width = VideoProcessor.classify_height_width_bin(
+                    source_h, source_w, ratios=_ACTION_RESOLUTION_BINS[resolution_key]
+                )
+
+            self._current_timestep = None
+            self._interrupt = False
+            self._guidance_scale = guidance_scale
+
+            if isinstance(prompt, list):
+                prompt = prompt[0] if prompt else ""
+            if isinstance(negative_prompt, list):
+                negative_prompt = negative_prompt[0] if negative_prompt else ""
+
+            device = self._get_execution_device()
+            dtype = self.transformer.dtype
+
+            if enable_safety_check and CosmosSafetyChecker is not None and isinstance(getattr(self, 'safety_checker', None), CosmosSafetyChecker):
+                self.safety_checker.to(device)
+                try:
+                    if not self.safety_checker.check_text_safety(prompt):
+                        raise ValueError(f"Unsafe text detected: {prompt}")
+                finally:
+                    self.safety_checker.to("cpu")
+
+            # Tokenize
+            cond_input_ids, uncond_input_ids = self.tokenize_prompt(
+                prompt, negative_prompt, num_frames=num_frames, height=height,
+                width=width, fps=fps, use_system_prompt=use_system_prompt,
+                add_resolution_template=add_resolution_template,
+                add_duration_template=add_duration_template,
+                action_mode=action_mode,
+                action_view_point=action.view_point if action is not None else None,
+            )
+
+            # CFG parallel: each rank only prepares its own text segment
+            if cfg_rank == 0:
+                my_input_ids = uncond_input_ids
+            else:
+                my_input_ids = cond_input_ids
+
+            my_text_segment = self._prepare_text_segment(my_input_ids, device=device)
+
+            # Prepare latents (same on both ranks)
+            (
+                latents, sound_latents, action_latents, fps_vision, fps_sound,
+                vision_condition_mask, sound_condition_mask, action_condition_mask,
+                action_domain_id, action_image_size, raw_action_dim_resolved,
+                action_condition_frame_indexes,
+            ) = self.prepare_latents(
+                image=image, num_frames=num_frames, height=height, width=width,
+                fps=fps, latents=latents, sound_latents=sound_latents,
+                action_latents=action_latents, generator=generator,
+                device=device, dtype=dtype, enable_sound=enable_sound, action=action,
+            )
+            vision_condition_indexes = torch.nonzero(
+                vision_condition_mask[:, 0, 0] > 0, as_tuple=False
+            ).flatten()
+            vision_condition_indexes = [int(idx.item()) for idx in vision_condition_indexes]
+            has_image_condition = bool(vision_condition_indexes)
+
+            # Prepare vision/sound segments (each rank uses its own text segment offset)
+            my_vision_segment = self._prepare_vision_segment(
+                input_vision_tokens=latents, has_image_condition=has_image_condition,
+                mrope_offset=my_text_segment["vision_start_temporal_offset"],
+                vision_fps=fps_vision, curr=my_text_segment["und_len"],
+                device=device, condition_frame_indexes=vision_condition_indexes,
+            )
+            my_sound_segment = {}
+            if sound_latents is not None:
+                my_sound_segment = self._prepare_sound_segment(
+                    input_sound_tokens=sound_latents,
+                    mrope_offset=my_text_segment["vision_start_temporal_offset"],
+                    sound_fps=fps_sound,
+                    curr=my_text_segment["und_len"] + my_vision_segment["num_vision_tokens"],
+                    device=device,
+                )
+            my_action_segment = {}
+            if action_latents is not None:
+                my_action_segment = self._prepare_action_segment(
+                    input_action_tokens=action_latents,
+                    condition_frame_indexes=action_condition_frame_indexes,
+                    mrope_offset=my_text_segment["vision_start_temporal_offset"],
+                    action_fps=fps_vision,
+                    curr=my_text_segment["und_len"] + my_vision_segment["num_vision_tokens"] + my_sound_segment.get("sound_len", 0),
+                    device=device,
+                )
+
+            mrope_segments = [my_text_segment["text_mrope_ids"], my_vision_segment["vision_mrope_ids"]]
+            if my_sound_segment:
+                mrope_segments.append(my_sound_segment["sound_mrope_ids"])
+            if my_action_segment:
+                mrope_segments.append(my_action_segment["action_mrope_ids"])
+
+            my_packed_static = {
+                **my_text_segment, **my_vision_segment, **my_sound_segment, **my_action_segment,
+                "position_ids": torch.cat(mrope_segments, dim=1),
+                "sequence_length": (my_text_segment["und_len"]
+                    + my_vision_segment["num_vision_tokens"]
+                    + my_sound_segment.get("sound_len", 0)
+                    + my_action_segment.get("action_len", 0)),
+            }
+
+            num_noisy_vision_tokens = my_vision_segment["num_noisy_vision_tokens"]
+            sound_len = my_sound_segment.get("sound_len")
+            action_noisy_len = my_action_segment.get("num_noisy_action_tokens")
+
+            # Schedulers
+            self.scheduler.set_timesteps(num_inference_steps, device=device)
+            timesteps = self.scheduler.timesteps
+            sound_scheduler = copy.deepcopy(self.scheduler) if sound_latents is not None else None
+            action_scheduler = copy.deepcopy(self.scheduler) if action_latents is not None else None
+
+            # Denoising loop
+            num_warmup_steps = len(timesteps) - num_inference_steps * self.scheduler.order
+            self._num_timesteps = len(timesteps)
+            with self.progress_bar(total=num_inference_steps) as progress_bar:
+                for i, t in enumerate(timesteps):
+                    if self.interrupt:
+                        continue
+
+                    self._current_timestep = t
+                    timestep = t.item()
+
+                    vision_tokens = latents.to(device=device, dtype=dtype)
+                    sound_tokens = sound_latents.to(device=device, dtype=dtype) if sound_latents is not None else None
+                    action_tokens = action_latents.to(device=device, dtype=dtype) if action_latents is not None else None
+                    vision_timesteps_t = torch.full((num_noisy_vision_tokens,), timestep, device=device)
+                    sound_timesteps_t = torch.full((sound_len,), timestep, device=device) if sound_tokens is not None else None
+                    action_timesteps_t = torch.full((action_noisy_len,), timestep, device=device) if action_tokens is not None else None
+
+                    # Each rank runs ONE transformer pass (cond or uncond)
+                    preds_vision, preds_sound, preds_action = self.transformer(
+                        input_ids=my_packed_static["input_ids"],
+                        text_indexes=my_packed_static["text_indexes"],
+                        position_ids=my_packed_static["position_ids"],
+                        und_len=my_packed_static["und_len"],
+                        sequence_length=my_packed_static["sequence_length"],
+                        vision_tokens=[vision_tokens],
+                        vision_token_shapes=my_packed_static["vision_token_shapes"],
+                        vision_sequence_indexes=my_packed_static["vision_sequence_indexes"],
+                        vision_mse_loss_indexes=my_packed_static["vision_mse_loss_indexes"],
+                        vision_timesteps=vision_timesteps_t,
+                        vision_noisy_frame_indexes=my_packed_static["vision_noisy_frame_indexes"],
+                        sound_tokens=[sound_tokens] if sound_tokens is not None else None,
+                        sound_token_shapes=my_packed_static.get("sound_token_shapes"),
+                        sound_sequence_indexes=my_packed_static.get("sound_sequence_indexes"),
+                        sound_mse_loss_indexes=my_packed_static.get("sound_mse_loss_indexes"),
+                        sound_timesteps=sound_timesteps_t,
+                        sound_noisy_frame_indexes=my_packed_static.get("sound_noisy_frame_indexes"),
+                        action_tokens=[action_tokens] if action_tokens is not None else None,
+                        action_token_shapes=my_packed_static.get("action_token_shapes"),
+                        action_sequence_indexes=my_packed_static.get("action_sequence_indexes"),
+                        action_mse_loss_indexes=my_packed_static.get("action_mse_loss_indexes"),
+                        action_timesteps=action_timesteps_t,
+                        action_noisy_frame_indexes=my_packed_static.get("action_noisy_frame_indexes"),
+                        action_domain_ids=[action_domain_id] if action_domain_id is not None else None,
+                    )
+                    my_v_vision, my_v_sound, my_v_action = self._mask_velocity_predictions(
+                        preds_vision, preds_sound,
+                        vision_condition_mask=[vision_condition_mask],
+                        sound_condition_mask=[sound_condition_mask] if sound_condition_mask is not None else None,
+                        preds_action=preds_action,
+                        action_condition_mask=[action_condition_mask] if action_condition_mask is not None else None,
+                        raw_action_dim=raw_action_dim_resolved,
+                    )
+
+                    # Gather velocity predictions across CFG ranks
+                    # Rank 0 = uncond, Rank 1 = cond
+                    uncond_v_vision, cond_v_vision = get_cfg_group().all_gather(
+                        my_v_vision, separate_tensors=True
+                    )
+                    velocity_vision = uncond_v_vision + guidance_scale * (cond_v_vision - uncond_v_vision)
+
+                    latents = self.scheduler.step(
+                        velocity_vision.unsqueeze(0), t, latents.unsqueeze(0), return_dict=False
+                    )[0].squeeze(0)
+
+                    if sound_scheduler is not None and my_v_sound is not None:
+                        uncond_v_sound, cond_v_sound = get_cfg_group().all_gather(
+                            my_v_sound, separate_tensors=True
+                        )
+                        velocity_sound = uncond_v_sound + guidance_scale * (cond_v_sound - uncond_v_sound)
+                        sound_latents = sound_scheduler.step(
+                            velocity_sound.unsqueeze(0), t, sound_latents.unsqueeze(0), return_dict=False
+                        )[0].squeeze(0)
+
+                    has_noisy_action = (
+                        action_condition_mask is not None and action_condition_mask.sum() < action_condition_mask.numel()
+                    )
+                    if action_scheduler is not None and has_noisy_action and my_v_action is not None:
+                        uncond_v_action, cond_v_action = get_cfg_group().all_gather(
+                            my_v_action, separate_tensors=True
+                        )
+                        velocity_action = uncond_v_action + guidance_scale * (cond_v_action - uncond_v_action)
+                        action_latents = action_scheduler.step(
+                            velocity_action.unsqueeze(0), t, action_latents.unsqueeze(0), return_dict=False
+                        )[0].squeeze(0)
+                        if raw_action_dim_resolved is not None:
+                            action_latents[:, raw_action_dim_resolved:] = 0
+
+                    if callback_on_step_end is not None:
+                        callback_kwargs = {k: locals()[k] for k in callback_on_step_end_tensor_inputs}
+                        callback_outputs = callback_on_step_end(self, i, t, callback_kwargs)
+                        latents = callback_outputs.pop("latents", latents)
+
+                    if i == len(timesteps) - 1 or ((i + 1) > num_warmup_steps and (i + 1) % self.scheduler.order == 0):
+                        progress_bar.update()
+
+            self._current_timestep = None
+
+            # Decode (same as parent)
+            sound = self.decode_sound(sound_latents) if sound_latents is not None else None
+            action_output = None
+            if action_mode in {"inverse_dynamics", "policy"} and action_latents is not None:
+                action_output = action_latents
+                if raw_action_dim_resolved is not None:
+                    action_output = action_output[:, :raw_action_dim_resolved]
+                action_output = [action_output.detach().cpu()]
+
+            if output_type == "latent":
+                video = latents
+            else:
+                in_dtype = latents.dtype
+                vae_dtype = self.vae.dtype
+                mean = self._vae_latents_mean.to(device=latents.device, dtype=vae_dtype)
+                inv_std = self._vae_latents_inv_std.to(device=latents.device, dtype=vae_dtype)
+                z_raw = latents.to(vae_dtype) / inv_std.view(1, -1, 1, 1, 1) + mean.view(1, -1, 1, 1, 1)
+                decoded = self.vae.decode(z_raw).sample.to(in_dtype)
+                video = self.video_processor.postprocess_video(decoded, output_type=output_type)[0]
+
+            self.maybe_free_model_hooks()
+
+            if not return_dict:
+                return (video, sound)
+            return Cosmos3OmniPipelineOutput(video=video, sound=sound, action=action_output)
+
+        @classmethod
+        def from_pretrained(cls, pretrained_model_name_or_path, engine_config=None, **kwargs):
+            pipeline = super().from_pretrained(pretrained_model_name_or_path, **kwargs)
+            pipeline.__class__ = cls
+            pipeline.engine_config = engine_config
+            return pipeline
+
+    return xFuserCosmos3OmniPipeline
+
+
+_pipeline_cls = None
+
+def get_cosmos3_pipeline_class():
+    global _pipeline_cls
+    if _pipeline_cls is None:
+        _pipeline_cls = _make_xfuser_cosmos3_pipeline_class()
+    return _pipeline_cls


### PR DESCRIPTION
## Summary

Add parallel inference support for [nvidia/Cosmos3-Super](https://huggingface.co/nvidia/Cosmos3-Super) (64B) and [nvidia/Cosmos3-Nano](https://huggingface.co/nvidia/Cosmos3-Nano) (16B) omnimodal world models. Supports both text-to-video (T2V) and image-to-video (I2V) generation.

Cosmos3 is architecturally distinct from existing xDiT models — it uses a Mixture-of-Transformers (MoT) with dual towers (autoregressive reasoner + diffusion generator) sharing joint attention within each layer. Text token IDs and vision latent tokens are packed into a single joint sequence with no separate text encoder.

### Features

- **USP** (Ulysses sequence parallelism) on the DM attention pathway with gen_seq chunking across ranks
- **CFG parallelism** with velocity-level gather in the denoising loop (cond/uncond on separate GPUs)
- **FSDP2** weight sharding across `transformer.layers`
- **FP8 GEMM** quantization via AITER blockscale
- **Mixed FP4/FP8 GEMM** precision (first/last 10 layers kept at FP8)
- **Parallel VAE** encode/decode via DistVAE (same `AutoencoderKLWan` as Wan models)
- **torch.compile** with inductor compute/comm overlap
- **I2V** support via `--input_images`
- **JSON prompt** file support (Cosmos3 structured caption format for best quality)

### Scope

This PR covers **video generation only** (T2V and I2V). Cosmos3 also supports audio, action/robotics, and text generation, which are left out of this PR.

### Attention backend note

Only full-precision attention backends are supported (`AITER`, `SDPA`, `FLASH`, `FLASH_3`). Quantized backends (`AITER_FP8`, `AITER_SAGE`, `AITER_SAGE_V2`, `AITER_MLA`, `FLASH_3_FP8`, `FLASH_4_FP4`, etc.) produce >50% relative error per attention layer on Cosmos3 due to extreme K/V dynamic range mismatch in the MoT dual-pathway attention (K absmax ~107 vs V absmax ~1.7). The model validates the backend at init and raises a clear error for unsupported backends. Quantized attention support to be added separately pending per-head or per-channel quantization.

## Performance

I2V, 720p, 121 frames (5s @ 24fps), 35 steps, 8x MI355X:

| Config | Total | Per-step | Speedup |
|--------|-------|----------|---------|
| BF16, U=8 | 30.9s | 0.88s | 1.0x |
| BF16, U=4 + CFG=2 | 24.0s | 0.69s | 1.3x |
| BF16, FSDP=8 + U=8 | 37.3s | 1.07s | 0.8x |
| BF16, FSDP=8 + U=4 + CFG=2 | 26.3s | 0.75s | 1.2x |
| FP8 GEMMs + U=4 + CFG=2 | 19.5s | 0.56s | 1.6x |

CFG parallel halves denoising work and U=4 gives fatter attention kernels (16 Q heads/GPU) with less all-to-all overhead than U=8. FP8 GEMMs add ~19% on top.

## Samples

Generated with `--ulysses_degree 4 --use_cfg_parallel --use_fp8_gemms`, 720p, 121 frames (5s @ 24fps), 35 steps, 8x MI355X:

**T2V** (prompt: `assets/example_t2v_prompt.json`):

https://github.com/user-attachments/assets/a6387abe-5c13-4070-8e7e-223e2ebdae33

**I2V** (prompt: `assets/example_i2v_prompt.json`, input: `assets/example_i2v_input.jpg`):

https://github.com/user-attachments/assets/b8ca673e-7154-44f5-a376-7f13fb2064e3

## Usage

The examples below use prompt/negative prompt JSON files bundled with the model (downloaded automatically with `huggingface-cli download nvidia/Cosmos3-Super`). Cosmos3 produces best quality with [JSON-upsampled prompts](https://huggingface.co/nvidia/Cosmos3-Super#prompt-upsampling); plain text prompts also work but with reduced quality.

```bash
# Download model assets (includes example prompts and input images)
huggingface-cli download nvidia/Cosmos3-Super

# Text-to-Video (8 GPUs: U=4 x CFG=2)
xdit --model nvidia/Cosmos3-Super \
  --ulysses_degree 4 --use_cfg_parallel \
  --use_torch_compile --use_parallel_vae --use_fp8_gemms \
  --prompt assets/example_t2v_prompt.json \
  --negative_prompt assets/negative_prompt.json \
  --num_frames 121 --height 720 --width 1280

# Image-to-Video
xdit --model nvidia/Cosmos3-Super \
  --ulysses_degree 4 --use_cfg_parallel \
  --use_torch_compile --use_parallel_vae --use_fp8_gemms \
  --input_images assets/example_i2v_input.jpg \
  --prompt assets/example_i2v_prompt.json \
  --negative_prompt assets/negative_prompt.json \
  --num_frames 121 --height 720 --width 1280

# With FSDP (reduced VRAM per GPU)
xdit --model nvidia/Cosmos3-Super \
  --ulysses_degree 4 --use_cfg_parallel --fully_shard_degree 8 \
  --use_torch_compile --use_parallel_vae \
  --prompt assets/example_t2v_prompt.json \
  --negative_prompt assets/negative_prompt.json \
  --num_frames 121 --height 720 --width 1280
```

Requires `diffusers >= 0.39.0` (for `Cosmos3OmniPipeline` and `Cosmos3OmniTransformer`).

## Files

| File | Description |
|------|-------------|
| `xfuser/model_executor/models/runner_models/cosmos3.py` | Runner model registration, loading, I2V support, FSDP/FP8/FP4 config |
| `xfuser/model_executor/models/transformers/transformer_cosmos3.py` | Transformer wrapper with dual-pathway attention processor and gen_seq chunking for SP |
| `xfuser/model_executor/pipelines/pipeline_cosmos3_omni.py` | Pipeline wrapper with CFG parallelism in the denoising loop |

No changes to existing files — auto-discovered via the runner model registry.
