### PR TITLE
RDNA4/gfx1201 General compile optimizations

### DIFF
--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -384,6 +384,8 @@ class xFuserModel(abc.ABC):
 
 
     def _get_compile_mode(self) -> str:
+        # Overrides should return "default" when PACKAGES_CHECKER._on_rdna4():
+        # CUDA graphs are slow on RDNA4.
         return "default"  # TODO: Configurable
 
     def _get_compile_dynamic(self) -> Optional[bool]:

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -383,14 +383,51 @@ class xFuserModel(abc.ABC):
                 raise ValueError(f"Model {self.settings.model_name} does not support distilled_transformer_path or distilled_transformer_2_path params.")
 
 
+    def _get_compile_mode(self) -> str:
+        return "default"  # TODO: Configurable
+
+    def _get_compile_dynamic(self) -> Optional[bool]:
+        return None  # torch default (auto)
+
+    def _get_compiled_pipe_components(self) -> List[str]:
+        return ["transformer"]
+
+    def _get_compile_warmup_steps(self, input_args: dict) -> Optional[int]:
+        return 2  # None = skip step reduction, run full warmup cycle
 
     def _compile_model(self, input_args: dict) -> None:
-        """ Compile the model using torch.compile."""
+        """Compile pipe components with torch.compile.
+
+        When FSDP is active (fully_shard_degree > 1), compiles each component's
+        FSDP-wrapped block lists individually (read from fsdp_strategy wrap_attrs)
+        to avoid dynamo tracing through FSDP2 forward_pre_hooks and fragmenting
+        the graph at every block boundary.
+        """
         torch._inductor.config.reorder_for_compute_comm_overlap = True
-        self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default") # TODO: Configurable
-        # two steps to warmup the torch compiler
-        input_args["num_inference_steps"] = 2  # Reduce steps for warmup # TODO: make this more generic
-        self._run_timed_pipe(input_args)
+        mode = self._get_compile_mode()
+        dynamic = self._get_compile_dynamic()
+        for component_name in self._get_compiled_pipe_components():
+            component = getattr(self.pipe, component_name, None)
+            if component is None:
+                continue
+            if self.config.fully_shard_degree > 1:
+                wrap_attrs = self.settings.fsdp_strategy.get(component_name, {}).get("wrap_attrs", [])
+                compiled_any = False
+                for attr in wrap_attrs:
+                    block_list = getattr(component, attr, None)
+                    if block_list is not None:
+                        for i in range(len(block_list)):
+                            block_list[i] = torch.compile(block_list[i], mode=mode, dynamic=dynamic)
+                        compiled_any = True
+                if not compiled_any:
+                    setattr(self.pipe, component_name, torch.compile(component, mode=mode, dynamic=dynamic))
+            else:
+                setattr(self.pipe, component_name, torch.compile(component, mode=mode, dynamic=dynamic))
+        compile_args = copy.deepcopy(input_args)
+        warmup_steps = self._get_compile_warmup_steps(input_args)
+        if warmup_steps is not None:
+            compile_args["num_inference_steps"] = warmup_steps
+        self._run_timed_pipe(compile_args)
 
 
     def run(self, input_args: dict) -> Tuple[DiffusionOutput, list]:

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -414,7 +414,10 @@ class xFuserModel(abc.ABC):
                 wrap_attrs = self.settings.fsdp_strategy.get(component_name, {}).get("wrap_attrs", [])
                 compiled_any = False
                 for attr in wrap_attrs:
-                    block_list = getattr(component, attr, None)
+                    try:
+                        block_list = rgetattr(component, attr)
+                    except AttributeError:
+                        block_list = None
                     if block_list is not None:
                         for i in range(len(block_list)):
                             block_list[i] = torch.compile(block_list[i], mode=mode, dynamic=dynamic)

--- a/xfuser/model_executor/models/runner_models/causal_wan.py
+++ b/xfuser/model_executor/models/runner_models/causal_wan.py
@@ -158,10 +158,5 @@ class xFuserCausalWanModel(xFuserModel):
         if task == "i2v" and len(images) != 1:
             raise ValueError("Exactly one input image is required for CausalWan I2V mode.")
 
