### PR TITLE
Add Head Balancing for AITER Sparge Backends

### DIFF
--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -172,6 +172,7 @@ class xFuserArgs:
     use_spargeattn_static_block_mask: bool = True
     spargeattn_simthreshold: float = 0.3
     spargeattn_cdfthreshold: float = 0.92
+    use_spargeattn_head_balance: bool = False
     # Distilled model weight paths
     distilled_transformer_path: Optional[str] = None
     distilled_transformer_2_path: Optional[str] = None
@@ -767,6 +768,13 @@ class xFuserArgs:
                  "--spargeattn_reorder_sequence is set. Use --no-use_spargeattn_static_block_mask to disable."
         )
         parser.add_argument(
+            "--use_spargeattn_head_balance",
+            action="store_true",
+            help="Balance per-rank attention work across Ulysses ranks by "
+                 "permuting heads (block-sparse load balancing). Only has an "
+                 "effect with ulysses_degree>1 and a Sparge attention backend.",
+        )
+        parser.add_argument(
             "--distilled_transformer_path",
             type=nullable_str,
             default=None,
@@ -859,6 +867,7 @@ class xFuserArgs:
             use_spargeattn_static_block_mask=self.use_spargeattn_static_block_mask,
             spargeattn_simthreshold=self.spargeattn_simthreshold,
             spargeattn_cdfthreshold=self.spargeattn_cdfthreshold,
+            use_spargeattn_head_balance=self.use_spargeattn_head_balance,
         )
 
         parallel_config = ParallelConfig(

--- a/xfuser/config/config.py
+++ b/xfuser/config/config.py
@@ -68,6 +68,7 @@ class RuntimeConfig:
     use_spargeattn_static_block_mask: bool = True
     spargeattn_simthreshold: float = 0.3
     spargeattn_cdfthreshold: float = 0.92
+    use_spargeattn_head_balance: bool = False
 
     def __post_init__(self):
         check_packages()

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -18,6 +18,7 @@ from xfuser.core.sparge_attention.sparge import (
     restore_sparge_output,
     mask_padded_kv_blocks,
 )
+from xfuser.core.sparge_attention import head_balance
 
 ATTENTION_FUNCTION_REGISTRY = {}
 
@@ -969,6 +970,14 @@ def _build_sparge_block_mask(query, key, value, is_causal, attention_kwargs, con
     )
     block_mask = mask_padded_kv_blocks(block_mask, state, config["BLOCK_N"])
     num_heads = q.shape[1]
+    # Per-head selected-block cost for the Ulysses head-balancer, written into
+    # the scratch "cost sink" tensor that USP passes down via attention_kwargs
+    # (only present when balancing is active). This keeps the head cost OUT of
+    # the (output, softmax_lse) return contract.
+    if head_balance.ENABLED:
+        cost_sink = (attention_kwargs or {}).get(head_balance.COST_SINK_KEY)
+        if cost_sink is not None:
+            cost_sink.copy_(block_mask.to(torch.float32).sum(dim=(0, 2, 3)))
     return q, k, v, state, block_mask, num_heads
 
 @register_attention_function(AttentionBackendType.AITER_SPARGE)

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -18,7 +18,7 @@ from xfuser.core.sparge_attention.sparge import (
     restore_sparge_output,
     mask_padded_kv_blocks,
 )
-from xfuser.core.sparge_attention import head_balance
+from xfuser.core.sparge_attention.head_balance import COST_SINK_KEY
 
 ATTENTION_FUNCTION_REGISTRY = {}
 
@@ -973,7 +973,7 @@ def _build_sparge_block_mask(query, key, value, is_causal, attention_kwargs, con
     # Per-head selected-block cost for the Ulysses head-balancer. USP injects a
     # scratch "cost sink" tensor into attention_kwargs only when balancing is
     # active.
-    cost_sink = (attention_kwargs or {}).get(head_balance.COST_SINK_KEY)
+    cost_sink = (attention_kwargs or {}).get(COST_SINK_KEY)
     if cost_sink is not None:
         cost_sink.copy_(block_mask.to(torch.float32).sum(dim=(0, 2, 3)))
     return q, k, v, state, block_mask, num_heads

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -970,14 +970,12 @@ def _build_sparge_block_mask(query, key, value, is_causal, attention_kwargs, con
     )
     block_mask = mask_padded_kv_blocks(block_mask, state, config["BLOCK_N"])
     num_heads = q.shape[1]
-    # Per-head selected-block cost for the Ulysses head-balancer, written into
-    # the scratch "cost sink" tensor that USP passes down via attention_kwargs
-    # (only present when balancing is active). This keeps the head cost OUT of
-    # the (output, softmax_lse) return contract.
-    if head_balance.ENABLED:
-        cost_sink = (attention_kwargs or {}).get(head_balance.COST_SINK_KEY)
-        if cost_sink is not None:
-            cost_sink.copy_(block_mask.to(torch.float32).sum(dim=(0, 2, 3)))
+    # Per-head selected-block cost for the Ulysses head-balancer. USP injects a
+    # scratch "cost sink" tensor into attention_kwargs only when balancing is
+    # active.
+    cost_sink = (attention_kwargs or {}).get(head_balance.COST_SINK_KEY)
+    if cost_sink is not None:
+        cost_sink.copy_(block_mask.to(torch.float32).sum(dim=(0, 2, 3)))
     return q, k, v, state, block_mask, num_heads
 
 @register_attention_function(AttentionBackendType.AITER_SPARGE)

--- a/xfuser/core/sparge_attention/head_balance.py
+++ b/xfuser/core/sparge_attention/head_balance.py
@@ -14,6 +14,10 @@ else:
 # separate global enable flag is needed).
 COST_SINK_KEY: str = "_hb_cost_sink"
 
+# Key under which the output-revert bookkeeping (applied + inverse head
+# permutation) is stashed in attention_kwargs, ignored by the backend.
+_HB_STATE_KEY: str = "_hb_revert_state"
+
 
 def _maybe_wait(tensor: torch.Tensor) -> torch.Tensor:
     """Resolve an async functional-collective tensor. No-op while tracing, where
@@ -21,7 +25,6 @@ def _maybe_wait(tensor: torch.Tensor) -> torch.Tensor:
     if isinstance(tensor, ft_c.AsyncCollectiveTensor):
         return tensor.wait()
     return tensor
-
 
 def compute_perm(cost: torch.Tensor, world_size: int) -> torch.Tensor:
     """Balanced equal-cardinality head permutation from per-head costs.
@@ -55,20 +58,37 @@ def scatter_to_global(full_in_applied_order: torch.Tensor,
                            full_in_applied_order)
 
 
-def apply_head_balance(query, key, value, head_perm, ulysses_world_size,
-                       attention_kwargs):
-    """Permute Q,K,V heads by ``head_perm`` (this step's plan) so each Ulysses rank
-    receives a cost-balanced head subset, before the input all-to-all.
+def apply_head_balance(query, key, value, head_balance_layer, *,
+                       enabled, ulysses_world_size, ring_world_size,
+                       is_sparge_backend, joint_strategy, attention_kwargs):
+    """Conditionally apply Ulysses block-sparse head balancing before the input
+    all-to-all.
 
-    Also attaches a per-head "cost sink" scratch tensor (shape = heads-per-rank)
-    that the sparge backend fills in place; passed via a shallow-copied
-    attention_kwargs so the head cost stays OUT of the (output, softmax_lse)
-    return contract.
+    Balancing engages only when the feature flag is set and we are on the
+    Ulysses-only sparge path with a per-layer balancing buffer present. When it
+    does, Q,K,V heads are permuted by this step's plan so each rank receives a
+    cost-balanced subset, and a per-head "cost sink" (for the backend to fill)
+    plus the revert bookkeeping (applied + inverse permutation) are stashed in a
+    shallow-copied attention_kwargs -- keeping the head cost OUT of the
+    (output, softmax_lse) contract and leaving USP with no extra locals.
 
-    Returns ``(query, key, value, applied_perm, inv_perm, cost_sink,
-    attention_kwargs)`` -- the permuted tensors plus the state needed later by
-    ``revert_head_balance``.
+    Returns ``(query, key, value, hb_applied, attention_kwargs)``; when not
+    applied the inputs are returned unchanged with ``hb_applied=False``. The gate
+    is composed of trace-time constants so it folds away cleanly under compile.
     """
+    head_perm = getattr(head_balance_layer, "head_perm", None)
+    hb_applied = (
+        enabled
+        and ulysses_world_size > 1
+        and ring_world_size == 1
+        and head_perm is not None
+        and is_sparge_backend
+        and joint_strategy is None
+        and query.shape[1] % ulysses_world_size == 0
+    )
+    if not hb_applied:
+        return query, key, value, False, attention_kwargs
+
     applied_perm = head_perm.clone()  # snapshot the permutation applied this step
     inv_perm = torch.argsort(applied_perm)
     query = query.index_select(1, applied_perm)
@@ -76,19 +96,27 @@ def apply_head_balance(query, key, value, head_perm, ulysses_world_size,
     value = value.index_select(1, applied_perm)
     cost_sink = query.new_zeros(query.shape[1] // ulysses_world_size,
                                 dtype=torch.float32)
-    attention_kwargs = {**(attention_kwargs or {}), COST_SINK_KEY: cost_sink}
-    return query, key, value, applied_perm, inv_perm, cost_sink, attention_kwargs
+    attention_kwargs = {
+        **(attention_kwargs or {}),
+        COST_SINK_KEY: cost_sink,
+        _HB_STATE_KEY: (applied_perm, inv_perm),
+    }
+    return query, key, value, True, attention_kwargs
 
 
-def revert_head_balance(out, applied_perm, inv_perm, cost_sink,
-                        head_balance_layer, ulysses_world_size):
+def revert_head_balance(out, attention_kwargs, head_balance_layer,
+                        ulysses_world_size):
     """Undo head balancing on the attention output and plan the next step.
 
-    Restores the original (global) head order on ``out``, then all-gathers this
-    step's per-head costs across the Ulysses group, maps them back to global head
-    order, and stores next step's balanced permutation into the per-layer
-    ``head_perm`` buffer. Returns the reordered ``out``.
+    Reads the cost sink and applied/inverse permutation back out of
+    ``attention_kwargs`` (stashed by ``apply_head_balance``). Restores the
+    original (global) head order on ``out``, all-gathers this step's per-head
+    costs across the Ulysses group, maps them back to global head order, and
+    stores next step's balanced permutation into the per-layer ``head_perm``
+    buffer. Returns the reordered ``out``.
     """
+    applied_perm, inv_perm = attention_kwargs[_HB_STATE_KEY]
+    cost_sink = attention_kwargs[COST_SINK_KEY]
     out = out.index_select(1, inv_perm)
     full = _maybe_wait(
         ft_c.all_gather_tensor(cost_sink, 0, PROCESS_GROUP.ULYSSES_PG)

--- a/xfuser/core/sparge_attention/head_balance.py
+++ b/xfuser/core/sparge_attention/head_balance.py
@@ -1,23 +1,26 @@
 import torch
+import torch.distributed._functional_collectives as ft_c
 
-# Gate for the feature. Sourced from the --use_spargeattn_head_balance CLI flag
-# via set_enabled(), which the runner calls ONCE before torch.compile
-ENABLED: bool = False
+import xfuser.envs as envs
 
-# Key under which USP injects the per-call "cost sink" tensor into a shallow
-# copy of attention_kwargs.
+if torch.cuda.is_available() or envs._is_npu():
+    from yunchang.globals import PROCESS_GROUP
+else:
+    PROCESS_GROUP = None
+
+# Key under which USP injects the per-call "cost sink" tensor into a shallow copy
+# of attention_kwargs. The sparge backend writes this rank's per-head cost into
+# it; the key's PRESENCE is what activates cost publishing in the backend (so no
+# separate global enable flag is needed).
 COST_SINK_KEY: str = "_hb_cost_sink"
 
 
-def set_enabled(flag: bool) -> None:
-    """Enable/disable head balancing. Must be called before torch.compile so the
-    flag is baked as a trace-time constant."""
-    global ENABLED
-    ENABLED = bool(flag)
-
-
-def enabled() -> bool:
-    return ENABLED
+def _maybe_wait(tensor: torch.Tensor) -> torch.Tensor:
+    """Resolve an async functional-collective tensor. No-op while tracing, where
+    the result is not an ``AsyncCollectiveTensor``."""
+    if isinstance(tensor, ft_c.AsyncCollectiveTensor):
+        return tensor.wait()
+    return tensor
 
 
 def compute_perm(cost: torch.Tensor, world_size: int) -> torch.Tensor:
@@ -50,3 +53,46 @@ def scatter_to_global(full_in_applied_order: torch.Tensor,
                        device=full_in_applied_order.device)
     return glob.index_copy(0, applied_perm.to(full_in_applied_order.device),
                            full_in_applied_order)
+
+
+def apply_head_balance(query, key, value, head_perm, ulysses_world_size,
+                       attention_kwargs):
+    """Permute Q,K,V heads by ``head_perm`` (this step's plan) so each Ulysses rank
+    receives a cost-balanced head subset, before the input all-to-all.
+
+    Also attaches a per-head "cost sink" scratch tensor (shape = heads-per-rank)
+    that the sparge backend fills in place; passed via a shallow-copied
+    attention_kwargs so the head cost stays OUT of the (output, softmax_lse)
+    return contract.
+
+    Returns ``(query, key, value, applied_perm, inv_perm, cost_sink,
+    attention_kwargs)`` -- the permuted tensors plus the state needed later by
+    ``revert_head_balance``.
+    """
+    applied_perm = head_perm.clone()  # snapshot the permutation applied this step
+    inv_perm = torch.argsort(applied_perm)
+    query = query.index_select(1, applied_perm)
+    key = key.index_select(1, applied_perm)
+    value = value.index_select(1, applied_perm)
+    cost_sink = query.new_zeros(query.shape[1] // ulysses_world_size,
+                                dtype=torch.float32)
+    attention_kwargs = {**(attention_kwargs or {}), COST_SINK_KEY: cost_sink}
+    return query, key, value, applied_perm, inv_perm, cost_sink, attention_kwargs
+
+
+def revert_head_balance(out, applied_perm, inv_perm, cost_sink,
+                        head_balance_layer, ulysses_world_size):
+    """Undo head balancing on the attention output and plan the next step.
+
+    Restores the original (global) head order on ``out``, then all-gathers this
+    step's per-head costs across the Ulysses group, maps them back to global head
+    order, and stores next step's balanced permutation into the per-layer
+    ``head_perm`` buffer. Returns the reordered ``out``.
+    """
+    out = out.index_select(1, inv_perm)
+    full = _maybe_wait(
+        ft_c.all_gather_tensor(cost_sink, 0, PROCESS_GROUP.ULYSSES_PG)
+    )
+    glob = scatter_to_global(full, applied_perm)
+    head_balance_layer.head_perm.copy_(compute_perm(glob, ulysses_world_size))
+    return out

--- a/xfuser/core/sparge_attention/head_balance.py
+++ b/xfuser/core/sparge_attention/head_balance.py
@@ -1,0 +1,52 @@
+import torch
+
+# Gate for the feature. Sourced from the --use_spargeattn_head_balance CLI flag
+# via set_enabled(), which the runner calls ONCE before torch.compile
+ENABLED: bool = False
+
+# Key under which USP injects the per-call "cost sink" tensor into a shallow
+# copy of attention_kwargs.
+COST_SINK_KEY: str = "_hb_cost_sink"
+
+
+def set_enabled(flag: bool) -> None:
+    """Enable/disable head balancing. Must be called before torch.compile so the
+    flag is baked as a trace-time constant."""
+    global ENABLED
+    ENABLED = bool(flag)
+
+
+def enabled() -> bool:
+    return ENABLED
+
+
+def compute_perm(cost: torch.Tensor, world_size: int) -> torch.Tensor:
+    """Balanced equal-cardinality head permutation from per-head costs.
+
+    ``cost`` is a 1-D tensor (length H, global head order). Returns a long
+    permutation (length H) that groups heads into ``world_size`` equal bins
+    (H/world_size heads each) so the per-bin cost sums are balanced, using a
+    sorted-snake assignment (sort by cost desc, then deal heads to bins in a
+    boustrophedon order so heavy and light heads pair up).
+    """
+    H = cost.shape[0]
+    order = torch.argsort(cost, descending=True)            # densest-first head ids
+    pos = torch.arange(H, device=cost.device)
+    rnd = pos // world_size                                  # which "deal round"
+    col = pos % world_size                                   # position within the round
+    # Snake: even rounds deal left->right, odd rounds right->left.
+    rank_of_sorted = torch.where(rnd % 2 == 0, col, (world_size - 1) - col)
+    # Stable group-by-rank preserves the (descending-cost) order within each bin.
+    group_order = torch.argsort(rank_of_sorted, stable=True)
+    return order[group_order]
+
+
+def scatter_to_global(full_in_applied_order: torch.Tensor,
+                      applied_perm: torch.Tensor) -> torch.Tensor:
+    """Map per-head costs gathered in applied-permutation (rank, local) order
+    back to global head order: global[applied_perm[j]] = full[j]. Traceable."""
+    H = full_in_applied_order.shape[0]
+    glob = torch.zeros(H, dtype=full_in_applied_order.dtype,
+                       device=full_in_applied_order.device)
+    return glob.index_copy(0, applied_perm.to(full_in_applied_order.device),
+                           full_in_applied_order)

--- a/xfuser/model_executor/layers/usp.py
+++ b/xfuser/model_executor/layers/usp.py
@@ -27,7 +27,10 @@ from xfuser.core.distributed.attention_backend import (
     ATTENTION_FUNCTION_REGISTRY,
     AttentionBackendType,
 )
-from xfuser.core.sparge_attention import head_balance
+from xfuser.core.sparge_attention.head_balance import (
+    apply_head_balance,
+    revert_head_balance,
+)
 
 # Sparge backends whose kernel cost can be load-balanced across Ulysses ranks.
 # These all build a block mask via _build_sparge_block_mask and write the
@@ -274,35 +277,17 @@ def USP(
 
     attention_function = _get_attention_function(backend=backend)
 
-    # ---- Ulysses block-sparse head load balancing ----
-    # Permute the heads before the input all-to-all so each rank receives a
-    # cost-balanced subset, then invert on the output. The permutation for this
-    # step is read from a per-layer buffer (filled from the previous step's
-    # per-head cost).
     hb_uly = get_ulysses_parallel_world_size()
-    hb_perm = getattr(head_balance_layer, "head_perm", None)
     hb_backend = backend if backend is not None else get_runtime_state().attention_backend
-    hb_active = (
-        get_runtime_state().runtime_config.use_spargeattn_head_balance
-        and hb_perm is not None
-        and joint_strategy is None
-        and hb_uly > 1
-        and get_ring_parallel_world_size() == 1
-        and query.shape[1] % hb_uly == 0
-        and hb_backend in _HEAD_BALANCE_BACKENDS
+    query, key, value, hb_applied, attention_kwargs = apply_head_balance(
+        query, key, value, head_balance_layer,
+        enabled=get_runtime_state().runtime_config.use_spargeattn_head_balance,
+        ulysses_world_size=hb_uly,
+        ring_world_size=get_ring_parallel_world_size(),
+        is_sparge_backend=hb_backend in _HEAD_BALANCE_BACKENDS,
+        joint_strategy=joint_strategy,
+        attention_kwargs=attention_kwargs,
     )
-    hb_applied = None
-    hb_inv = None
-    hb_cost_sink = None
-    # attention_kwargs to pass to the (sparge) attention call: identical to the
-    # caller's unless head balancing is active, in which case it carries the
-    # per-head cost sink.
-    attn_call_kwargs = attention_kwargs
-    if hb_active:
-        (query, key, value, hb_applied, hb_inv, hb_cost_sink,
-         attn_call_kwargs) = head_balance.apply_head_balance(
-            query, key, value, hb_perm, hb_uly, attention_kwargs
-        )
 
     joint_attn_kwargs = None
     if joint_strategy:
@@ -355,7 +340,7 @@ def USP(
                                         dropout_p=dropout_p,
                                         is_causal=is_causal,
                                         joint_attn_kwargs=joint_attn_kwargs,
-                                        attention_kwargs=attn_call_kwargs)
+                                        attention_kwargs=attention_kwargs)
         else: # USP
             out = ring_attn(attention_function,
                             query,
@@ -366,11 +351,11 @@ def USP(
                             joint_attn_kwargs=joint_attn_kwargs,
                             attention_kwargs=attention_kwargs)
         out = _ft_c_output_all_to_all(out)
-        if hb_active:
+        if hb_applied:
             # Restore global head order on the output, gather this step's per-head
             # costs across the Ulysses group, and plan next step's permutation.
-            out = head_balance.revert_head_balance(
-                out, hb_applied, hb_inv, hb_cost_sink, head_balance_layer, hb_uly
+            out = revert_head_balance(
+                out, attention_kwargs, head_balance_layer, hb_uly
             )
 
     return out

--- a/xfuser/model_executor/layers/usp.py
+++ b/xfuser/model_executor/layers/usp.py
@@ -36,6 +36,7 @@ from xfuser.core.sparge_attention import head_balance
 _HEAD_BALANCE_BACKENDS = frozenset({
     AttentionBackendType.AITER_SPARGE,
     AttentionBackendType.AITER_SPARGE_V2,
+    AttentionBackendType.FLEX_BLOCK_SPARGE,
 })
 
 

--- a/xfuser/model_executor/layers/usp.py
+++ b/xfuser/model_executor/layers/usp.py
@@ -283,7 +283,7 @@ def USP(
     hb_perm = getattr(head_balance_layer, "head_perm", None)
     hb_backend = backend if backend is not None else get_runtime_state().attention_backend
     hb_active = (
-        head_balance.ENABLED
+        get_runtime_state().runtime_config.use_spargeattn_head_balance
         and hb_perm is not None
         and joint_strategy is None
         and hb_uly > 1
@@ -291,26 +291,18 @@ def USP(
         and query.shape[1] % hb_uly == 0
         and hb_backend in _HEAD_BALANCE_BACKENDS
     )
+    hb_applied = None
     hb_inv = None
     hb_cost_sink = None
-    hb_attention_kwargs = attention_kwargs
+    # attention_kwargs to pass to the (sparge) attention call: identical to the
+    # caller's unless head balancing is active, in which case it carries the
+    # per-head cost sink.
+    attn_call_kwargs = attention_kwargs
     if hb_active:
-        hb_perm = hb_perm.clone()  # snapshot the permutation applied this step
-        hb_inv = torch.argsort(hb_perm)
-        query = query.index_select(1, hb_perm)
-        key = key.index_select(1, hb_perm)
-        value = value.index_select(1, hb_perm)
-        # Scratch tensor for the sparse backend to write this rank's per-head
-        # cost into (shape = heads-per-rank). Passed via a shallow-copied
-        # attention_kwargs. Written in-place by the backend; read
-        # back below..
-        hb_cost_sink = query.new_zeros(query.shape[1] // hb_uly, dtype=torch.float32)
-        hb_attention_kwargs = {
-            **(attention_kwargs or {}),
-            head_balance.COST_SINK_KEY: hb_cost_sink,
-        }
-    else:
-        hb_perm = None
+        (query, key, value, hb_applied, hb_inv, hb_cost_sink,
+         attn_call_kwargs) = head_balance.apply_head_balance(
+            query, key, value, hb_perm, hb_uly, attention_kwargs
+        )
 
     joint_attn_kwargs = None
     if joint_strategy:
@@ -363,7 +355,7 @@ def USP(
                                         dropout_p=dropout_p,
                                         is_causal=is_causal,
                                         joint_attn_kwargs=joint_attn_kwargs,
-                                        attention_kwargs=hb_attention_kwargs)
+                                        attention_kwargs=attn_call_kwargs)
         else: # USP
             out = ring_attn(attention_function,
                             query,
@@ -375,19 +367,10 @@ def USP(
                             attention_kwargs=attention_kwargs)
         out = _ft_c_output_all_to_all(out)
         if hb_active:
-            # Restore the original (global) head order on the output.
-            out = out.index_select(1, hb_inv)
-            # hb_cost_sink now holds this rank's per-head cost (written in place
-            # by the sparse backend). Exchange across the Ulysses group via a
-            # functional collective, map back to global
-            # head order, and store next step's balanced permutation into the
-            # per-layer buffer.
-            full = _maybe_wait(
-                ft_c.all_gather_tensor(hb_cost_sink, 0, PROCESS_GROUP.ULYSSES_PG)
-            )
-            glob = head_balance.scatter_to_global(full, hb_perm)
-            head_balance_layer.head_perm.copy_(
-                head_balance.compute_perm(glob, hb_uly)
+            # Restore global head order on the output, gather this step's per-head
+            # costs across the Ulysses group, and plan next step's permutation.
+            out = head_balance.revert_head_balance(
+                out, hb_applied, hb_inv, hb_cost_sink, head_balance_layer, hb_uly
             )
 
     return out

--- a/xfuser/model_executor/layers/usp.py
+++ b/xfuser/model_executor/layers/usp.py
@@ -23,7 +23,20 @@ from xfuser.core.distributed import (
 
 from packaging.version import parse
 from xfuser.core.cache_manager.cache_manager import get_cache_manager
-from xfuser.core.distributed.attention_backend import ATTENTION_FUNCTION_REGISTRY
+from xfuser.core.distributed.attention_backend import (
+    ATTENTION_FUNCTION_REGISTRY,
+    AttentionBackendType,
+)
+from xfuser.core.sparge_attention import head_balance
+
+# Sparge backends whose kernel cost can be load-balanced across Ulysses ranks.
+# These all build a block mask via _build_sparge_block_mask and write the
+# per-head cost into the head-balance "cost sink". Non-sparge backends are
+# excluded so head balancing is a clean no-op for them.
+_HEAD_BALANCE_BACKENDS = frozenset({
+    AttentionBackendType.AITER_SPARGE,
+    AttentionBackendType.AITER_SPARGE_V2,
+})
 
 
 def ring_attn(attention_function, query, key, value, dropout_p=0.0, is_causal=False, joint_attn_kwargs=None, attention_kwargs=None):
@@ -241,16 +254,62 @@ def USP(
         combine_qkv_a2a: bool | None = None,
         backend=None,
         attention_kwargs: dict | None = None,
+        head_balance_layer=None,
     ):
     """
     Unified Sequence Parallelism (USP) attention call, supporting combinations of Ulysses and
     Ring attention. Also supports joint tensors and key-value caching for pipeline parallelism.
     Explicit backend can be provided to specify the attention backend to use.
+
+    ``head_balance_layer`` (optional): a stable per-layer handle (e.g. the
+    attention module). When provided and --use_spargeattn_head_balance is set, the
+    Ulysses head dimension is permuted so each rank gets a cost-balanced subset
+    of heads (block-sparse load balancing); the permutation is inverted on the
+    output. No-op for non-sparse backends (no cost is published) and for ring/
+    joint paths.
     """
     if combine_qkv_a2a is None:
         combine_qkv_a2a = False
 
     attention_function = _get_attention_function(backend=backend)
+
+    # ---- Ulysses block-sparse head load balancing ----
+    # Permute the heads before the input all-to-all so each rank receives a
+    # cost-balanced subset, then invert on the output. The permutation for this
+    # step is read from a per-layer buffer (filled from the previous step's
+    # per-head cost).
+    hb_uly = get_ulysses_parallel_world_size()
+    hb_perm = getattr(head_balance_layer, "head_perm", None)
+    hb_backend = backend if backend is not None else get_runtime_state().attention_backend
+    hb_active = (
+        head_balance.ENABLED
+        and hb_perm is not None
+        and joint_strategy is None
+        and hb_uly > 1
+        and get_ring_parallel_world_size() == 1
+        and query.shape[1] % hb_uly == 0
+        and hb_backend in _HEAD_BALANCE_BACKENDS
+    )
+    hb_inv = None
+    hb_cost_sink = None
+    hb_attention_kwargs = attention_kwargs
+    if hb_active:
+        hb_perm = hb_perm.clone()  # snapshot the permutation applied this step
+        hb_inv = torch.argsort(hb_perm)
+        query = query.index_select(1, hb_perm)
+        key = key.index_select(1, hb_perm)
+        value = value.index_select(1, hb_perm)
+        # Scratch tensor for the sparse backend to write this rank's per-head
+        # cost into (shape = heads-per-rank). Passed via a shallow-copied
+        # attention_kwargs. Written in-place by the backend; read
+        # back below..
+        hb_cost_sink = query.new_zeros(query.shape[1] // hb_uly, dtype=torch.float32)
+        hb_attention_kwargs = {
+            **(attention_kwargs or {}),
+            head_balance.COST_SINK_KEY: hb_cost_sink,
+        }
+    else:
+        hb_perm = None
 
     joint_attn_kwargs = None
     if joint_strategy:
@@ -303,7 +362,7 @@ def USP(
                                         dropout_p=dropout_p,
                                         is_causal=is_causal,
                                         joint_attn_kwargs=joint_attn_kwargs,
-                                        attention_kwargs=attention_kwargs)
+                                        attention_kwargs=hb_attention_kwargs)
         else: # USP
             out = ring_attn(attention_function,
                             query,
@@ -314,6 +373,21 @@ def USP(
                             joint_attn_kwargs=joint_attn_kwargs,
                             attention_kwargs=attention_kwargs)
         out = _ft_c_output_all_to_all(out)
+        if hb_active:
+            # Restore the original (global) head order on the output.
+            out = out.index_select(1, hb_inv)
+            # hb_cost_sink now holds this rank's per-head cost (written in place
+            # by the sparse backend). Exchange across the Ulysses group via a
+            # functional collective, map back to global
+            # head order, and store next step's balanced permutation into the
+            # per-layer buffer.
+            full = _maybe_wait(
+                ft_c.all_gather_tensor(hb_cost_sink, 0, PROCESS_GROUP.ULYSSES_PG)
+            )
+            glob = head_balance.scatter_to_global(full, hb_perm)
+            head_balance_layer.head_perm.copy_(
+                head_balance.compute_perm(glob, hb_uly)
+            )
 
     return out
 
@@ -326,11 +400,16 @@ def attention(
         is_causal: bool = False,
         backend=None,
         attention_kwargs=None,
+        head_balance_layer=None,
     ):
     """
     Runs attention call without any parallelism.
     This can be used when the logic necessitates no Ulysses or Ring parallelism in any case.
     Explicit backend can be provided to specify the attention backend to use.
+
+    ``head_balance_layer`` is accepted for call-site signature parity with
+    ``USP`` but ignored here: with no Ulysses parallelism there is no head
+    sharding to balance.
     """
     attention_function = _get_attention_function(backend=backend)
     out, _ = attention_function(

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -20,6 +20,7 @@ from xfuser.envs import (
     _is_cuda,
 )
 from xfuser.core.distributed.parallel_state import get_fs_group
+from xfuser.core.sparge_attention import head_balance
 from xfuser.core.utils.runner_utils import (
     log,
     load_dataset_prompts,
@@ -255,6 +256,11 @@ class xFuserModel(abc.ABC):
 
     def _enable_options(self) -> None:
         """ Enable model options based on config"""
+        # Set the Sparge head-balancing gate before any torch.compile (which
+        # happens in _compile_model, called after this). Setting it here keeps
+        # head_balance.ENABLED a trace-time constant for dynamo.
+        head_balance.set_enabled(getattr(self.config, "use_spargeattn_head_balance", False))
+
         if self.config.enable_slicing:
             log("Enabling VAE slicing...")
             self.pipe.vae.enable_slicing()

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -20,7 +20,6 @@ from xfuser.envs import (
     _is_cuda,
 )
 from xfuser.core.distributed.parallel_state import get_fs_group
-from xfuser.core.sparge_attention import head_balance
 from xfuser.core.utils.runner_utils import (
     log,
     load_dataset_prompts,
@@ -256,10 +255,8 @@ class xFuserModel(abc.ABC):
 
     def _enable_options(self) -> None:
         """ Enable model options based on config"""
-        # Set the Sparge head-balancing gate before any torch.compile (which
-        # happens in _compile_model, called after this). Setting it here keeps
-        # head_balance.ENABLED a trace-time constant for dynamo.
-        head_balance.set_enabled(getattr(self.config, "use_spargeattn_head_balance", False))
+        if getattr(self.config, "use_spargeattn_head_balance", False):
+            log("Enabling Sparge block-sparse head balancing...")
 
         if self.config.enable_slicing:
             log("Enabling VAE slicing...")

--- a/xfuser/model_executor/models/transformers/transformer_wan.py
+++ b/xfuser/model_executor/models/transformers/transformer_wan.py
@@ -146,6 +146,7 @@ class xFuserWanAttnProcessor(WanAttnProcessor):
             value.transpose(1, 2),
             backend=backend,
             attention_kwargs=self.attention_kwargs,
+            head_balance_layer=attn,
         ).transpose(1, 2)
 
         hidden_states = hidden_states.flatten(2, 3)
@@ -204,6 +205,15 @@ class xFuserWanTransformer3DWrapper(WanTransformer3DModel):
         for block in self.blocks:
             block.attn1.processor = xFuserWanAttnProcessor(attention_kwargs=self.attention_kwargs)
             block.attn2.processor = xFuserWanAttnProcessor(use_ulysses_parallel_attention=False, is_cross_attention=True)
+            # Per-layer head permutation buffer for the Ulysses block-sparse head
+            # balancer (read/updated in-place inside USP; identity = no balancing).
+            # Registered pre-compile and non-persistent so it stays out of the
+            # state_dict and is captured as a graph input by torch.compile.
+            block.attn1.register_buffer(
+                "head_perm",
+                torch.arange(num_attention_heads, dtype=torch.long),
+                persistent=False,
+            )
 
 
     def _chunk_and_pad_sequence(self, x: torch.Tensor, sp_world_rank: int, sp_world_size: int, pad_amount: int, dim: int) -> torch.Tensor:


### PR DESCRIPTION
This pull request introduces a new feature for block-sparse attention: per-rank head balancing for Ulysses parallelism, controlled by a new CLI/config flag. When enabled, attention heads are permuted so that each Ulysses rank receives a balanced subset of heads based on per-head computational cost, improving load balancing for Sparge attention backends. The implementation includes new logic for tracking, computing, and applying these permutations, as well as handling the necessary state and communication between ranks. The changes are backward-compatible and have no effect unless the new flag is set.

Key changes by theme:

**Feature: Ulysses Block-Sparse Head Balancing**
* Added a new config/CLI flag `use_spargeattn_head_balance` to enable per-rank head balancing for Sparge attention backends in distributed Ulysses setups.
* Implemented the `head_balance` module with logic for enabling/disabling the feature, computing balanced head permutations, and scattering per-head costs back to the global order.
* Integrated head balancing into the USP attention path: heads are permuted before all-to-all communication, per-head costs are gathered and exchanged, and the permutation is updated each step.
* Registered a per-layer, non-persistent buffer to track the current head permutation, ensuring compatibility with torch.compile and avoiding state_dict pollution.
* Ensured the head balancing feature is enabled/disabled before model compilation for correct torch.compile tracing.

**Integration and API Changes**
* Updated the attention and transformer code to accept and propagate the new `head_balance_layer` argument, ensuring the balancing logic is only applied where appropriate. 

**Backend Support**
* Modified the Sparge attention backend to publish per-head costs to the balancing logic via a new "cost sink" in `attention_kwargs` when balancing is enabled.