### PR TITLE
RDNA4/gfx1201 FP8 quant improvements

### DIFF
--- a/xfuser/model_executor/layers/fp8_linear.py
+++ b/xfuser/model_executor/layers/fp8_linear.py
@@ -11,7 +11,6 @@ _FP8_MAX = 448.0  # torch.finfo(torch.float8_e4m3fn).max
 _FP8_BLOCK = 128
 
 
-@torch.compile
 def _quantize_weight_blocks(w_blocks: torch.Tensor, w_amax: torch.Tensor) -> torch.Tensor:
     return (w_blocks / w_amax[:, None, :, None] * _FP8_MAX).clamp(-_FP8_MAX, _FP8_MAX).to(torch.float8_e4m3fn)
 

--- a/xfuser/model_executor/layers/fp8_linear.py
+++ b/xfuser/model_executor/layers/fp8_linear.py
@@ -1,4 +1,3 @@
-import math
 import torch
 import torch.nn as nn
 from typing import Optional
@@ -12,46 +11,53 @@ _FP8_MAX = 448.0  # torch.finfo(torch.float8_e4m3fn).max
 _FP8_BLOCK = 128
 
 
-@torch.library.custom_op("mylib::fp8_blockscale_gemm", mutates_args=())
-def _fp8_blockscale_gemm(
-    a_q: torch.Tensor,
-    a_scale: torch.Tensor,
-    w_fp8: torch.Tensor,
-    w_scale: torch.Tensor,
-) -> torch.Tensor:
-    return aiter.gemm_a8w8_blockscale(a_q, w_fp8, a_scale, w_scale)
-
-
-@_fp8_blockscale_gemm.register_fake
-def _(
-    a_q: torch.Tensor,
-    a_scale: torch.Tensor,
-    w_fp8: torch.Tensor,
-    w_scale: torch.Tensor,
-) -> torch.Tensor:
-    M = a_q.shape[0]
-    N = w_fp8.shape[0]
-    return torch.empty(M, N, dtype=torch.bfloat16, device=a_q.device)
+@torch.compile
+def _quantize_weight_blocks(w_blocks: torch.Tensor, w_amax: torch.Tensor) -> torch.Tensor:
+    return (w_blocks / w_amax[:, None, :, None] * _FP8_MAX).clamp(-_FP8_MAX, _FP8_MAX).to(torch.float8_e4m3fn)
 
 
 def _pad_cols_to_multiple(t: torch.Tensor, block: int) -> tuple[torch.Tensor, bool]:
-    """Pad last dim (cols) to a multiple of block. Returns (padded, was_padded)."""
     c_pad = (-t.shape[-1]) % block
     if c_pad == 0:
         return t, False
     return torch.nn.functional.pad(t, (0, c_pad)), True
 
 