-    def _compile_model(self, input_args):
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
-        self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
-        self.pipe.transformer_2 = torch.compile(self.pipe.transformer_2, mode="default")
-        compile_args = copy.deepcopy(input_args)
-        compile_args["num_inference_steps"] = 2
-        self._run_timed_pipe(compile_args)
+    def _get_compiled_pipe_components(self):
+        return ["transformer", "transformer_2"]

--- a/xfuser/model_executor/models/runner_models/cosmos3.py
+++ b/xfuser/model_executor/models/runner_models/cosmos3.py
@@ -1,4 +1,3 @@
-import copy
 import json
 import torch
 from diffusers import UniPCMultistepScheduler
@@ -206,13 +205,6 @@ class xFuserCosmos3SuperModel(xFuserModel):
                 image = resize_and_crop_image(image, width, height, self.settings.mod_value)
             input_args["image"] = image
         return input_args
-
-    def _compile_model(self, input_args: dict) -> None:
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
-        self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
-        compile_args = copy.deepcopy(input_args)
-        compile_args["num_inference_steps"] = 2
-        self._run_timed_pipe(compile_args)
 
     def _post_load_and_state_initialization(self, input_args: dict) -> None:
         super()._post_load_and_state_initialization(input_args)

--- a/xfuser/model_executor/models/runner_models/flux.py
+++ b/xfuser/model_executor/models/runner_models/flux.py
@@ -1,7 +1,7 @@
 import torch
+from typing import Optional
 from diffusers import FluxPipeline, FluxKontextPipeline, Flux2Pipeline, Flux2KleinPipeline
 from diffusers.pipelines.pipeline_utils import DiffusionPipeline
-from xfuser.envs import PACKAGES_CHECKER
 from xfuser.model_executor.models.transformers.transformer_flux import xFuserFlux1Transformer2DWrapper
 from xfuser.model_executor.models.transformers.transformer_flux2 import xFuserFlux2Transformer2DWrapper
 from xfuser.model_executor.models.runner_models.base_model import (
@@ -83,13 +83,8 @@ class xFuserFluxModel(xFuserModel):
         if self.config.use_parallel_vae:
             _setup_parallel_vae(self.pipe.vae)
 
-    def _compile_model(self, input_args: dict) -> None:
-        """ Compile the model using torch.compile."""
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
-        self.pipe.transformer = torch.compile(self.pipe.transformer, mode="reduce-overhead") # Better perf for FLUX.1
-        # two steps to warmup the torch compiler
-        input_args["num_inference_steps"] = 2
-        self._run_timed_pipe(input_args)
+    def _get_compile_mode(self) -> str:
+        return "reduce-overhead"
 
     def _load_model(self) -> DiffusionPipeline:
         if self.config.pipefusion_parallel_degree > 1:
@@ -293,22 +288,12 @@ class xFuserFlux2Model(xFuserModel):
                 f"rel_l1_thresh={rel_l1_thresh}, num_steps={num_steps}"
             )
 
