### PR TITLE
xfuser: keep selected linear layers in FP8 during FP4 GEMMs via prefix/suffix override patterns

### DIFF
--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -138,6 +138,8 @@ class xFuserArgs:
     cross_attention_backend: Optional[str] = None
     use_fp8_gemms: bool = False
     use_fp4_gemms: bool = False
+    fp8_precision_override_prefix_patterns: Optional[str] = None
+    fp8_precision_override_suffix_patterns: Optional[str] = None
     # Model runner specific
     num_iterations: int = 1
     profile: bool = False
@@ -614,6 +616,18 @@ class xFuserArgs:
             action="store_true",
             help="Quantize the transformer linear layers (selected models only).",
         )
+        parser.add_argument(
+            "--fp8_precision_override_prefix_patterns",
+            type=nullable_str,
+            default=None,
+            help="Comma-delimited FQN prefix patterns to keep in FP8 during FP4 GEMMs.",
+        )
+        parser.add_argument(
+            "--fp8_precision_override_suffix_patterns",
+            type=nullable_str,
+            default=None,
+            help="Comma-delimited FQN suffix patterns to keep in FP8 during FP4 GEMMs.",
+        )
 
         parser.add_argument(
             "--num_iterations",
@@ -838,6 +852,15 @@ class xFuserArgs:
         if self.use_hybrid_gemm_schedule:
             if not self.use_fp4_gemms:
                 raise ValueError("When use_hybrid_gemm_schedule is True, use_fp4_gemms must be set.")
+
+        if (
+            self.fp8_precision_override_prefix_patterns is not None
+            or self.fp8_precision_override_suffix_patterns is not None
+        ) and not self.use_fp4_gemms:
+            raise ValueError(
+                "FP8 precision override patterns require --use_fp4_gemms: "
+                "overrides apply when quantizing linear layers for FP4 GEMMs."
+            )
 
         model_config = ModelConfig(
             model=self.model,

--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -359,7 +359,26 @@ def rgetattr(obj: object, attr: str) -> object:
     """ Recursive getattr to get nested attributes """
     return functools.reduce(getattr, [obj] + attr.split("."))
 
-def quantize_linear_layers_to_fp4(model, parent_name='', fp8_layers=None, use_hybrid_schedule: bool = False, device: Optional[torch.device] = None):
+def _layer_uses_fp8_override(
+    layer_fqn: str,
+    fp8_layers: tuple[str] | None,
+    fp8_suffix_layers: tuple[str] | None,
+) -> bool:
+    if fp8_layers and layer_fqn.startswith(fp8_layers):
+        return True
+    if fp8_suffix_layers and layer_fqn.endswith(fp8_suffix_layers):
+        return True
+    return False
+
+
+def quantize_linear_layers_to_fp4(
+    model,
+    parent_name='',
+    fp8_layers=None,
+    fp8_suffix_layers: tuple[str] | None = None,
+    use_hybrid_schedule: bool = False,
+    device: Optional[torch.device] = None,
+):
     from torchao.quantization.granularity import PerTensor
     from torchao.quantization.quant_api import Float8DynamicActivationFloat8WeightConfig, quantize_
     from xfuser.model_executor.layers.mxfp4_linear import xFuserMXFP4Linear, xFuserHybridMXFP4Linear
@@ -368,7 +387,7 @@ def quantize_linear_layers_to_fp4(model, parent_name='', fp8_layers=None, use_hy
         full_name = f"{parent_name}.{name}" if parent_name else name
 
         if isinstance(module, torch.nn.Linear):
-            if fp8_layers and full_name.startswith(fp8_layers):
+            if _layer_uses_fp8_override(full_name, fp8_layers, fp8_suffix_layers):
                 quantize_(
                       module,
                       config=Float8DynamicActivationFloat8WeightConfig(
@@ -421,12 +440,20 @@ def quantize_linear_layers_to_fp4(model, parent_name='', fp8_layers=None, use_hy
                 setattr(model, name, new_layer)
 
         elif len(list(module.children())) > 0:
-            quantize_linear_layers_to_fp4(module, full_name, fp8_layers=fp8_layers, use_hybrid_schedule=use_hybrid_schedule, device=device)
+            quantize_linear_layers_to_fp4(
+                module,
+                full_name,
+                fp8_layers=fp8_layers,
+                fp8_suffix_layers=fp8_suffix_layers,
+                use_hybrid_schedule=use_hybrid_schedule,
+                device=device,
+            )
 
 
 def quantize_linear_layers_to_nvfp4(
     module_or_module_list_to_quantize: torch.nn.Module | torch.nn.ModuleList,
     fp8_layers: tuple[str] = None,
+    fp8_suffix_layers: tuple[str] | None = None,
     device: Optional[torch.device] = None,
     min_layer_size: int = 0,
     use_triton_kernel: bool = True,
@@ -435,8 +462,8 @@ def quantize_linear_layers_to_nvfp4(
 
     Args:
         module_or_module_list_to_quantize: Module(s) whose linear layers will be quantized.
-        fp8_layers: FQN prefixes of layers that should use FP8 instead of NVFP4
-            for quality-sensitive blocks.
+        fp8_layers: FQN prefixes of layers that should use FP8 instead of NVFP4.
+        fp8_suffix_layers: FQN suffixes of layers that should use FP8 instead of NVFP4.
         device: Target device.
         min_layer_size: Skip NVFP4 for layers where min(out_features, in_features)
             is below this threshold (quantization overhead may exceed the speedup).
@@ -464,7 +491,7 @@ def quantize_linear_layers_to_nvfp4(
             if not isinstance(submodule, torch.nn.Linear):
                 continue
 
-            if fp8_layers and fqn.startswith(fp8_layers):
+            if _layer_uses_fp8_override(fqn, fp8_layers, fp8_suffix_layers):
                 skipped_fp8_count += 1
                 continue
 
@@ -478,7 +505,7 @@ def quantize_linear_layers_to_nvfp4(
         def nvfp4_filter_fn(mod, fqn):
             if not _is_linear(mod, fqn):
                 return False
-            if fp8_layers and fqn.startswith(fp8_layers):
+            if _layer_uses_fp8_override(fqn, fp8_layers, fp8_suffix_layers):
                 return False
             if min_layer_size > 0:
                 layer_min = min(mod.out_features, mod.in_features)
@@ -488,7 +515,7 @@ def quantize_linear_layers_to_nvfp4(
 
         quantize_(module, config=nvfp4_config, filter_fn=nvfp4_filter_fn, device=device)
 
-        if fp8_layers:
+        if fp8_layers or fp8_suffix_layers:
             from torchao.quantization.granularity import PerTensor
             from torchao.quantization.quant_api import Float8DynamicActivationFloat8WeightConfig
 
@@ -501,7 +528,7 @@ def quantize_linear_layers_to_nvfp4(
             def fp8_filter_fn(mod, fqn):
                 if not _is_linear(mod, fqn):
                     return False
-                return fqn.startswith(fp8_layers)
+                return _layer_uses_fp8_override(fqn, fp8_layers, fp8_suffix_layers)
 
             quantize_(module, config=fp8_config, filter_fn=fp8_filter_fn, device=device)
 

--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -98,6 +98,17 @@ def _get_fp8_kernel_preference():
     return KernelPreference.AUTO
 
 
+def _float8_tensor_op_table(float8_cls: type) -> dict:
+    """Return the mutable per-class op table (torchao 0.14+ naming varies)."""
+    for attr in ("_ATEN_OP_TABLE", "_ATEN_OP_OR_TORCH_FN_TABLE"):
+        root = getattr(float8_cls, attr, None)
+        if root is not None:
+            if float8_cls not in root:
+                root[float8_cls] = {}
+            return root[float8_cls]
+    raise AttributeError(f"{float8_cls!r} has no _ATEN_OP_* op table")
+
+
 def _patch_torchao_float8_fsdp2() -> list[str]:
     """
     Patch torchao's inference Float8Tensor for FSDP2 (fully_shard) compatibility.
@@ -123,7 +134,7 @@ def _patch_torchao_float8_fsdp2() -> list[str]:
     from torchao.quantization.quantize_.workflows.float8.float8_tensor import Float8Tensor
 
     aten = torch.ops.aten
-    table = Float8Tensor._ATEN_OP_TABLE.get(Float8Tensor, {})
+    table = _float8_tensor_op_table(Float8Tensor)
     patched = []
 
     def _make_float8(tensor, new_qdata, new_block_size=None):
@@ -138,18 +149,23 @@ def _patch_torchao_float8_fsdp2() -> list[str]:
     # expects 3 positional args which raises a ValueError. Also handles PerTensor
     # scale when FSDP2 flattens weights to 1D before making them a DTensor.
     split_op = aten.split.Tensor
-    if split_op in table:
-        _orig_split = table[split_op]
-        def _split(func, types, args, kwargs):
-            if len(args) == 2:
-                args = args + (kwargs.pop("dim", 0),)
-            tensor, split_size, dim = args
-            if isinstance(tensor, Float8Tensor) and tensor.scale.numel() == 1:
-                new_qdatas = aten.split.Tensor(tensor.qdata, split_size, dim)
-                return tuple(_make_float8(tensor, qd, list(qd.shape)) for qd in new_qdatas)
+    _orig_split = table.get(split_op)
+
+    def _split(func, types, args, kwargs):
+        if len(args) == 2:
+            args = args + (kwargs.pop("dim", 0),)
+        tensor, split_size, dim = args
+        if isinstance(tensor, Float8Tensor) and tensor.scale.numel() == 1:
+            new_qdatas = aten.split.Tensor(tensor.qdata, split_size, dim)
+            return tuple(_make_float8(tensor, qd, list(qd.shape)) for qd in new_qdatas)
+        if _orig_split is not None:
             return _orig_split(func, types, args, kwargs)
-        table[split_op] = _split
-        patched.append("aten.split.Tensor")
+        raise NotImplementedError(
+            f"Float8Tensor split: unhandled types={types} args={args} kwargs={kwargs}"
+        )
+
+    table[split_op] = _split
+    patched.append("aten.split.Tensor")
 
     # aten.new_empty: FSDP2 calls _chunk_with_empty which pads short chunk lists with size-0 tensors
     def _new_empty(_, _t, args, kwargs):
@@ -208,7 +224,7 @@ def _patch_torchao_float8_fsdp2() -> list[str]:
     def _patched_dispatch(cls, func, types, args=(), kwargs=None):
         if kwargs is None:
             kwargs = {}
-        inner_table = cls._ATEN_OP_TABLE.get(cls, {})
+        inner_table = _float8_tensor_op_table(cls)
         if func in inner_table:
             return inner_table[func](func, types, args, kwargs)
         def _unwrap(t):

--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -160,8 +160,18 @@ def _patch_torchao_float8_fsdp2() -> list[str]:
             return tuple(_make_float8(tensor, qd, list(qd.shape)) for qd in new_qdatas)
         if _orig_split is not None:
             return _orig_split(func, types, args, kwargs)
-        raise NotImplementedError(
-            f"Float8Tensor split: unhandled types={types} args={args} kwargs={kwargs}"
+        # Fall back to the same unwrap-and-dispatch behavior as _patched_dispatch
+        # for anything not special-cased above (matches the pre-existing fallthrough).
+        # Limitation: for a Float8Tensor with a non-scalar (block/row) scale this
+        # unwraps to raw qdata and drops the Float8Tensor subclass + scale, so the
+        # split result is no longer fp8-aware. That scale layout does not occur on
+        # the supported static per-tensor-scale inference path (handled above);
+        # revisit if block-scaled weights are ever sharded via FSDP2.
+        def _unwrap(t):
+            return t.qdata if isinstance(t, Float8Tensor) else t
+        return func(
+            *torch.utils._pytree.tree_map(_unwrap, args),
+            **torch.utils._pytree.tree_map(_unwrap, kwargs),
         )
 
     table[split_op] = _split

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -224,9 +224,26 @@ class xFuserModel(abc.ABC):
     fps: int = 0
 
     def __init__(self, config: xFuserArgs) -> None:
+        self.settings = copy.deepcopy(self.settings)
+        self._customize_settings(config)
         self._validate_config(config)
+        self._update_model_settings(config)
         self.config = config
         self.pipe = None
+
+    def _customize_settings(self, config: xFuserArgs) -> None:
+        """Hook for subclasses to mutate self.settings before validation and CLI overrides.
+
+        Runs on the instance-local deepcopy, before _validate_config and
+        _update_model_settings, so subclass model_name/valid_tasks/overrides are in
+        place when those consumers run. Subclasses must use the `config` parameter;
+        self.config is not assigned until __init__ completes.
+        """
+        pass
+
+    def _update_model_settings(self, config: xFuserArgs) -> None:
+        if config.use_fp4_gemms:
+            self._apply_fp8_override_cli_from_config(config)
 
     def initialize(self, input_args: dict) -> None:
         """ Load the model pipeline """
@@ -274,14 +291,14 @@ class xFuserModel(abc.ABC):
     def _validate_config(self, config: xFuserArgs) -> None:
         """ Validate if the model supports requested config """
         for key in ModelCapabilities.__annotations__.keys():
-            config_value = getattr(config, key, None) # Some config options might not be set in the CLI, such as support for specific attention backends.
+            config_value = getattr(config, key, None)  # Some config options might not be set in the CLI, such as support for specific attention backends.
             if isinstance(config_value, int):
                 if not getattr(self.capabilities, key) and config_value > 1:
                     raise ValueError(f"Model {self.settings.model_name} does not support {key}.")
             else:
                 if config_value and not getattr(self.capabilities, key):
                     raise ValueError(f"Model {self.settings.model_name} does not support {key}.")
-        
+
         backend = _parse_attention_backend(config.attention_backend, "attention backend")
         supports_sparse = self.capabilities.supports_sparse_attention_backends
         supports_sparge = self.capabilities.supports_sparge_attention_backends

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -154,6 +154,7 @@ class ModelSettings:
     fp8_gemm_module_list: List[str] = None
     fp4_gemm_module_list: List[str] = None
     fp8_precision_overrides: Tuple[str] = None
+    fp8_precision_override_suffixes: Tuple[str] = None
     fbcache_thresh: float = 0.12
     # FSDP strategy is just for the components to be sharded - other components will be moved to correct device automatically
     fsdp_strategy: dict = field(default_factory=lambda: {
@@ -582,6 +583,24 @@ class xFuserModel(abc.ABC):
             name += f"_{self.config.task}"
         return name
 
+    def _apply_fp8_override_cli_from_config(self, config: xFuserArgs) -> None:
+        """Apply optional CLI FP8 override patterns (per-slot) into ModelSettings."""
+
+        def _parse_csv_patterns(raw: Optional[str]) -> Optional[Tuple[str, ...]]:
+            if raw is None or not raw.strip():
+                return None
+            patterns = tuple(p.strip() for p in raw.split(",") if p.strip())
+            return patterns or None
+
+        if config.fp8_precision_override_prefix_patterns is not None:
+            self.settings.fp8_precision_overrides = _parse_csv_patterns(
+                config.fp8_precision_override_prefix_patterns
+            )
+        if config.fp8_precision_override_suffix_patterns is not None:
+            self.settings.fp8_precision_override_suffixes = _parse_csv_patterns(
+                config.fp8_precision_override_suffix_patterns
+            )
+
     def _post_load_and_state_initialization(self, input_args: dict) -> None: ##TODO: should this be renamed?
         """ Hook for any post model-load and state initialization """
 
@@ -690,6 +709,19 @@ class xFuserModel(abc.ABC):
                         cuda_device if name in cpu_offloaded else None
                     )
 
+    def _log_fp8_overrides(self, prefixes, suffixes) -> None:
+        """Log the FP8 precision-override patterns (prefix and suffix) consistently."""
+        if prefixes:
+            log(
+                "The following layers will be quantized to FP8, to maintain output quality: "
+                f"{prefixes} (prefix match)"
+            )
+        if suffixes:
+            log(
+                "The following layers will be quantized to FP8, to maintain output quality: "
+                f"{suffixes} (suffix match)"
+            )
+
     def _build_fsdp_quantize_fn(
         self, component_name: str, wrap_attrs: list, local_rank: int
     ):
@@ -700,6 +732,9 @@ class xFuserModel(abc.ABC):
         fp8_precision_overrides entries like "5." apply to block index 5. We strip
         the block-index prefix before passing to the quantize functions so they see
         the same local FQN paths they would in the non-FSDP path.
+
+        Suffix patterns (e.g. .net.0.proj) are block-local FQNs and are passed
+        through unchanged on every block; only prefix patterns are stripped.
         """
         if not (self.config.use_fp4_gemms or self.config.use_fp8_gemms):
             return None
@@ -708,6 +743,7 @@ class xFuserModel(abc.ABC):
         fp4_list = set(self.settings.fp4_gemm_module_list or [])
         fp8_list = set(self.settings.fp8_gemm_module_list or [])
         fp8_overrides = self.settings.fp8_precision_overrides or ()
+        fp8_suffix_overrides = self.settings.fp8_precision_override_suffixes
 
         paths = [f"{component_name}.{a}" for a in wrap_attrs]
 
@@ -722,6 +758,9 @@ class xFuserModel(abc.ABC):
         if not use_fp4_here and not use_fp8_here:
             return None
 
+        if use_fp4_here:
+            self._log_fp8_overrides(fp8_overrides, fp8_suffix_overrides)
+
         def quantize_fn(block, block_idx: int) -> None:
             block_prefix = f"{block_idx}."
             # Strip the block-index prefix so the quantize functions see local FQN paths.
@@ -730,11 +769,17 @@ class xFuserModel(abc.ABC):
             ) or None
             if use_fp4_here:
                 if _is_cuda():
-                    quantize_linear_layers_to_nvfp4(block, fp8_layers=local_fp8, device=device)
+                    quantize_linear_layers_to_nvfp4(
+                        block,
+                        fp8_layers=local_fp8,
+                        fp8_suffix_layers=fp8_suffix_overrides,
+                        device=device,
+                    )
                 else:
                     quantize_linear_layers_to_fp4(
                         block,
                         fp8_layers=local_fp8,
+                        fp8_suffix_layers=fp8_suffix_overrides,
                         use_hybrid_schedule=self.config.use_hybrid_gemm_schedule,
                         device=device,
                     )
@@ -752,12 +797,15 @@ class xFuserModel(abc.ABC):
             # a number of transformer blocks while using FP4 for others. This mixed-precision
             # approach balances performance and output quality better than uniform quantization.
             log(f"Quantizing linear layers in {module_name} to FP4...")
-            if self.settings.fp8_precision_overrides:
-                log(f"The following blocks will be quantized to FP8, to maintain output quality: {self.settings.fp8_precision_overrides}")
+            self._log_fp8_overrides(
+                self.settings.fp8_precision_overrides,
+                self.settings.fp8_precision_override_suffixes,
+            )
             module = rgetattr(self.pipe, module_name)
             quantize_linear_layers_to_fp4(
                 module,
                 fp8_layers=self.settings.fp8_precision_overrides,
+                fp8_suffix_layers=self.settings.fp8_precision_override_suffixes,
                 use_hybrid_schedule=self.config.use_hybrid_gemm_schedule,
                 device=f"cuda:{local_rank}",
             )
@@ -775,12 +823,15 @@ class xFuserModel(abc.ABC):
     def _setup_nvfp4_gemms(self, local_rank):
         for module_name in self.settings.fp4_gemm_module_list:
             log(f"Quantizing linear layers in {module_name} to NVFP4 (torchao)...")
-            if self.settings.fp8_precision_overrides:
-                log(f"The following blocks will use FP8 instead, to maintain output quality: {self.settings.fp8_precision_overrides}")
+            self._log_fp8_overrides(
+                self.settings.fp8_precision_overrides,
+                self.settings.fp8_precision_override_suffixes,
+            )
             module = rgetattr(self.pipe, module_name)
             quantize_linear_layers_to_nvfp4(
                 module,
                 fp8_layers=self.settings.fp8_precision_overrides,
+                fp8_suffix_layers=self.settings.fp8_precision_override_suffixes,
                 device=f"cuda:{local_rank}",
             )
         for module_name in self.settings.fp8_gemm_module_list:

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -605,6 +605,13 @@ class xFuserModel(abc.ABC):
         """ Hook for any post model-load and state initialization """
 
         local_rank = get_world_group().local_rank
+        # Log FP8 precision overrides once here rather than per module/block in the
+        # quantization and FSDP-sharding loops below (avoids duplicate log spam).
+        if self.config.use_fp4_gemms:
+            self._log_fp8_overrides(
+                self.settings.fp8_precision_overrides,
+                self.settings.fp8_precision_override_suffixes,
+            )
         # FSDP path handles device placement and quantization (per-block for FSDP2).
         if self.config.fully_shard_degree > 1:
             self._shard_model_with_fsdp()
@@ -758,9 +765,6 @@ class xFuserModel(abc.ABC):
         if not use_fp4_here and not use_fp8_here:
             return None
 
-        if use_fp4_here:
-            self._log_fp8_overrides(fp8_overrides, fp8_suffix_overrides)
-
         def quantize_fn(block, block_idx: int) -> None:
             block_prefix = f"{block_idx}."
             # Strip the block-index prefix so the quantize functions see local FQN paths.
@@ -797,10 +801,6 @@ class xFuserModel(abc.ABC):
             # a number of transformer blocks while using FP4 for others. This mixed-precision
             # approach balances performance and output quality better than uniform quantization.
             log(f"Quantizing linear layers in {module_name} to FP4...")
-            self._log_fp8_overrides(
-                self.settings.fp8_precision_overrides,
-                self.settings.fp8_precision_override_suffixes,
-            )
             module = rgetattr(self.pipe, module_name)
             quantize_linear_layers_to_fp4(
                 module,
@@ -823,10 +823,6 @@ class xFuserModel(abc.ABC):
     def _setup_nvfp4_gemms(self, local_rank):
         for module_name in self.settings.fp4_gemm_module_list:
             log(f"Quantizing linear layers in {module_name} to NVFP4 (torchao)...")
-            self._log_fp8_overrides(
-                self.settings.fp8_precision_overrides,
-                self.settings.fp8_precision_override_suffixes,
-            )
             module = rgetattr(self.pipe, module_name)
             quantize_linear_layers_to_nvfp4(
                 module,

--- a/xfuser/model_executor/models/runner_models/hunyuan.py
+++ b/xfuser/model_executor/models/runner_models/hunyuan.py
@@ -131,9 +131,9 @@ class xFuserHunyuanvideo15Model(xFuserModel):
     )
 
 
-    def __init__(self, config: xFuserArgs) -> None:
-        super().__init__(config)
-        if self.config.task == "i2v": # TODO: different model for 480p
+    def _customize_settings(self, config: xFuserArgs) -> None:
+        super()._customize_settings(config)
+        if config.task == "i2v": # TODO: different model for 480p
             self.settings.model_name = "hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-720p_i2v"
         else:
             self.settings.model_name = "hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-720p_t2v"
@@ -210,8 +210,8 @@ class xFuserHunyuanvideo15Model(xFuserModel):
 @register_model("Hunyuanvideo-1.5-Distilled")
 class xFuserHunyuanvideo15DistilledModel(xFuserHunyuanvideo15Model):
     
-    def __init__(self, config: xFuserArgs) -> None:
-        super().__init__(config)
+    def _customize_settings(self, config: xFuserArgs) -> None:
+        super()._customize_settings(config)
         self.settings.model_name = "hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-720p_i2v_distilled"
         self.settings.output_name = "hunyuan_video_1_5_distilled"
         self.settings.valid_tasks = ["i2v"]
@@ -271,8 +271,8 @@ class xFuserHunyuanvideo15SparseModel(xFuserHunyuanvideo15Model):
         assert len(attn_param["tile_size"]) == 3, "tile_size must be a tuple of 3 integers"
         assert np.prod(attn_param["tile_size"]) == 128 or np.prod(attn_param["tile_size"]) == 384, "product of ssta_tile_thw must be 128 or 384"
 
-    def __init__(self, config: xFuserArgs) -> None:
-        super().__init__(config)
+    def _customize_settings(self, config: xFuserArgs) -> None:
+        super()._customize_settings(config)
         self.settings.model_name = "tencent/HunyuanVideo-1.5"
         self.settings.output_name = "hunyuan_video_1_5_sparse"
         self.settings.valid_tasks = ["i2v"]

--- a/xfuser/model_executor/models/runner_models/qwen.py
+++ b/xfuser/model_executor/models/runner_models/qwen.py
@@ -1,5 +1,4 @@
 import torch
-import copy
 from diffusers import QwenImageEditPipeline, QwenImagePipeline
 from diffusers.pipelines.pipeline_utils import DiffusionPipeline
 from xfuser.model_executor.models.runner_models.base_model import (
@@ -49,9 +48,8 @@ class xFuserQwenImageEditModel(xFuserModel):
         fp8_gemm_module_list=["transformer.transformer_blocks"],
     )
 
-    def __init__(self, config: xFuserArgs) -> None:
-        super().__init__(config)
-        self.settings = copy.deepcopy(self.settings)
+    def _customize_settings(self, config: xFuserArgs) -> None:
+        super()._customize_settings(config)
         if "2511" in config.model:
             self.settings.model_name = "Qwen/Qwen-Image-Edit-2511"
             self.settings.output_name = "qwen_image_edit_2511"
@@ -128,9 +126,8 @@ class xFuserQwenImageModel(xFuserModel):
         },
     )
 
-    def __init__(self, config: xFuserArgs) -> None:
-        super().__init__(config)
-        self.settings = copy.deepcopy(self.settings)
+    def _customize_settings(self, config: xFuserArgs) -> None:
+        super()._customize_settings(config)
         if "2512" in config.model:
             self.settings.model_name = "Qwen/Qwen-Image-2512"
             self.settings.output_name = "qwen_image_2512"

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -283,16 +283,16 @@ class xFuserWan21I2VModel(xFuserModel):
 @register_model("Wan2.2-I2V")
 class xFuserWan22I2VModel(xFuserWan21I2VModel):
 
-    def __init__(self, config: xFuserArgs) -> None:
+    def _customize_settings(self, config: xFuserArgs) -> None:
+        super()._customize_settings(config)
         self.settings.model_name = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
         self.settings.output_name = "wan2.2_i2v"
-        super().__init__(config)
         self.settings.fsdp_strategy["transformer_2"] = {
                 "wrap_attrs": ["blocks"],
                 "dtype": torch.bfloat16,
         }
-        self.settings.fp8_gemm_module_list=["transformer.blocks", "transformer_2.blocks"]
-        self.settings.fp8_precision_overrides=None
+        self.settings.fp8_gemm_module_list = ["transformer.blocks", "transformer_2.blocks"]
+        self.settings.fp8_precision_overrides = None
 
 
     def _load_model(self) -> DiffusionPipeline:
@@ -366,10 +366,10 @@ class xFuserWan22DistilledI2VModel(xFuserWan22I2VModel):
         num_hybrid_attn_high_precision_steps=1,
     )
 
-    def __init__(self, config: xFuserArgs) -> None:
+    def _customize_settings(self, config: xFuserArgs) -> None:
+        super()._customize_settings(config)
         self.settings.model_name = self._BASE_MODEL
         self.settings.output_name = "wan2.2_distilled_i2v"
-        super().__init__(config)
 
     def _load_model(self) -> DiffusionPipeline:
         transformer = xFuserWanTransformer3DWrapper.from_pretrained(
@@ -534,8 +534,8 @@ class xFuserWan21T2VModel(xFuserModel):
 @register_model("Wan2.2-T2V")
 class xFuserWan22T2VModel(xFuserWan21T2VModel):
 
-    def __init__(self, config: xFuserArgs) -> None:
-        super().__init__(config)
+    def _customize_settings(self, config: xFuserArgs) -> None:
+        super()._customize_settings(config)
         self.settings.model_name = "Wan-AI/Wan2.2-T2V-A14B-Diffusers"
         self.settings.output_name = "wan2.2_t2v"
         self.settings.fsdp_strategy["transformer_2"] = {
@@ -724,8 +724,8 @@ class xFuserWan21VACEModel(xFuserModel):
         },
     )
 
-    def __init__(self, config: xFuserArgs) -> None:
-        super().__init__(config)
+    def _customize_settings(self, config: xFuserArgs) -> None:
+        super()._customize_settings(config)
         if "14B" in config.model:
             self.settings.model_name = "Wan-AI/Wan2.1-VACE-14B-diffusers"
             self.settings.output_name = "wan.2.1_vace_14b"

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -613,6 +613,7 @@ class xFuserWan22TI2VModel(xFuserWan21T2VModel):
         fp8_gemm_module_list=["transformer.blocks"],
         fp4_gemm_module_list=["transformer.blocks"],
         fp8_precision_overrides=("0.", "1.", "28.", "29."),
+        fp8_precision_override_suffixes=(".net.0.proj", ".net.2"),
         fsdp_strategy=COMMON_FSDP_STRATEGY,
         valid_tasks=["i2v", "t2v"],
     )


### PR DESCRIPTION
## Summary

Adds CLI control over which transformer linear layers stay in **FP8** while the
rest of the module is quantized to **FP4**, so quality-sensitive layers can be
pinned to higher precision without giving up the FP4 speedup:

- `--fp8_precision_override_prefix_patterns` — comma-delimited FQN **prefix** patterns
- `--fp8_precision_override_suffix_patterns` — comma-delimited FQN **suffix** patterns

These map onto per-model `ModelSettings.fp8_precision_overrides` (prefix) and
`ModelSettings.fp8_precision_override_suffixes` (suffix), so models can ship
sensible defaults while users can override from the CLI.

This PR also includes two supporting changes (see below) that the feature builds on.

## Motivation

Uniform FP4 quantization drifts on quality-sensitive layers — e.g. FFN
projections (`.net.0.proj`, `.net.2`) and the first/last transformer blocks.
Pinning those layers to FP8 recovers output quality while keeping FP4 throughput
on the bulk of the network. Prefix patterns target block-indexed FQNs
(`0.`, `1.`, `28.`, `29.`); suffix patterns target block-local FQNs
(`.net.0.proj`, `.net.2`) that recur across every block.

## What's in this PR

### 1. FP8 precision-override prefix/suffix patterns (headline feature)
- **`config/args.py`**: two `nullable_str` flags + help text, and a
  `create_config()` guard that raises `ValueError` if either pattern is set
  without `--use_fp4_gemms` (overrides only apply on the FP4 quant path).
- **`core/utils/runner_utils.py`**: new `_layer_uses_fp8_override(fqn, prefixes, suffixes)`
  (startswith / endswith) wired into `quantize_linear_layers_to_fp4` and
  `quantize_linear_layers_to_nvfp4`; both now accept `fp8_suffix_layers`.
- **`model_executor/models/runner_models/base_model.py`**: new
  `ModelSettings.fp8_precision_override_suffixes`; `_apply_fp8_override_cli_from_config`
  parses the CSV flags into settings; `_setup_mxfp4_gemms` / `_setup_nvfp4_gemms`
  and the FSDP2 per-block `_build_fsdp_quantize_fn` honor both prefix and suffix
  patterns (prefix patterns are block-index-stripped per block; suffix patterns
  pass through unchanged); `_log_fp8_overrides` logs prefix/suffix matches
  consistently.
- **`model_executor/models/runner_models/wan.py`**: Wan2.2 **TI2V-5B** ships a
  default suffix override `(".net.0.proj", ".net.2")` alongside its existing
  prefix overrides `("0.", "1.", "28.", "29.")`. (Wan2.2 I2V/T2V-A14B leave
  `fp8_precision_overrides=None`.)

### 2. Centralized `ModelSettings` deepcopy + `_customize_settings` hook
- `xFuserModel.__init__` now deep-copies `self.settings` once and calls a new
  `_customize_settings(config)` hook **before** `_validate_config` and CLI override
  application, so subclass `model_name` / `valid_tasks` / default overrides are in
  place when validation and override-wiring run.
- Subclasses (`hunyuan.py`, `qwen.py`, `wan.py`) migrate from overriding
  `__init__` to overriding `_customize_settings`. This removes the per-subclass
  `copy.deepcopy(self.settings)` duplication (notably in `qwen.py`) and fixes the
  ordering bug where some subclasses set `model_name` after `super().__init__()`.

### 3. torchao Float8 FSDP2 op-table compatibility fix (`runner_utils.py`)
- `_patch_torchao_float8_fsdp2` previously read `Float8Tensor._ATEN_OP_TABLE`
  directly. torchao 0.14+ renamed/relocated this to
  `_ATEN_OP_OR_TORCH_FN_TABLE`. New `_float8_tensor_op_table()` helper resolves the
  table across both naming schemes and the `aten.split` override was reworked to
  always register (with a typed fall-through) so FSDP2 + FP8 keeps working on newer
  torchao.

## How to test

FP4 with FFN projections pinned to FP8 (Wan2.2 TI2V-5B):

```
--use_fp4_gemms \
--fp8_precision_override_suffix_patterns .net.0.proj,.net.2
```

Prefix example (pin boundary blocks):

```
--use_fp4_gemms \
--fp8_precision_override_prefix_patterns 0.,1.,28.,29.
```

Guard: setting either pattern flag **without** `--use_fp4_gemms` raises
`ValueError` from `create_config()`.

Validated on MI355 (8×gfx950, ROCm) across single- and multi-GPU (FSDP2) runs;
the suffix-override path is the default for Wan2.2 TI2V-5B. Quality/throughput
deltas captured in internal experiment logs.

## Notes for reviewers

- Changes #2 and #3 are bundled here because the feature wiring sits on top of
  them; happy to split either into a standalone PR if preferred.
- Supersedes the earlier, since-closed #704 (which used a single
  `--fp8_precision_override_extend` union flag); this revision replaces that with
  explicit prefix/suffix pattern flags.
