### PR TITLE
fix: enable PipeFusion for FLUX.1-dev to support low-VRAM inference

### DIFF
--- a/xfuser/core/distributed/runtime_state.py
+++ b/xfuser/core/distributed/runtime_state.py
@@ -399,7 +399,7 @@ class DiTRuntimeState(RuntimeState):
             )
         else:
             vae_scale_factor = getattr(pipeline, "vae_scale_factor", 0)
-            if pipeline.__class__.__name__.startswith("Flux") and diffusers.__version__ >= '0.32':
+            if pipeline.__class__.__name__.startswith(("Flux", "xFuserFlux")) and diffusers.__version__ >= '0.32':
                 vae_scale_factor *= 2
             self._set_model_parameters(
                 vae_scale_factor=vae_scale_factor,

--- a/xfuser/model_executor/models/runner_models/flux.py
+++ b/xfuser/model_executor/models/runner_models/flux.py
@@ -51,6 +51,7 @@ class xFuserFluxModel(xFuserModel):
     capabilities = ModelCapabilities(
         ulysses_degree=True,
         ring_degree=True,
+        pipefusion_parallel_degree=True,
         use_fp8_gemms=True,
         use_parallel_vae=True,
         enable_tiling=True,

--- a/xfuser/model_executor/models/transformers/transformer_flux.py
+++ b/xfuser/model_executor/models/transformers/transformer_flux.py
@@ -146,6 +146,7 @@ class xFuserFluxAttnProcessor(FluxAttnProcessor):
             query = apply_rotary_emb(query, image_rotary_emb, sequence_dim=1)
             key = apply_rotary_emb(key, image_rotary_emb, sequence_dim=1)
 
+        distri_cache_updated = False
         if (
             get_runtime_state().num_pipeline_patch > 1
             and not self.use_long_ctx_attn_kvcache
@@ -164,6 +165,7 @@ class xFuserFluxAttnProcessor(FluxAttnProcessor):
             )
             key = torch.cat([encoder_hidden_states_key_proj, key], dim=1)
             value = torch.cat([encoder_hidden_states_value_proj, value], dim=1)
+            distri_cache_updated = True
 
         query = query.transpose(1, 2)
         key = key.transpose(1, 2)
@@ -179,14 +181,16 @@ class xFuserFluxAttnProcessor(FluxAttnProcessor):
                 encoder_hidden_states_key_proj = None
                 encoder_hidden_states_value_proj = None
             else:
+                num_query_tokens_q = query.shape[2] - num_encoder_hidden_states_tokens
+                num_query_tokens_kv = key.shape[2] - num_encoder_hidden_states_tokens
                 encoder_hidden_states_query_proj, query = query.split(
-                    [num_encoder_hidden_states_tokens, num_query_tokens], dim=2
+                    [num_encoder_hidden_states_tokens, num_query_tokens_q], dim=2
                 )
                 encoder_hidden_states_key_proj, key = key.split(
-                    [num_encoder_hidden_states_tokens, num_query_tokens], dim=2
+                    [num_encoder_hidden_states_tokens, num_query_tokens_kv], dim=2
                 )
                 encoder_hidden_states_value_proj, value = value.split(
-                    [num_encoder_hidden_states_tokens, num_query_tokens], dim=2
+                    [num_encoder_hidden_states_tokens, num_query_tokens_kv], dim=2
                 )
             hidden_states = USP(
                 query,
@@ -198,7 +202,7 @@ class xFuserFluxAttnProcessor(FluxAttnProcessor):
                 joint_key=encoder_hidden_states_key_proj,
                 joint_value=encoder_hidden_states_value_proj,
                 joint_strategy="front",
-                attn_layer=attn,
+                attn_layer=None if distri_cache_updated else attn,
             )
             hidden_states = hidden_states.transpose(1, 2)
 


### PR DESCRIPTION
## Summary
This PR enables PipeFusion parallelism for FLUX.1-dev, allowing it to run on multiple GPUs with limited VRAM (e.g., 8× 24GB GPUs).

## Changes
`xfuser/model_executor/models/runner_models/flux.py`
Added pipefusion_parallel_degree=True to xFuserFluxModel.capabilities to enable PipeFusion support for FLUX.1-dev

`xfuser/model_executor/models/transformers/transformer_flux.py`
Fixed dimension mismatch in xFuserFluxAttnProcessor when PipeFusion and USP (Ulysses Sequence Parallel) are used together: num_query_tokens was reused for both Q and K/V splits, but their sequence lengths differ after PipeFusion cache update. Now computed separately as num_query_tokens_q and num_query_tokens_kv
Fixed incorrect attn_layer passing to USP when distri cache is already updated, avoiding double application

`xfuser/core/distributed/runtime_state.py`
Fixed vae_scale_factor detection to also match xFuserFlux* class names (previously only matched Flux*)

## Tested
Verified on 8× NVIDIA A30 (24GB) GPUs with FLUX.1-dev at 1024×1024 resolution. 

benchmark scripts
```bash
xdit --model FLUX.1-dev-local \
     --pipefusion_parallel_degree 8 --ulysses_degree 1 \
     --height 1024 --width 1024 \
     --attention-backend flash \
     --prompt "A small cat" \
     --output_directory /workspace/xDiT/bench_pp8 \
     --num_iterations 2 \
     2>&1 | tee /workspace/xDiT/flux1_dev_pp8.log

xdit --model FLUX.1-dev-local \
     --pipefusion_parallel_degree 4 --ulysses_degree 2 \
     --height 1024 --width 1024 \
     --attention-backend flash \
     --prompt "A small cat" \
     --output_directory /workspace/xDiT/bench_pp4_usp2 \
     --num_iterations 2 \
     2>&1 | tee /workspace/xDiT/flux1_dev_pp4_usp2.log
```

pp8 image
<img width="1024" height="1024" alt="flux_1_dev_local_u1r1_tc_False_1024x1024_0" src="https://github.com/user-attachments/assets/8f6a2ee9-f826-4d96-b1b2-928a80f8c8b4" />

pp4 usp2 image
<img width="1024" height="1024" alt="flux_1_dev_local_u2r1_tc_False_1024x1024_0" src="https://github.com/user-attachments/assets/530bd417-113c-44c3-88a6-f3d35d670d14" />

pp8 latency in timings.json
```json
[
  20.042900390625
]
```

pp4 usp2 latency in timings.json
```json
[
  20.7262578125
]
```

Peak VRAM logging script
```bash

nvidia-smi --query-gpu=index,memory.used --format=csv,noheader -l 1 > /tmp/vram_log.txt &
NVPID=$!

bash /workspace/xDiT/run_flux1_dev.sh

kill $NVPID

awk -F', ' '{mem[$1] = ($2+0 > mem[$1]+0) ? $2 : mem[$1]} END {for (g in mem) print "GPU " g ": " mem[g]}' /tmp/vram_log.txt
```

pp8 peak VRAM
```bash
GPU 3: 15493 MiB
GPU 6: 15513 MiB
GPU 5: 15513 MiB
GPU 2: 16711 MiB
GPU 1: 18301 MiB
GPU 4: 15461 MiB
GPU 0: 18293 MiB
GPU 7: 16921 MiB
```

pp4 usp2 peak VRAM
```bash
GPU 3: 18531 MiB
GPU 6: 16215 MiB
GPU 5: 17009 MiB
GPU 2: 18531 MiB
GPU 1: 22611 MiB
GPU 4: 17009 MiB
GPU 0: 22599 MiB
GPU 7: 20147 MiB
```