+@torch.library.custom_op("mylib::fp8_blockscale_gemm", mutates_args=())
+def _fp8_blockscale_gemm(
+    x: torch.Tensor,
+    w_fp8: torch.Tensor,
+    w_scale: torch.Tensor,
+) -> torch.Tensor:
+    K = x.shape[1]
+    x_padded, needs_pad = _pad_cols_to_multiple(x, _FP8_BLOCK)
+    x_q, x_scale = aiter.get_hip_quant(aiter.QuantType.per_1x128)(x_padded, quant_dtype=aiter.dtypes.fp8)
+    if needs_pad:
+        x_q = x_q[:, :K].contiguous()
+    return aiter.gemm_a8w8_blockscale(x_q, w_fp8, x_scale, w_scale)
+
+
+@_fp8_blockscale_gemm.register_fake
+def _(
+    x: torch.Tensor,
+    w_fp8: torch.Tensor,
+    w_scale: torch.Tensor,
+) -> torch.Tensor:
+    M = x.shape[0]
+    N = w_fp8.shape[0]
+    return torch.empty(M, N, dtype=torch.bfloat16, device=x.device)
+
+
 class xFuserFP8BlockScaleLinear(nn.Module):
     """
     Drop-in nn.Linear replacement using AITER gemm_a8w8_blockscale (block-128 FP8 w8a8).
 
-    Weights pre-quantized at load time to float8_e4m3fn. Activations block-quantized
-    dynamically in forward() — ops are visible to torch.compile/Inductor for fusion.
+    Weights pre-quantized at load time. Activations quantized inside the custom op
+    via aiter.get_hip_quant(QuantType.per_1x128) — fused with GEMM under torch.compile.
 
     Scale shapes:
         weight_scale: [ceil(N/128), ceil(K/128)]
-        x_scale (runtime): [M, ceil(K/128)]
+        x_scale (runtime): [M, K/128]
     """
 
     def __init__(self, in_features: int, out_features: int, bias: bool = True,
@@ -83,7 +89,6 @@ class xFuserFP8BlockScaleLinear(nn.Module):
 
         target = device if device is not None else weight.device
         w = weight.to(device=target)
-        # Pad both dims for the [n_blocks, 128, k_blocks, 128] reshape
         r_pad = (-N) % _FP8_BLOCK
         c_pad = (-K) % _FP8_BLOCK
         if r_pad or c_pad:
@@ -96,10 +101,7 @@ class xFuserFP8BlockScaleLinear(nn.Module):
         w_amax = w_blocks.abs().amax(dim=(1, 3)).clamp(min=1e-12)  # [n_blocks, k_blocks]
         w_scale = (w_amax.float() / _FP8_MAX)
 
-        # One row-block at a time: avoids a full BF16 intermediate alongside the weight.
-        w_q = torch.empty_like(w_blocks, dtype=torch.float8_e4m3fn)
-        for i in range(n_blocks):
-            w_q[i] = (w_blocks[i] / w_amax[i][None, :, None] * _FP8_MAX).clamp(-_FP8_MAX, _FP8_MAX).to(torch.float8_e4m3fn)
+        w_q = _quantize_weight_blocks(w_blocks, w_amax)
         w_q = w_q.reshape(n_blocks * _FP8_BLOCK, k_blocks * _FP8_BLOCK)
         if was_padded:
             w_q = w_q[:N, :K].contiguous()
@@ -117,27 +119,8 @@ class xFuserFP8BlockScaleLinear(nn.Module):
 
         original_shape = input.shape
         x = input.view(-1, self.in_features)
-        M, K = x.shape
-        k_blocks = math.ceil(K / _FP8_BLOCK)
-
-        # aiter.get_hip_quant(aiter.QuantType.per_1x128) is the natural API here —
-        # fused HIP kernel matching MXFP4's per_1x32 pattern — but module_quant JIT
-        # fails to build on gfx1201 with ROCm 7.2.3:
-        #   __builtin_amdgcn_raw_ptr_buffer_load_lds needs vmem-to-lds-load-insts
-        # Manual block-128 quant; torch.compile/Inductor fuses these into ~2 kernels.
-        x_padded, needs_pad = _pad_cols_to_multiple(x, _FP8_BLOCK)
-        K_pad = x_padded.shape[1]
-
-        x_blocks = x_padded.reshape(M, k_blocks, _FP8_BLOCK)
-        x_amax = x_blocks.abs().amax(dim=-1).clamp(min=1e-12)  # [M, k_blocks]
-        x_scale = (x_amax.float() / _FP8_MAX)
-        x_q = (x_blocks / x_amax.unsqueeze(-1) * _FP8_MAX).clamp(-_FP8_MAX, _FP8_MAX)
-        x_q = x_q.to(torch.float8_e4m3fn).reshape(M, K_pad)
-        if needs_pad:
-            x_q = x_q[:, :K].contiguous()
-
         output = torch.ops.mylib.fp8_blockscale_gemm(
-            x_q, x_scale, self.weight_fp8, self.weight_scale,
+            x, self.weight_fp8, self.weight_scale,
         ).to(input.dtype)
         if self.bias is not None:
             output = output + self.bias


### PR DESCRIPTION
- Replace manual Python block-128 activation quant in `forward()` with `aiter.get_hip_quant(QuantType.per_1x128)` - a native HIP kernel. This behaves as expected with newer aiter builds than the one I was testing previously.

- Move activation quant + padding inside the `custom_op`, matching the MXFP4 pattern.

- Together, the above two points reduce activation-quant from ~2 Inductor-fused kernels to one native HIP kernel, and moves quant+padding into the opaque custom_op so Inductor sees a single fused op instead of a multi-op sequence.

- Replace per-row-block Python loop in `_quantize_weights` with a `torch.compile`-fused vectorized op. Same VRAM footprint, better GPU parallelism.