### PR TITLE
Hadamard Rotation for FP8 Attention

### DIFF
--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -91,6 +91,41 @@ def _aiter_sage_v2_hadamard_matrix(block_r):
         hadamard_matrix[device] = _hadamard.to(device) if _hadamard is not None else None
     return hadamard_matrix
 
+
+def _build_hadamard_matrix(block_r, dtype=torch.bfloat16):
+    """Normalized Hadamard matrix (block_r x block_r, R @ R.T == I; block_r a
+    power of two). Uses aiter's create_hadamard_matrix with a local Sylvester
+    fallback, so it doesn't depend on the sage_v2 modules."""
+    try:
+        try:
+            from aiter.ops.triton._triton_kernels.attention.fav3_sage_attention_mxfp4 import (
+                create_hadamard_matrix,
+            )
+        except ImportError:
+            from aiter.ops.triton.quant.sage_attention_quant_wrappers import (
+                create_hadamard_matrix,
+            )
+        return create_hadamard_matrix(block_r, dtype=dtype) / (block_r ** 0.5)
+    except ImportError:
+        # Local Sylvester construction: H1=[[1]], H2n=[[Hn,Hn],[Hn,-Hn]].
+        assert block_r & (block_r - 1) == 0, "Hadamard block_r must be a power of 2"
+        H = torch.ones((1, 1), dtype=torch.float32)
+        while H.shape[0] < block_r:
+            H = torch.cat([torch.cat([H, H], dim=1), torch.cat([H, -H], dim=1)], dim=0)
+        return (H / (block_r ** 0.5)).to(dtype)
+
+
+def _aiter_fp8_hadamard_matrix(block_r):
+    hadamard_matrix = {}
+    _hadamard = _build_hadamard_matrix(block_r, dtype=torch.bfloat16)
+    if torch.cuda.is_available():
+        for i in range(torch.cuda.device_count()):
+            device = torch.device(f"cuda:{i}")
+            hadamard_matrix[device] = _hadamard.to(device)
+    else:
+        hadamard_matrix[torch.device("cpu")] = _hadamard.to(torch.device("cpu"))
+    return hadamard_matrix
+
 def _get_mla_cache_device_key(device):
     if device.type == "cuda":
         return (device.type, torch.cuda.current_device() if device.index is None else device.index)
@@ -341,6 +376,9 @@ if env_info["has_aiter"]:
     AITER_SAGE_SUPPORTS_RING = _check_aiter_sage_supports_ring()
     AITER_SAGE_V2_SUPPORTS_RING = _check_aiter_sage_v2_supports_ring()
     HADAMARD_MATRIX = _aiter_sage_v2_hadamard_matrix(AITER_SAGE_V2_BLOCK_R)
+    # Own Hadamard matrix for the fp8 paths (separate from sage_v2's);
+    # block_r = 128 = head_dim (full-head rotation).
+    FP8_HADAMARD_MATRIX = _aiter_fp8_hadamard_matrix(128)
     _TRITON_SSTA_BLOCK_SIZE = 128
     
 
