### PR TITLE
feat: Add quant W8A8 INT8

### DIFF
--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -136,6 +136,7 @@ class xFuserArgs:
     shard_t5_encoder: bool = False
     attention_backend: Optional[str] = None
     cross_attention_backend: Optional[str] = None
+    use_int8_gemms: bool = False
     use_fp8_gemms: bool = False
     use_fp4_gemms: bool = False
     fp8_precision_override_prefix_patterns: Optional[str] = None
@@ -406,6 +407,11 @@ class xFuserArgs:
             action="store_true",
             help="Quantize the transformer linear layers (selected models only).",
         )
+        runtime_group.add_argument(
+            "--use_int8_gemms",
+            action="store_true",
+            help="Quantize the transformer linear layers (selected models only).",
+        )
 
         # DiTFastAttn arguments
         fast_attn_group = parser.add_argument_group("DiTFastAttn Options")
@@ -606,6 +612,11 @@ class xFuserArgs:
             "--enable_slicing",
             action="store_true",
             help="Enable VAE slicing to save GPU memory.",
+        )
+        parser.add_argument(
+            "--use_int8_gemms",
+            action="store_true",
+            help="Quantize the transformer linear layers (selected models only).",
         )
         parser.add_argument(
             "--use_fp8_gemms",

--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -292,6 +292,46 @@ except Exception as e:
     logger.debug("torchao Float8Tensor FSDP2 patches skipped (%s): %s", type(e).__name__, e)
 
 
+def quantize_linear_layers_to_int8(
+    module_or_module_list: torch.nn.Module | torch.nn.ModuleList,
+    filter_fn: Optional[Callable[[torch.nn.Module, str], bool]] = None,
+    device: Optional[torch.device] = None,
+    min_layer_size: int = 0,
+) -> None:
+    from torchao.quantization.granularity import PerRow
+    from torchao.quantization.quant_primitives import MappingType
+    from torchao.quantization.quant_api import (
+        Int8DynamicActivationInt8WeightConfig,
+        quantize_,
+        _is_linear,
+    )
+
+    if filter_fn is None:
+        if min_layer_size > 0:
+            def filter_fn(mod, fqn):
+                if not _is_linear(mod, fqn):
+                    return False
+                return min(mod.out_features, mod.in_features) >= min_layer_size
+        else:
+            filter_fn = _is_linear
+
+    config = Int8DynamicActivationInt8WeightConfig(
+        granularity=PerRow(),
+        act_mapping_type=MappingType.SYMMETRIC,
+        set_inductor_config=False,
+    )
+
+    if isinstance(module_or_module_list, torch.nn.Module):
+        module_or_module_list = [module_or_module_list]
+
+    for module in module_or_module_list:
+        quantize_(
+            module,
+            config=config,
+            filter_fn=filter_fn,
+            device=device,
+        )
+
 def quantize_linear_layers_to_fp8(module_or_module_list_to_quantize: torch.nn.Module | torch.nn.ModuleList,
     filter_fn: Optional[Callable[[torch.nn.Module, str], bool]] = None,
     device: Optional[torch.device] = None) -> None:

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -118,6 +118,7 @@ class ModelCapabilities:
     enable_tiling: bool = False
     use_vae_channels_last_format: bool = True
     # Other features
+    use_int8_gemms: bool = False
     use_fp8_gemms: bool = False
     use_fp4_gemms: bool = False
     use_fbcache: bool = False

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -23,6 +23,7 @@ from xfuser.core.distributed.parallel_state import get_fs_group
 from xfuser.core.utils.runner_utils import (
     log,
     load_dataset_prompts,
+    quantize_linear_layers_to_int8,
     quantize_linear_layers_to_fp8,
     quantize_linear_layers_to_fp8_blockscale,
     quantize_linear_layers_to_fp4,
@@ -151,6 +152,7 @@ class ModelSettings:
     model_output_type: Optional[str] = None
     mod_value: Optional[int] = None
     fps: Optional[int] = None
+    int8_gemm_module_list: List[str] = None
     fp8_gemm_module_list: List[str] = None
     fp4_gemm_module_list: List[str] = None
     fp8_precision_overrides: Tuple[str] = None
@@ -364,6 +366,12 @@ class xFuserModel(abc.ABC):
         if self.model_output_type == "video" and not self.fps:
             raise ValueError(f"Model {self.settings.model_name} produces video output but fps is not set.")
 
+        if config.use_int8_gemms:
+            if config.use_fp8_gemms or config.use_fp4_gemms:
+                raise ValueError("Cannot use int8 gemms with fp8 or fp4 gemms.")
+            if _is_hip():
+                raise ValueError("Int8 GEMMs on ROCm are not supported.")
+            
         if config.use_fp4_gemms:
             if _is_hip() and not packages_info.get("has_aiter", False):
                 raise ValueError("FP4 GEMMs on ROCm require AITER.")
@@ -683,6 +691,13 @@ class xFuserModel(abc.ABC):
                 for module_name in self.settings.fp8_gemm_module_list:
                     log(f"Quantizing {module_name} to FP8 (torchao)...")
                     quantize_linear_layers_to_fp8(rgetattr(self.pipe, module_name), device=f"cuda:{local_rank}")
+            if self.config.use_int8_gemms:
+                for module_name in self.settings.int8_gemm_module_list:
+                    log(f"Quantizing {module_name} to W8A8 INT8 (torchao)...")
+                    quantize_linear_layers_to_int8(
+                        rgetattr(self.pipe, module_name), device=f"cuda:{local_rank}",
+                        min_layer_size=512,
+                    )
 
         if self.config.use_hybrid_attn_schedule:
             self._setup_hybrid_attn_schedule(input_args)
@@ -796,6 +811,7 @@ class xFuserModel(abc.ABC):
         fp8_list = set(self.settings.fp8_gemm_module_list or [])
         fp8_overrides = self.settings.fp8_precision_overrides or ()
         fp8_suffix_overrides = self.settings.fp8_precision_override_suffixes
+        int8_list = set(self.settings.int8_gemm_module_list or [])
 
         paths = [f"{component_name}.{a}" for a in wrap_attrs]
 
@@ -806,8 +822,9 @@ class xFuserModel(abc.ABC):
         ) or (
             self.config.use_fp4_gemms and any(p in fp8_list and p not in fp4_list for p in paths)
         )
+        use_int8_here = self.config.use_int8_gemms and any(p in int8_list for p in paths)
 
-        if not use_fp4_here and not use_fp8_here:
+        if not use_fp4_here and not use_fp8_here and not use_int8_here:
             return None
 
         def quantize_fn(block, block_idx: int) -> None:
@@ -832,11 +849,14 @@ class xFuserModel(abc.ABC):
                         use_hybrid_schedule=self.config.use_hybrid_gemm_schedule,
                         device=device,
                     )
