### PR TITLE
Use explicit device_id for init_process_group(); fix set_device()

### DIFF
--- a/xfuser/core/distributed/parallel_state.py
+++ b/xfuser/core/distributed/parallel_state.py
@@ -243,6 +243,16 @@ def init_distributed_environment(
         distributed_init_method,
         backend,
     )
+    # set the local rank
+    # local_rank is not available in torch ProcessGroup,
+    # see https://github.com/pytorch/pytorch/issues/122816
+    if local_rank == -1:
+        # local rank not set, this usually happens in single-node
+        # setting, where we can use rank as local rank
+        if distributed_init_method == "env://":
+            local_rank = envs.LOCAL_RANK
+        else:
+            local_rank = rank
     if not torch.distributed.is_initialized():
         assert distributed_init_method is not None, (
             "distributed_init_method must be provided when initializing "
@@ -254,18 +264,9 @@ def init_distributed_environment(
             init_method=distributed_init_method,
             world_size=world_size,
             rank=rank,
+            device_id=envs.get_device(local_rank),
         )
-        set_device(torch.distributed.get_rank() % device_count())
-    # set the local rank
-    # local_rank is not available in torch ProcessGroup,
-    # see https://github.com/pytorch/pytorch/issues/122816
-    if local_rank == -1:
-        # local rank not set, this usually happens in single-node
-        # setting, where we can use rank as local rank
-        if distributed_init_method == "env://":
-            local_rank = envs.LOCAL_RANK
-        else:
-            local_rank = rank
+        set_device(local_rank)
     global _WORLD
     if _WORLD is None:
         ranks = list(range(torch.distributed.get_world_size()))


### PR DESCRIPTION
Recent PyTorch has stricter validation rules for multi-GPU process tracking, causing a mismatched rank synchronization during lazy NCCL initialization. Lack of explicit device specification causes errors such as:

```
[rank2]: return group.recv([tensor], group_src, tag)[rank2]:
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank2]: torch.distributed.DistBackendError: [2] is setting up NCCL communicator and retrieving ncclUniqueId from [0] via c10d key-value store by key '0', but store->get('0') got error: wait timeout after 600000ms, keys: /default_pg/0//27//cuda//0
```

This PR adds an explicit `device_id` specification to `torch.distributed.init_process_group()` call.

Additionally, it fixes a nearby bug in `set_device()` call, which was using `torch.distributed.get_rank() % device_count()` instead of explicitly provided `local_rank` value. By coincidence, this worked in most setups, however, it's easy to imagine cases when this diverge with the `local_rank` (/`LOCAL_RANK` env variable orchestrated by `torchrun`): first of all, this relies on a specific `local_rank` allocation procedure, which is an implementation detail and a subject to change. Second, consider a multi-node setup with fewer processes than visible GPUs: 2 nodes, 8 GPUs visible each, with `--nproc_per_node=4`. On node 1, global ranks are 4,5,6,7 give `LOCAL_RANK=0,1,2,3`, but `get_rank() % 8= 4,5,6,7`. So `device_id`/GroupCoordinator binds to `cuda:0-3` while `set_device()` picks `cuda:4-7`. I.e. different physical GPUs.

To fix this, the `if local_rank == -1:` block that ensures correct `local_rank` value, is moved prior to the `if not torch.distributed.is_initialized():` block, and then both `torch.distributed.init_process_group(device_id=)` and `set_device()` use the same consistent `local_rank` value.