-    def _compile_model(self, input_args: dict) -> None:
-        """Compile the model using torch.compile.
+    def _get_compile_mode(self) -> str:
+        # FBCache cross-step caching is incompatible with CUDA graphs.
+        return "default" if self.config.use_fbcache else "reduce-overhead"
 
-        When FBCache is enabled, uses mode="default" instead of "reduce-overhead"
-        because FBCache's cross-step tensor caching is incompatible with CUDA
-        graphs (buffer aliasing on dynamo guard changes).
-        """
-        compile_mode = "default" if self.config.use_fbcache else "reduce-overhead"
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
-        self.pipe.transformer = torch.compile(
-            self.pipe.transformer,
-            mode=compile_mode,
-            dynamic=False,
-        )
-        input_args["num_inference_steps"] = 2
-        self._run_timed_pipe(input_args)
+    def _get_compile_dynamic(self) -> Optional[bool]:
+        return False
 
     def _load_model(self) -> DiffusionPipeline:
         transformer = xFuserFlux2Transformer2DWrapper.from_pretrained(
@@ -389,22 +374,12 @@ class xFuserFlux2Klein9BModel(xFuserModel):
         if self.config.use_parallel_vae:
             _setup_parallel_vae(self.pipe.vae)
 
-    def _compile_model(self, input_args: dict) -> None:
-        """Compile the model using torch.compile.
+    def _get_compile_mode(self) -> str:
+        # FBCache cross-step caching is incompatible with CUDA graphs.
+        return "default" if self.config.use_fbcache else "reduce-overhead"
 
-        When FBCache is enabled, uses mode="default" instead of "reduce-overhead"
-        because FBCache's cross-step tensor caching is incompatible with CUDA
-        graphs (buffer aliasing on dynamo guard changes).
-        """
-        compile_mode = "default" if self.config.use_fbcache else "reduce-overhead"
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
-        self.pipe.transformer = torch.compile(
-            self.pipe.transformer,
-            mode=compile_mode,
-            dynamic=False,
-        )
-        input_args["num_inference_steps"] = 2
-        self._run_timed_pipe(input_args)
+    def _get_compile_dynamic(self) -> Optional[bool]:
+        return False
 
     def _load_model(self) -> DiffusionPipeline:
         transformer = xFuserFlux2Transformer2DWrapper.from_pretrained(

--- a/xfuser/model_executor/models/runner_models/flux.py
+++ b/xfuser/model_executor/models/runner_models/flux.py
@@ -12,6 +12,7 @@ from xfuser.model_executor.models.runner_models.base_model import (
     DiffusionOutput,
     ModelSettings,
 )
+from xfuser.envs import PACKAGES_CHECKER
 from xfuser.core.utils.runner_utils import (
     log,
     resize_and_crop_image,
@@ -84,6 +85,8 @@ class xFuserFluxModel(xFuserModel):
             _setup_parallel_vae(self.pipe.vae)
 
     def _get_compile_mode(self) -> str:
+        if PACKAGES_CHECKER._on_rdna4():
+            return "default"
         return "reduce-overhead"
 
     def _load_model(self) -> DiffusionPipeline:
@@ -289,8 +292,11 @@ class xFuserFlux2Model(xFuserModel):
             )
 
     def _get_compile_mode(self) -> str:
-        # FBCache cross-step caching is incompatible with CUDA graphs.
-        return "default" if self.config.use_fbcache else "reduce-overhead"
+        # CUDA graphs incompatible with FBCache cross-step caching,
+        # and cause pathological re-captures on RDNA4.
+        if self.config.use_fbcache or PACKAGES_CHECKER._on_rdna4():
+            return "default"
+        return "reduce-overhead"
 
     def _get_compile_dynamic(self) -> Optional[bool]:
         return False
@@ -375,8 +381,11 @@ class xFuserFlux2Klein9BModel(xFuserModel):
             _setup_parallel_vae(self.pipe.vae)
 
     def _get_compile_mode(self) -> str:
-        # FBCache cross-step caching is incompatible with CUDA graphs.
-        return "default" if self.config.use_fbcache else "reduce-overhead"
+        # CUDA graphs incompatible with FBCache cross-step caching,
+        # and cause pathological re-captures on RDNA4.
+        if self.config.use_fbcache or PACKAGES_CHECKER._on_rdna4():
+            return "default"
+        return "reduce-overhead"
 
     def _get_compile_dynamic(self) -> Optional[bool]:
         return False

--- a/xfuser/model_executor/models/runner_models/ltx.py
+++ b/xfuser/model_executor/models/runner_models/ltx.py
@@ -179,10 +179,14 @@ class xFuserLTX23VideoModel(xFuserModel):
 
         return DiffusionOutput(videos=output, pipe_args=input_args)
 
+    def _get_compile_mode(self) -> str:
+        if PACKAGES_CHECKER._on_rdna4():
+            return "default"
+        return "reduce-overhead"
+
     def _compile_model(self, input_args: dict) -> None:
         torch._inductor.config.reorder_for_compute_comm_overlap = True
-        compile_mode = "default" if PACKAGES_CHECKER._on_rdna4() else "reduce-overhead"
-        self.pipe.transformer.compile_repeated_blocks(mode=compile_mode)
+        self.pipe.transformer.compile_repeated_blocks(mode=self._get_compile_mode())
 
         # two steps to warmup the torch compiler
         compile_args = copy.deepcopy(input_args)
@@ -309,10 +313,14 @@ class xFuserLTX2VideoModel(xFuserModel):
         )
         return DiffusionOutput(videos=output, pipe_args=input_args)
 
+    def _get_compile_mode(self) -> str:
+        if PACKAGES_CHECKER._on_rdna4():
+            return "default"
+        return "reduce-overhead"
+
     def _compile_model(self, input_args: dict) -> None:
         torch._inductor.config.reorder_for_compute_comm_overlap = True
-        compile_mode = "default" if PACKAGES_CHECKER._on_rdna4() else "reduce-overhead"
-        self.pipe.transformer.compile_repeated_blocks(mode=compile_mode)
+        self.pipe.transformer.compile_repeated_blocks(mode=self._get_compile_mode())
 
         # two steps to warmup the torch compiler
         compile_args = copy.deepcopy(input_args)

--- a/xfuser/model_executor/models/runner_models/ltx.py
+++ b/xfuser/model_executor/models/runner_models/ltx.py
@@ -7,6 +7,7 @@ from diffusers.pipelines.ltx2.utils import STAGE_2_DISTILLED_SIGMA_VALUES
 from diffusers.pipelines.pipeline_utils import DiffusionPipeline
 from diffusers.pipelines.ltx2.export_utils import encode_video
 from xfuser.model_executor.models.transformers.transformer_ltx2 import xFuserLTX2VideoTransformer3DWrapper
+from xfuser.envs import PACKAGES_CHECKER
 from xfuser.model_executor.models.runner_models.base_model import (
     xFuserModel,
     register_model,
@@ -180,7 +181,8 @@ class xFuserLTX23VideoModel(xFuserModel):
 
     def _compile_model(self, input_args: dict) -> None:
         torch._inductor.config.reorder_for_compute_comm_overlap = True
-        self.pipe.transformer.compile_repeated_blocks(mode="reduce-overhead")
+        compile_mode = "default" if PACKAGES_CHECKER._on_rdna4() else "reduce-overhead"
+        self.pipe.transformer.compile_repeated_blocks(mode=compile_mode)
 
         # two steps to warmup the torch compiler
         compile_args = copy.deepcopy(input_args)
@@ -309,7 +311,8 @@ class xFuserLTX2VideoModel(xFuserModel):
 
     def _compile_model(self, input_args: dict) -> None:
         torch._inductor.config.reorder_for_compute_comm_overlap = True
-        self.pipe.transformer.compile_repeated_blocks(mode="reduce-overhead")
+        compile_mode = "default" if PACKAGES_CHECKER._on_rdna4() else "reduce-overhead"
+        self.pipe.transformer.compile_repeated_blocks(mode=compile_mode)
 
         # two steps to warmup the torch compiler
         compile_args = copy.deepcopy(input_args)

--- a/xfuser/model_executor/models/runner_models/stable_diffusion.py
+++ b/xfuser/model_executor/models/runner_models/stable_diffusion.py
@@ -55,12 +55,8 @@ class xFuserStableDiffusionModel(xFuserModel):
         )
         return pipe
 
-    def _compile_model(self, input_args: dict) -> None:
-        self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
-        self.pipe.text_encoder = torch.compile(self.pipe.text_encoder, mode="default")
-        self.pipe.text_encoder_2 = torch.compile(self.pipe.text_encoder_2, mode="default")
-        self.pipe.text_encoder_3 = torch.compile(self.pipe.text_encoder_3, mode="default")
-        self._run_timed_pipe(input_args)
+    def _get_compiled_pipe_components(self):
+        return ["transformer", "text_encoder", "text_encoder_2", "text_encoder_3"]
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
         output = self.pipe(

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -1,7 +1,7 @@
 import copy
 import re
 import torch
-from typing import List
+from typing import List, Optional
 from PIL import Image
 from diffusers import FlowMatchEulerDiscreteScheduler, WanPipeline
 from diffusers.pipelines.pipeline_utils import DiffusionPipeline
@@ -269,14 +269,12 @@ class xFuserWan21I2VModel(xFuserModel):
         if len(images) != 1:
             raise ValueError("Exactly one input image is required for Wan I2V model.")
 
-    def _compile_model(self, input_args):
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
-        self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
-        compile_args = copy.deepcopy(input_args)
-        # If a per-step attention schedule is active, do a full warmup to trigger all backend paths.
+    def _get_compile_warmup_steps(self, input_args: dict) -> Optional[int]:
+        # Full warmup when a per-step attention or GEMM schedule is active,
+        # to trigger all backend paths; reduce to 2 steps otherwise.
         if not get_runtime_state().has_attention_schedule() and not get_runtime_state().has_gemm_schedule():
-            compile_args["num_inference_steps"] = 2 # Reduce steps for warmup
-        self._run_timed_pipe(compile_args)
+            return 2
+        return None
 
 
 @register_model("Wan-AI/Wan2.2-I2V-A14B-Diffusers")
@@ -316,12 +314,11 @@ class xFuserWan22I2VModel(xFuserWan21I2VModel):
         )
         return pipe
 
-    def _compile_model(self, input_args):
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
-        self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
-        self.pipe.transformer_2 = torch.compile(self.pipe.transformer_2, mode="default")
-        # Full cycle to warmup the torch compiler
-        self._run_timed_pipe(input_args)
+    def _get_compiled_pipe_components(self):
+        return ["transformer", "transformer_2"]
+
+    def _get_compile_warmup_steps(self, input_args: dict) -> Optional[int]:
+        return None  # full warmup cycle
 
 
 @register_model("Wan2.2-Distilled-I2V")
@@ -520,14 +517,10 @@ class xFuserWan21T2VModel(xFuserModel):
         )
         return DiffusionOutput(videos=output.frames, pipe_args=input_args)
 