-            else:
+            elif use_fp8_here:
                 if _use_aiter_fp8_rdna4():
                     quantize_linear_layers_to_fp8_blockscale(block, device=device)
                 else:
                     quantize_linear_layers_to_fp8(block, device=device)
+            else:
+                # use_int8_here
+                quantize_linear_layers_to_int8(block, device=device, min_layer_size=512)
 
         return quantize_fn
 

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -804,7 +804,7 @@ class xFuserModel(abc.ABC):
         Suffix patterns (e.g. .net.0.proj) are block-local FQNs and are passed
         through unchanged on every block; only prefix patterns are stripped.
         """
-        if not (self.config.use_fp4_gemms or self.config.use_fp8_gemms):
+        if not (self.config.use_fp4_gemms or self.config.use_fp8_gemms or self.config.use_int8_gemms):
             return None
 
         device = f"cuda:{local_rank}"

--- a/xfuser/model_executor/models/runner_models/z_image.py
+++ b/xfuser/model_executor/models/runner_models/z_image.py
@@ -72,6 +72,11 @@ class xFuserZImageModel(xFuserModel):
             },
         },
         fp8_gemm_module_list=["transformer.layers", "transformer.noise_refiner", "transformer.context_refiner"],
+        int8_gemm_module_list=[
+            "transformer.layers", 
+            "transformer.noise_refiner", 
+            "transformer.context_refiner"
+        ],
     )
 
     def _load_model(self) -> DiffusionPipeline:
@@ -130,6 +135,7 @@ class xFuserZImageTurboModel(xFuserModel):
             },
         },
         fp8_gemm_module_list=["transformer.layers", "transformer.noise_refiner", "transformer.context_refiner"],
+        int8_gemm_module_list=["transformer.layers", "transformer.noise_refiner", "transformer.context_refiner"],
     )
 
     def _load_model(self) -> DiffusionPipeline:

--- a/xfuser/model_executor/models/runner_models/z_image.py
+++ b/xfuser/model_executor/models/runner_models/z_image.py
@@ -58,6 +58,7 @@ class xFuserZImageModel(xFuserModel):
         enable_slicing=True,
         fully_shard_degree=True,
         use_fp8_gemms=True,
+        use_int8_gemms=True,
     )
     settings = ModelSettings(
         model_name="Tongyi-MAI/Z-Image",
@@ -78,6 +79,21 @@ class xFuserZImageModel(xFuserModel):
             "transformer.context_refiner"
         ],
     )
+
+    def _customize_settings(self, config) -> None:
+        """Exclude context_refiner from INT8 quant when sequence parallelism is active.
+
+        Both Ulysses and Ring attention split the sequence across GPUs.  The
+        caption features processed by ``context_refiner`` may be very short; 
+        after SP chunking each GPU may see M <= 16, which is below the minimum 
+        M required by the ``torch._int_mm`` kernel used by torch.compile.
+        """
+        sp_world_size = (config.ulysses_degree or 1) * (config.ring_degree or 1)
+        if sp_world_size > 1 and config.use_int8_gemms:
+            self.settings.int8_gemm_module_list = [
+                m for m in self.settings.int8_gemm_module_list
+                if m != "transformer.context_refiner"
+            ]
 
     def _load_model(self) -> DiffusionPipeline:
         transformer = xFuserZImageTransformer2DWrapper.from_pretrained(
@@ -112,15 +128,14 @@ class xFuserZImageTurboModel(xFuserModel):
 
     capabilities = ModelCapabilities(
         use_fp8_gemms=True,
+        use_int8_gemms=True,
+        fully_shard_degree=True,
     )
     default_input_values = DefaultInputValues(
         height=1024,
         width=1024,
         num_inference_steps=9,
         guidance_scale=0.0,
-    )
-    capabilities = ModelCapabilities(
-        fully_shard_degree=True,
     )
     settings = ModelSettings(
         model_name="Tongyi-MAI/Z-Image-Turbo",
@@ -137,6 +152,21 @@ class xFuserZImageTurboModel(xFuserModel):
         fp8_gemm_module_list=["transformer.layers", "transformer.noise_refiner", "transformer.context_refiner"],
         int8_gemm_module_list=["transformer.layers", "transformer.noise_refiner", "transformer.context_refiner"],
     )
+
+    def _customize_settings(self, config) -> None:
+        """Exclude context_refiner from INT8 quant when sequence parallelism is active.
+
+        Both Ulysses and Ring attention split the sequence across GPUs.  The
+        caption features processed by ``context_refiner`` may be very short; 
+        after SP chunking each GPU may see M <= 16, which is below the minimum 
+        M required by the ``torch._int_mm`` kernel used by torch.compile.
+        """
+        sp_world_size = (config.ulysses_degree or 1) * (config.ring_degree or 1)
+        if sp_world_size > 1 and config.use_int8_gemms:
+            self.settings.int8_gemm_module_list = [
+                m for m in self.settings.int8_gemm_module_list
+                if m != "transformer.context_refiner"
+            ]
 
     def _load_model(self) -> DiffusionPipeline:
         transformer = xFuserZImageTransformer2DWrapper.from_pretrained(


### PR DESCRIPTION
This PR implements W8A8 INT8 quantization using `Int8DynamicActivationInt8WeightConfig` from `torchao`. It has been validated on the Z-Image-Turbo model, with correct results and reduced end-to-end latency.

Test code:
```
xdit --model Tongyi-MAI/Z-Image-Turbo \
    --prompt "A cup of coffee on the table." \
    --num_inference_steps 9 \
    --guidance_scale 0.0 \
    --seed 42 \
    --warmup_calls 2 \
    --ulysses_degree 1 \
    --use_torch_compile \
    --use_int8_gemms
```

`--use_torch_compile` is necessary; otherwise, the quantized model performs poorly.

GPU: A40

| GPUs | use_int8_gemms | output | e2e latency |
| - | - | - | - | 
| 1 | False | <img width="64" height="64" alt="image" src="https://github.com/user-attachments/assets/65b6d481-f267-473b-b2a9-fc9981307115" /> | 5.45 s |
| 1 | True| <img width="64" height="64" alt="image" src="https://github.com/user-attachments/assets/81693a44-4342-49c5-a8c7-fac8136b5f57" /> | 4.13 s |
| 2 | Flase | <img width="64" height="64" alt="image" src="https://github.com/user-attachments/assets/48bbb565-e5d6-42f6-9e91-cc6f2021fd55" /> | 3.51 s |
| 2 | True | <img width="64" height="64" alt="image" src="https://github.com/user-attachments/assets/d8c679c9-209a-4fbf-afce-c141fb57d1d4" /> | 2.86 s |