@@ -614,6 +652,18 @@ def _flash_attn_4_fp4_call(query, key, value, dropout_p, is_causal, attention_kw
     output = torch.permute(output, [0, 2, 1, 3])
     return output, softmax_lse
 
+def _fp8_hadamard_rotate(x: torch.Tensor, R: torch.Tensor) -> torch.Tensor:
+    """Orthonormal Hadamard rotation along head_dim (in blocks of R.shape[-1]).
+    Rotating both Q and K by R leaves Q @ K.T unchanged (kernel sees identical
+    scores) while spreading outliers to cut fp8 quant error."""
+    d = x.shape[-1]
+    block_r = R.shape[-1]
+    R = R.to(x.dtype)
+    if block_r == d:
+        return torch.matmul(x, R)
+    return torch.matmul(x.unflatten(-1, (d // block_r, block_r)), R).flatten(-2)
+
+
 @register_attention_function(AttentionBackendType.AITER_FP8)
 def _aiter_fp8_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs=None):
     """
@@ -623,6 +673,11 @@ def _aiter_fp8_attn_call(query, key, value, dropout_p, is_causal, attention_kwar
     query = torch.permute(query, [0, 2, 1, 3]).contiguous()
     key = torch.permute(key, [0, 2, 1, 3]).contiguous()
     value = torch.permute(value, [0, 2, 1, 3]).contiguous()
+
+    # Hadamard-rotate Q,K before quant: QK-preserving (kernel unchanged), cuts fp8 quant error.
+    R = FP8_HADAMARD_MATRIX[query.device]
+    query = _fp8_hadamard_rotate(query, R).contiguous()
+    key = _fp8_hadamard_rotate(key, R).contiguous()
 
     softmax_lse = None
     quant_dtype = aiter.dtypes.fp8

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -86,7 +86,7 @@ def _build_hadamard_matrix(block_r, dtype=torch.bfloat16, allow_sylvester_fallba
         if not allow_sylvester_fallback:
             return None
         # Local Sylvester construction: H1=[[1]], H2n=[[Hn,Hn],[Hn,-Hn]].
-        assert block_r & (block_r - 1) == 0, "Hadamard block_r must be a power of 2"
+        assert block_r > 0 and (block_r & (block_r - 1)) == 0, 'Hadamard block_r must be a positive power of 2'
         H = torch.ones((1, 1), dtype=torch.float32)
         while H.shape[0] < block_r:
             H = torch.cat([torch.cat([H, H], dim=1), torch.cat([H, -H], dim=1)], dim=0)
@@ -647,6 +647,8 @@ def _fp8_hadamard_rotate(x: torch.Tensor, R: torch.Tensor) -> torch.Tensor:
     """Orthonormal Hadamard rotation along head_dim (in blocks of R.shape[-1]).
     Rotating both Q and K by R leaves Q @ K.T unchanged (kernel sees identical
     scores) while spreading outliers to cut fp8 quant error."""
+    if R is None:
+        return x
     d = x.shape[-1]
     block_r = R.shape[-1]
     R = R.to(x.dtype)

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -67,35 +67,11 @@ def _check_aiter_sage_v2_supports_ring():
     except (NameError, ImportError, AttributeError, TypeError):
         return False
 
-def _aiter_sage_v2_hadamard_matrix(block_r):
-    hadamard_matrix = {}
-    try:
-        try:
-            from aiter.ops.triton._triton_kernels.attention.fav3_sage_attention_mxfp4 import (
-                create_hadamard_matrix,
-            )
-        except ImportError:
-            from aiter.ops.triton.quant.sage_attention_quant_wrappers import create_hadamard_matrix
-        # Create the hadamard_matrix and replicate it on each available GPU
-        _hadamard = create_hadamard_matrix(block_r, dtype=torch.bfloat16) / (block_r ** 0.5)
-    except ImportError:
-        # If create_hadamard_matrix is not available, set the hadamard_matrix to None.
-        _hadamard = None
-    if torch.cuda.is_available():
-        for i in range(torch.cuda.device_count()):
-            device = torch.device(f"cuda:{i}")
-            hadamard_matrix[device] = _hadamard.to(device) if _hadamard is not None else None
-    else:
-        # Fallback to CPU
-        device = torch.device("cpu")
-        hadamard_matrix[device] = _hadamard.to(device) if _hadamard is not None else None
-    return hadamard_matrix
-
-
-def _build_hadamard_matrix(block_r, dtype=torch.bfloat16):
+def _build_hadamard_matrix(block_r, dtype=torch.bfloat16, allow_sylvester_fallback=True):
     """Normalized Hadamard matrix (block_r x block_r, R @ R.T == I; block_r a
-    power of two). Uses aiter's create_hadamard_matrix with a local Sylvester
-    fallback, so it doesn't depend on the sage_v2 modules."""
+    power of two). Uses aiter's create_hadamard_matrix. If that's unavailable,
+    falls back to a local Sylvester construction when allow_sylvester_fallback
+    is set, otherwise returns None."""
     try:
         try:
             from aiter.ops.triton._triton_kernels.attention.fav3_sage_attention_mxfp4 import (
@@ -107,6 +83,8 @@ def _build_hadamard_matrix(block_r, dtype=torch.bfloat16):
             )
         return create_hadamard_matrix(block_r, dtype=dtype) / (block_r ** 0.5)
     except ImportError:
+        if not allow_sylvester_fallback:
+            return None
         # Local Sylvester construction: H1=[[1]], H2n=[[Hn,Hn],[Hn,-Hn]].
         assert block_r & (block_r - 1) == 0, "Hadamard block_r must be a power of 2"
         H = torch.ones((1, 1), dtype=torch.float32)
@@ -115,16 +93,27 @@ def _build_hadamard_matrix(block_r, dtype=torch.bfloat16):
         return (H / (block_r ** 0.5)).to(dtype)
 
 
-def _aiter_fp8_hadamard_matrix(block_r):
-    hadamard_matrix = {}
-    _hadamard = _build_hadamard_matrix(block_r, dtype=torch.bfloat16)
+def _replicate_hadamard_per_device(hadamard):
+    """Replicate a single Hadamard matrix on each available device, keyed by
+    torch.device (all GPUs if CUDA is available, else CPU). A None matrix maps
+    to None on every device."""
     if torch.cuda.is_available():
-        for i in range(torch.cuda.device_count()):
-            device = torch.device(f"cuda:{i}")
-            hadamard_matrix[device] = _hadamard.to(device)
+        devices = [torch.device(f"cuda:{i}") for i in range(torch.cuda.device_count())]
     else:
-        hadamard_matrix[torch.device("cpu")] = _hadamard.to(torch.device("cpu"))
-    return hadamard_matrix
+        devices = [torch.device("cpu")]
+    return {
+        device: (hadamard.to(device) if hadamard is not None else None)
+        for device in devices
+    }
+
+
+def _aiter_hadamard_matrix(block_r, allow_sylvester_fallback=True):
+    """Build a normalized Hadamard matrix and replicate it across devices."""
+    return _replicate_hadamard_per_device(
+        _build_hadamard_matrix(
+            block_r, dtype=torch.bfloat16, allow_sylvester_fallback=allow_sylvester_fallback
+        )
+    )
 
 def _get_mla_cache_device_key(device):
     if device.type == "cuda":
@@ -375,10 +364,12 @@ if env_info["has_aiter"]:
     AITER_FP8_HAS_DESCALE = _check_aiter_fp8_has_descale()
     AITER_SAGE_SUPPORTS_RING = _check_aiter_sage_supports_ring()
     AITER_SAGE_V2_SUPPORTS_RING = _check_aiter_sage_v2_supports_ring()
-    HADAMARD_MATRIX = _aiter_sage_v2_hadamard_matrix(AITER_SAGE_V2_BLOCK_R)
+    # sage_v2 relies on aiter's own matrix and has no Sylvester fallback (None
+    # disables hadamard_rotation when create_hadamard_matrix is unavailable).
+    HADAMARD_MATRIX = _aiter_hadamard_matrix(AITER_SAGE_V2_BLOCK_R, allow_sylvester_fallback=False)
     # Own Hadamard matrix for the fp8 paths (separate from sage_v2's);
-    # block_r = 128 = head_dim (full-head rotation).
-    FP8_HADAMARD_MATRIX = _aiter_fp8_hadamard_matrix(128)
+    # block_r = 128 = head_dim (full-head rotation). Sylvester fallback allowed.
+    FP8_HADAMARD_MATRIX = _aiter_hadamard_matrix(128)
     _TRITON_SSTA_BLOCK_SIZE = 128
     
 


### PR DESCRIPTION
The FP8 Attention backends have been suffering from artifacts in the output videos, forcing users to utilize hybrid attention strategies with higher precision backends to keep acceptable output quality. By borrowing the idea of using a Hadamard Matrix rotation in the quantization step from the AITER Sage V2 kernel (mxfp4), the artifacts disappear as well as the need for combining FP8 Attention calls with a hybrid attention schedule. 

Using this command:
`xdit --model Wan-AI/Wan2.2-T2V-A14B-Diffusers     --ulysses_degree 8     --prompt "a car stuck in traffic during rush hour"     --height 720     --width 1280     --num_frames 81     --num_inference_steps 20     --guidance-scale 4.0    --use_fp4_gemms     --attention_backend AITER_FP8     --cross_attention_backend AITER --use_parallel_vae --use-torch-compile`

without Hadamard rotation:

https://github.com/user-attachments/assets/18af400a-cae5-4a78-9f89-4da56a318910

and with Hadamard rotation:

https://github.com/user-attachments/assets/0766d880-ed52-499b-907b-1e595c4c88ea