-    def _compile_model(self, input_args):
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
-        self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
-        compile_args = copy.deepcopy(input_args)
-        # If a per-step attention schedule is active, do a full warmup to trigger all backend paths.
+    def _get_compile_warmup_steps(self, input_args: dict) -> Optional[int]:
         if not get_runtime_state().has_attention_schedule() and not get_runtime_state().has_gemm_schedule():
-            compile_args["num_inference_steps"] = 2 # Reduce steps for warmup
-        self._run_timed_pipe(compile_args)
+            return 2
+        return None
 
 
 @register_model("Wan-AI/Wan2.2-T2V-A14B-Diffusers")
@@ -566,12 +559,11 @@ class xFuserWan22T2VModel(xFuserWan21T2VModel):
         )
         return pipe
 
-    def _compile_model(self, input_args):
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
-        self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
-        self.pipe.transformer_2 = torch.compile(self.pipe.transformer_2, mode="default")
-        # Full cycle to warmup the torch compiler
-        self._run_timed_pipe(input_args)
+    def _get_compiled_pipe_components(self):
+        return ["transformer", "transformer_2"]
+
+    def _get_compile_warmup_steps(self, input_args: dict) -> Optional[int]:
+        return None  # full warmup cycle
 
 
 @register_model("Wan-AI/Wan2.2-TI2V-5B-Diffusers")
@@ -651,10 +643,8 @@ class xFuserWan22TI2VModel(xFuserWan21T2VModel):
         output = self.pipe(**kwargs)
         return DiffusionOutput(videos=output.frames, pipe_args=input_args)
 
-    def _compile_model(self, input_args):
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
-        self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
-        self._run_timed_pipe(input_args)
+    def _get_compile_warmup_steps(self, input_args: dict) -> Optional[int]:
+        return None  # full warmup cycle
 
     def _preprocess_args_images(self, input_args: dict) -> dict:
         input_args = super()._preprocess_args_images(input_args)


### PR DESCRIPTION
- When using FSDP, do explicit shard-aligned compilation. This reduces some awkward graph breaks when dynamo tries to trace across block boundaries.
- Some refactoring and centralization of the model compile logic for consistency and maintainability.
- `reduce-overhead` is significantly slower on gfx1201 in my testing - this adds a simple check to switch to `default` where relevant.