### PR TITLE
Skip spmd_check() for pipeline-parallel models

### DIFF
--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -410,14 +410,10 @@ class xFuserModel(abc.ABC):
     def _get_compile_warmup_steps(self, input_args: dict) -> Optional[int]:
         return 2  # None = skip step reduction, run full warmup cycle
 
-    def _compile_model(self, input_args: dict) -> None:
-        """Compile pipe components with torch.compile.
-
-        When FSDP is active (fully_shard_degree > 1), compiles each component's
-        FSDP-wrapped block lists individually (read from fsdp_strategy wrap_attrs)
-        to avoid dynamo tracing through FSDP2 forward_pre_hooks and fragmenting
-        the graph at every block boundary.
-        """
+    def _enable_compute_comm_overlap(self) -> None:
+        """Enables compute-communication overlap for the model while caring for
+        pipeline-parallel models that don't respect the SPMD assumption and could
+        deadlock in torch's compiler spmd_check()."""
         torch._inductor.config.reorder_for_compute_comm_overlap = True
 
         # torch >= ~2.13: enabling the overlap machinery activates an SPMD
@@ -429,6 +425,16 @@ class xFuserModel(abc.ABC):
             _ado = getattr(torch._inductor.config, "aten_distributed_optimizations", None)
             if _ado is not None and hasattr(_ado, "spmd_check"):
                 _ado.spmd_check = False
+
+    def _compile_model(self, input_args: dict) -> None:
+        """Compile pipe components with torch.compile.
+
+        When FSDP is active (fully_shard_degree > 1), compiles each component's
+        FSDP-wrapped block lists individually (read from fsdp_strategy wrap_attrs)
+        to avoid dynamo tracing through FSDP2 forward_pre_hooks and fragmenting
+        the graph at every block boundary.
+        """
+        self._enable_compute_comm_overlap()
 
         mode = self._get_compile_mode()
         dynamic = self._get_compile_dynamic()

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -39,6 +39,7 @@ from xfuser.core.distributed import (
     get_data_parallel_world_size,
     get_sequence_parallel_rank,
     get_classifier_free_guidance_rank,
+    get_pipeline_parallel_world_size,
     initialize_runtime_state,
     get_runtime_state,
     init_distributed_environment,
@@ -418,6 +419,17 @@ class xFuserModel(abc.ABC):
         the graph at every block boundary.
         """
         torch._inductor.config.reorder_for_compute_comm_overlap = True
+
+        # torch >= ~2.13: enabling the overlap machinery activates an SPMD
+        # graph-consistency check that issues a WORLD-group all_gather_object at
+        # compile time. Pipeline parallelism is non-SPMD (stages compile different
+        # graphs at data-dependent times), so that collective deadlocks. For SPMD
+        # runs the check is a cheap, useful guard, so only disable it under PP.
+        if get_pipeline_parallel_world_size() > 1:
+            _ado = getattr(torch._inductor.config, "aten_distributed_optimizations", None)
+            if _ado is not None and hasattr(_ado, "spmd_check"):
+                _ado.spmd_check = False
+
         mode = self._get_compile_mode()
         dynamic = self._get_compile_dynamic()
         for component_name in self._get_compiled_pipe_components():

--- a/xfuser/model_executor/models/runner_models/hunyuan.py
+++ b/xfuser/model_executor/models/runner_models/hunyuan.py
@@ -90,7 +90,7 @@ class xFuserHunyuanvideoModel(xFuserModel):
         # is pattern-matched on the FX graph and is a no-op for configurations
         # that don't produce the bad pattern (non-sage backends, symmetric SP).
         install_inductor_passes()
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
+        super()._enable_compute_comm_overlap()
         self.pipe.transformer.compile()
 
         compile_args = copy.deepcopy(input_args)
@@ -196,7 +196,7 @@ class xFuserHunyuanvideo15Model(xFuserModel):
         # that don't produce the bad pattern (e.g., symmetric SP, non-sage
         # backends, models without the post-A2A joint cat).
         install_inductor_passes()
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
+        super()._enable_compute_comm_overlap()
         self.pipe.transformer = torch.compile(self.pipe.transformer, mode="default")
 
         # two steps to warmup the torch compiler

--- a/xfuser/model_executor/models/runner_models/ltx.py
+++ b/xfuser/model_executor/models/runner_models/ltx.py
@@ -185,7 +185,7 @@ class xFuserLTX23VideoModel(xFuserModel):
         return "reduce-overhead"
 
     def _compile_model(self, input_args: dict) -> None:
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
+        super()._enable_compute_comm_overlap()
         self.pipe.transformer.compile_repeated_blocks(mode=self._get_compile_mode())
 
         # two steps to warmup the torch compiler
@@ -319,7 +319,7 @@ class xFuserLTX2VideoModel(xFuserModel):
         return "reduce-overhead"
 
     def _compile_model(self, input_args: dict) -> None:
-        torch._inductor.config.reorder_for_compute_comm_overlap = True
+        super()._enable_compute_comm_overlap()
         self.pipe.transformer.compile_repeated_blocks(mode=self._get_compile_mode())
 
         # two steps to warmup the torch compiler


### PR DESCRIPTION
Recent PyTorch added a `spmd_check()` call into a compiler to ensure that when comms overlap is enabled, a compiled graph still conforms to SPMD requirements (i.e. each rank executes the same graph in a lockstep fashion - this might no longer be true after reordering). Internally, `spmd_check()` on each rank computes a hash of the rank's compute graph and then uses world-wide `all_gather()` to distribute hash values across ranks. This implies that every rank must enter `all_gather()` simultaneously, otherwise NCCL hangs in waiting.

xDiT features pipeline-parallel models such as SD3 that are not SPMD by definition: different ranks execute different parts of the model while exchanging data such as activations between each other. On SD3 specifically this causes a NCCL hang: on the first step, first stage ranks are initialized with noise and skip execution directly to not yet compiled transformer block. The compiler kicks in and the ranks stall inside `spmd_check/all_gather()`. Meanwhile other stages/ranks are awaiting for the first stage to provide activation values (results of stage's transformer block sequence) and they never reach their own transformer block. Deadlock.

The solution is to disable incompatible by definition `spmd_check()` call for pipeline-parallel models.

Since `torch._inductor.config.reorder_for_compute_comm_overlap = True` is what enables the comm overlap, and since it's used in every other `_compile_model()` override (not calling this base `_compile_model()`), leaving the `spmd_check()` disabler code only in the base `_compile_model()` is a maintenance risk - even though other models overriding `_compile_model()` aren't PP, they could be modified, or their code could be copy-pasted in a different but PP model. So it's safer to refactor setting the `reorder_for_compute_comm_overlap` in a separate method and make it always coupled with the `spmd_check()` disabler; then always call the method whenever comm reordering is needed.