### PR TITLE
[Model] Add Krea-2 Raw/Turbo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ The following open-sourced DiT Models are released with xDiT in day 1.
 | [🟠 Flux Kontext](https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev) | ❎ | ✔️ |  ❎ | ❎ | ✔️ | NA |
 | [🟢 Qwen Image](https://huggingface.co/Qwen/Qwen-Image-2512) | ❎ | ✔️ | ❎ | ❎ | ✔️ | NA |
 | [🟢 Qwen Image-Edit](https://huggingface.co/Qwen/Qwen-Image-Edit-2511) | ❎ | ✔️ | ❎ | ❎ | ✔️ | NA |
+| [🟢 Krea2-Raw](https://huggingface.co/krea/Krea-2-Raw) | ❎ | ✔️ | ❎ | ❎ | ✔️ | NA |
+| [🟢 Krea2-Turbo](https://huggingface.co/krea/Krea-2-Turbo) | ❎ | ✔️ | ❎ | ❎ | ✔️ | NA |
 | [🔴 PixArt-Sigma](https://huggingface.co/PixArt-alpha/PixArt-Sigma-XL-2-1024-MS) | ✔️ | ✔️ | ✔️ | ❎ | ❎ | [Report](./docs/performance/pixart_alpha_legacy.md) |
 | [🟢 PixArt-alpha](https://huggingface.co/PixArt-alpha/PixArt-alpha) | ✔️ | ✔️ | ✔️ | ❎ | ❎ | [Report](./docs/performance/pixart_alpha_legacy.md) |
 | [🟠 Stable Diffusion 3](https://huggingface.co/stabilityai/stable-diffusion-3-medium-diffusers) | ✔️ | ✔️ | ✔️ | ❎ | ✔️ | [Report](./docs/performance/sd3.md) |

--- a/docs/runner/runner.md
+++ b/docs/runner/runner.md
@@ -100,6 +100,8 @@ Individual model classes that inherit from `xFuserModel`:
 | LTX-2 | `LTX-2`, `Lightricks/LTX-2` |
 | Qwen-Image | `Qwen-Image`, `Qwen/Qwen-Image`, `Qwen-Image-2512`, `Qwen/Qwen-Image-2512` |
 | Qwen-Image-Edit | `Qwen-Image-Edit`, `Qwen/Qwen-Image-Edit`, `Qwen-Image-Edit-2509`, `Qwen/Qwen-Image-Edit-2509`, `Qwen-Image-Edit-2511`, `Qwen/Qwen-Image-Edit-2511` |
+| Krea2-Raw | `krea/krea-2-raw`, `krea/Krea-2-Raw`, `Krea-2-Raw` |
+| Krea2-Turbo | `krea/krea-2-turbo`, `krea/Krea-2-Turbo`, `Krea-2-Turbo` |
 
 
 

--- a/xfuser/config/diffusers.py
+++ b/xfuser/config/diffusers.py
@@ -10,13 +10,19 @@ MINIMUM_DIFFUSERS_VERSIONS = {
     "flux_kontext": "0.35.2",
     "hunyuanvideo": "0.35.2",
     "wan": "0.35.2",
+    "krea2": "0.39.0",
 }
 
-def has_valid_diffusers_version(model_name: str|None = None) -> bool:
+
+def has_valid_diffusers_version(model_name: str | None = None) -> bool:
     diffusers_version = diffusers.__version__
-    minimum_diffusers_version = MINIMUM_DIFFUSERS_VERSIONS.get(model_name, DEFAULT_MINIMUM_DIFFUSERS_VERSION)
-    return Version(diffusers_version).release >= Version(minimum_diffusers_version).release
+    minimum_diffusers_version = MINIMUM_DIFFUSERS_VERSIONS.get(
+        model_name, DEFAULT_MINIMUM_DIFFUSERS_VERSION
+    )
+    return (
+        Version(diffusers_version).release >= Version(minimum_diffusers_version).release
+    )
 
 
-def get_minimum_diffusers_version(model_name: str|None = None) -> str:
+def get_minimum_diffusers_version(model_name: str | None = None) -> str:
     return MINIMUM_DIFFUSERS_VERSIONS.get(model_name, DEFAULT_MINIMUM_DIFFUSERS_VERSION)

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -896,7 +896,7 @@ def _flash_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs=N
     packed = _varlen_pack_keys(query, key, value, attention_kwargs)
     if packed is not None:
         q_flat, k_packed, v_packed, cu_seqlens_q, cu_seqlens_k, max_seqlen_k, B, S, H, D = packed
-        output, = flash_attn_varlen_func_2(
+        output = flash_attn_varlen_func_2(
             q_flat, k_packed, v_packed,
             cu_seqlens_q, cu_seqlens_k,
             max_seqlen_q=S, max_seqlen_k=max_seqlen_k,

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -535,12 +535,11 @@ def _sdpa_efficient_attn_call(query, key, value, dropout_p, is_causal, attention
     """
     Performs attention using Pytorch's internal memory-efficient implementation.
     """
-    attn_mask = attention_kwargs.get("attn_mask") if attention_kwargs else None
     output, softmax_lse, *rest = aten._scaled_dot_product_efficient_attention(
         query,
         key,
         value,
-        attn_mask=attn_mask,
+        attn_bias=None,
         compute_log_sumexp=True,
         dropout_p=dropout_p,
         is_causal=is_causal,
@@ -553,12 +552,11 @@ def _cudnn_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs=N
     Performs the necessary tensor permutes and
     then calls attention through cuDNN backend
     """
-    attn_mask = attention_kwargs.get("attn_mask") if attention_kwargs else None
     output, softmax_lse, *rest = aten._scaled_dot_product_cudnn_attention(
         query,
         key,
         value,
-        attn_mask=attn_mask,
+        attn_bias=None,
         compute_log_sumexp=True,
         dropout_p=dropout_p,
         is_causal=is_causal,
@@ -897,13 +895,14 @@ def _flash_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs=N
     packed = _varlen_pack(query, key, value, attention_kwargs)
     if packed is not None:
         q_flat, k_packed, v_packed, cu_seqlens_q, cu_seqlens_k, max_seqlen_k, B, S, H, D = packed
-        output, softmax_lse, _ = flash_attn_varlen_func_2(
+        output, = flash_attn_varlen_func_2(
             q_flat, k_packed, v_packed,
             cu_seqlens_q, cu_seqlens_k,
             max_seqlen_q=S, max_seqlen_k=max_seqlen_k,
             dropout_p=dropout_p, softmax_scale=D ** -0.5,
-            causal=is_causal, return_softmax=True,
+            causal=is_causal,
         )
+        softmax_lse = None
         output = output.reshape(B, S, H, D)
     else:
         output, softmax_lse, _ = flash_attn_func_2(

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -462,11 +462,12 @@ def register_attention_function(backend_type):
         return func
     return decorator
 
-def _varlen_pack(query_bshd, key_bshd, value_bshd, attention_kwargs):
+def _varlen_pack_keys(query_bshd, key_bshd, value_bshd, attention_kwargs):
     """Pack K/V using pre-computed mask indices for varlen attention kernels.
 
     Called after BHSD->BSHD permute.  Returns a tuple with everything needed
     to call a varlen function, or None when no mask indices are present.
+    Only K/V are packed and Q is never filtered (all B*S query positions are kept).
     """
     indices_k = (attention_kwargs or {}).get("indices_k")
     if indices_k is None:
@@ -573,7 +574,7 @@ def _flash_attn_3_call(query, key, value, dropout_p, is_causal, attention_kwargs
     query = torch.permute(query, [0, 2, 1, 3]).contiguous()
     key = torch.permute(key, [0, 2, 1, 3]).contiguous()
     value = torch.permute(value, [0, 2, 1, 3]).contiguous()
-    packed = _varlen_pack(query, key, value, attention_kwargs)
+    packed = _varlen_pack_keys(query, key, value, attention_kwargs)
     if packed is not None:
         q_flat, k_packed, v_packed, cu_seqlens_q, cu_seqlens_k, max_seqlen_k, B, S, H, D = packed
         output, softmax_lse = flash_attn_varlen_func_3(
@@ -651,12 +652,12 @@ def _flash_attn_4_call(query, key, value, dropout_p, is_causal, attention_kwargs
     query = torch.permute(query, [0, 2, 1, 3]).contiguous()
     key = torch.permute(key, [0, 2, 1, 3]).contiguous()
     value = torch.permute(value, [0, 2, 1, 3]).contiguous()
-    packed = _varlen_pack(query, key, value, attention_kwargs)
+    packed = _varlen_pack_keys(query, key, value, attention_kwargs)
     if packed is not None:
         q_flat, k_packed, v_packed, cu_seqlens_q, cu_seqlens_k, max_seqlen_k, B, S, H, D = packed
         output, softmax_lse = flash_attn_varlen_func_4(
             q_flat, k_packed, v_packed,
-            cu_seqlens_q, cu_seqlens_k,
+            cu_seqlens_q=cu_seqlens_q, cu_seqlens_k=cu_seqlens_k,
             max_seqlen_q=S, max_seqlen_k=max_seqlen_k,
             causal=is_causal,
         )
@@ -780,7 +781,7 @@ def _aiter_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs=N
     key   = torch.permute(key,   [0, 2, 1, 3]).contiguous()
     value = torch.permute(value, [0, 2, 1, 3]).contiguous()
 
-    packed = _varlen_pack(query, key, value, attention_kwargs)
+    packed = _varlen_pack_keys(query, key, value, attention_kwargs)
 
     if packed is not None:
         q_flat, k_packed, v_packed, cu_seqlens_q, cu_seqlens_k, max_seqlen_k, B, S, H, D = packed
@@ -892,7 +893,7 @@ def _flash_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs=N
     query = torch.permute(query, [0, 2, 1, 3])
     key = torch.permute(key, [0, 2, 1, 3])
     value = torch.permute(value, [0, 2, 1, 3])
-    packed = _varlen_pack(query, key, value, attention_kwargs)
+    packed = _varlen_pack_keys(query, key, value, attention_kwargs)
     if packed is not None:
         q_flat, k_packed, v_packed, cu_seqlens_q, cu_seqlens_k, max_seqlen_k, B, S, H, D = packed
         output, = flash_attn_varlen_func_2(

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -344,6 +344,7 @@ env_info = PACKAGES_CHECKER.get_packages_info()
 if env_info["has_aiter"]:
     import aiter
     from aiter import flash_attn_func as flash_attn_func_aiter
+    from aiter import flash_attn_varlen_func as flash_attn_varlen_func_aiter
     try:
         from aiter.ops.triton.attention.fav3_sage import fav3_sage_wrapper_func, get_sage_fwd_configs
     except ImportError:
@@ -401,10 +402,13 @@ if env_info["has_aiter"]:
         pass
 if env_info["has_flash_attn"]:
     from flash_attn import flash_attn_func as flash_attn_func_2
+    from flash_attn import flash_attn_varlen_func as flash_attn_varlen_func_2
 if env_info["has_flash_attn_3"]:
     from flash_attn_interface import flash_attn_func as flash_attn_func_3
+    from flash_attn_interface import flash_attn_varlen_func as flash_attn_varlen_func_3
 if env_info["has_flash_attn_4"]:
     from flash_attn.cute.interface import flash_attn_func as flash_attn_func_4
+    from flash_attn.cute.interface import flash_attn_varlen_func as flash_attn_varlen_func_4
 if env_info["has_flash_attn_4_fp4"]:
     from flash_attn.cute.interface import flash_attn_func as flash_attn_func_4_fp4
     from xfuser.core.distributed.fp4_quantize import quantize_qk_to_fp4
@@ -458,14 +462,41 @@ def register_attention_function(backend_type):
         return func
     return decorator
 
+def _varlen_pack(query_bshd, key_bshd, value_bshd, attention_kwargs):
+    """Pack K/V using pre-computed mask indices for varlen attention kernels.
+
+    Called after BHSD->BSHD permute.  Returns a tuple with everything needed
+    to call a varlen function, or None when no mask indices are present.
+    """
+    indices_k = (attention_kwargs or {}).get("indices_k")
+    if indices_k is None:
+        return None
+    B, S, H, D = query_bshd.shape
+    k_flat = key_bshd.reshape(B * S, H, D)
+    v_flat = value_bshd.reshape(B * S, H, D)
+    k_packed = torch.index_select(k_flat, 0, indices_k)
+    v_packed = torch.index_select(v_flat, 0, indices_k)
+    cu_seqlens_q = torch.arange(0, B + 1, dtype=torch.int32, device=query_bshd.device) * S
+    return (
+        query_bshd.reshape(B * S, H, D),
+        k_packed,
+        v_packed,
+        cu_seqlens_q,
+        attention_kwargs["cu_seqlens_k"],
+        attention_kwargs["max_seqlen_k"],
+        B, S, H, D,
+    )
+
+
 @register_attention_function(AttentionBackendType.SDPA)
 def _sdpa_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs=None):
     """
     Performs attention through PyTorch's scaled_dot_product_attention.
     Allows Pytorch to decide which SDPA backend to use.
     """
+    attn_mask = attention_kwargs.get("attn_mask") if attention_kwargs else None
     output = F.scaled_dot_product_attention(
-        query, key, value, dropout_p=dropout_p, is_causal=is_causal
+        query, key, value, attn_mask=attn_mask, dropout_p=dropout_p, is_causal=is_causal
     )
     return output, None
 
@@ -488,10 +519,12 @@ def _sdpa_math_attn_call(query, key, value, dropout_p, is_causal, attention_kwar
     """
     Performs attention using Pytorch's internal math implementation.
     """
+    attn_mask = attention_kwargs.get("attn_mask") if attention_kwargs else None
     output, softmax_lse = aten._scaled_dot_product_attention_math(
         query,
         key,
         value,
+        attn_mask=attn_mask,
         dropout_p=dropout_p,
         is_causal=is_causal,
     )
@@ -502,11 +535,12 @@ def _sdpa_efficient_attn_call(query, key, value, dropout_p, is_causal, attention
     """
     Performs attention using Pytorch's internal memory-efficient implementation.
     """
+    attn_mask = attention_kwargs.get("attn_mask") if attention_kwargs else None
     output, softmax_lse, *rest = aten._scaled_dot_product_efficient_attention(
         query,
         key,
         value,
-        attn_bias=None,
+        attn_mask=attn_mask,
         compute_log_sumexp=True,
         dropout_p=dropout_p,
         is_causal=is_causal,
@@ -519,11 +553,12 @@ def _cudnn_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs=N
     Performs the necessary tensor permutes and
     then calls attention through cuDNN backend
     """
+    attn_mask = attention_kwargs.get("attn_mask") if attention_kwargs else None
     output, softmax_lse, *rest = aten._scaled_dot_product_cudnn_attention(
         query,
         key,
         value,
-        attn_bias=None,
+        attn_mask=attn_mask,
         compute_log_sumexp=True,
         dropout_p=dropout_p,
         is_causal=is_causal,
@@ -540,13 +575,24 @@ def _flash_attn_3_call(query, key, value, dropout_p, is_causal, attention_kwargs
     query = torch.permute(query, [0, 2, 1, 3]).contiguous()
     key = torch.permute(key, [0, 2, 1, 3]).contiguous()
     value = torch.permute(value, [0, 2, 1, 3]).contiguous()
-    output, softmax_lse = flash_attn_func_3(
-        query,
-        key,
-        value,
-        causal=is_causal,
-        return_attn_probs=True,
-    )
+    packed = _varlen_pack(query, key, value, attention_kwargs)
+    if packed is not None:
+        q_flat, k_packed, v_packed, cu_seqlens_q, cu_seqlens_k, max_seqlen_k, B, S, H, D = packed
+        output, softmax_lse = flash_attn_varlen_func_3(
+            q_flat, k_packed, v_packed,
+            cu_seqlens_q, cu_seqlens_k,
+            max_seqlen_q=S, max_seqlen_k=max_seqlen_k,
+            causal=is_causal, return_attn_probs=True,
+        )
+        output = output.reshape(B, S, H, D)
+    else:
+        output, softmax_lse = flash_attn_func_3(
+            query,
+            key,
+            value,
+            causal=is_causal,
+            return_attn_probs=True,
+        )
     output = torch.permute(output, [0, 2, 1, 3])
     return output, softmax_lse
 
@@ -607,12 +653,23 @@ def _flash_attn_4_call(query, key, value, dropout_p, is_causal, attention_kwargs
     query = torch.permute(query, [0, 2, 1, 3]).contiguous()
     key = torch.permute(key, [0, 2, 1, 3]).contiguous()
     value = torch.permute(value, [0, 2, 1, 3]).contiguous()
-    output, softmax_lse = flash_attn_func_4(
-        query,
-        key,
-        value,
-        causal=is_causal,
-    )
+    packed = _varlen_pack(query, key, value, attention_kwargs)
+    if packed is not None:
+        q_flat, k_packed, v_packed, cu_seqlens_q, cu_seqlens_k, max_seqlen_k, B, S, H, D = packed
+        output, softmax_lse = flash_attn_varlen_func_4(
+            q_flat, k_packed, v_packed,
+            cu_seqlens_q, cu_seqlens_k,
+            max_seqlen_q=S, max_seqlen_k=max_seqlen_k,
+            causal=is_causal,
+        )
+        output = output.reshape(B, S, H, D)
+    else:
+        output, softmax_lse = flash_attn_func_4(
+            query,
+            key,
+            value,
+            causal=is_causal,
+        )
     output = torch.permute(output, [0, 2, 1, 3])
     return output, softmax_lse
 
@@ -722,23 +779,48 @@ def _aiter_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs=N
     then calls attention through AITER
     """
     query = torch.permute(query, [0, 2, 1, 3]).contiguous()
-    key = torch.permute(key, [0, 2, 1, 3]).contiguous()
+    key   = torch.permute(key,   [0, 2, 1, 3]).contiguous()
     value = torch.permute(value, [0, 2, 1, 3]).contiguous()
-    kwargs = {
-        "dropout_p": dropout_p,
-        "causal": is_causal,
-        "return_attn_probs": False,
-        "return_lse": True,
-    }
-    if AITER_HAS_ROUND_MODE:
-        kwargs["how_v3_bf16_cvt"] = HOW_V3_BF16_CVT
-    output, softmax_lse = flash_attn_func_aiter(
-        query,
-        key,
-        value,
-        **kwargs
-    )
-    output = torch.permute(output, [0, 2, 1, 3])
+
+    packed = _varlen_pack(query, key, value, attention_kwargs)
+
+    if packed is not None:
+        q_flat, k_packed, v_packed, cu_seqlens_q, cu_seqlens_k, max_seqlen_k, B, S, H, D = packed
+        varlen_kwargs = {
+            "softmax_scale": D ** -0.5,
+            "dropout_p": dropout_p,
+            "causal": is_causal,
+            "return_lse": True,
+            "return_attn_probs": False,
+        }
+        if AITER_HAS_ROUND_MODE:
+            varlen_kwargs["how_v3_bf16_cvt"] = HOW_V3_BF16_CVT
+        output, softmax_lse = flash_attn_varlen_func_aiter(
+            q_flat, k_packed, v_packed,
+            cu_seqlens_q, cu_seqlens_k,
+            max_seqlen_q=S, max_seqlen_k=max_seqlen_k,
+            **varlen_kwargs,
+        )
+        output = output.reshape(B, S, H, D)
+        output = torch.permute(output, [0, 2, 1, 3])
+
+    else:
+        kwargs = {
+            "dropout_p": dropout_p,
+            "causal": is_causal,
+            "return_attn_probs": False,
+            "return_lse": True,
+        }
+        if AITER_HAS_ROUND_MODE:
+            kwargs["how_v3_bf16_cvt"] = HOW_V3_BF16_CVT
+        output, softmax_lse = flash_attn_func_aiter(
+            query,
+            key,
+            value,
+            **kwargs
+        )
+        output = torch.permute(output, [0, 2, 1, 3])
+
     return output, softmax_lse
 
 @register_attention_function(AttentionBackendType.AITER_MLA)
@@ -812,14 +894,26 @@ def _flash_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs=N
     query = torch.permute(query, [0, 2, 1, 3])
     key = torch.permute(key, [0, 2, 1, 3])
     value = torch.permute(value, [0, 2, 1, 3])
-    output, softmax_lse, S_mask = flash_attn_func_2(
-        query,
-        key,
-        value,
-        dropout_p=dropout_p,
-        causal=is_causal,
-        return_attn_probs=True,
-    )
+    packed = _varlen_pack(query, key, value, attention_kwargs)
+    if packed is not None:
+        q_flat, k_packed, v_packed, cu_seqlens_q, cu_seqlens_k, max_seqlen_k, B, S, H, D = packed
+        output, softmax_lse, _ = flash_attn_varlen_func_2(
+            q_flat, k_packed, v_packed,
+            cu_seqlens_q, cu_seqlens_k,
+            max_seqlen_q=S, max_seqlen_k=max_seqlen_k,
+            dropout_p=dropout_p, softmax_scale=D ** -0.5,
+            causal=is_causal, return_softmax=True,
+        )
+        output = output.reshape(B, S, H, D)
+    else:
+        output, softmax_lse, _ = flash_attn_func_2(
+            query,
+            key,
+            value,
+            dropout_p=dropout_p,
+            causal=is_causal,
+            return_attn_probs=True,
+        )
     output = torch.permute(output, [0, 2, 1, 3])
     return output, softmax_lse
 

--- a/xfuser/model_executor/layers/attention_mask.py
+++ b/xfuser/model_executor/layers/attention_mask.py
@@ -1,0 +1,40 @@
+import dataclasses
+
+import torch
+import torch.nn.functional as F
+
+
+@dataclasses.dataclass
+class AttentionMaskWithMeta:
+    """Key-padding mask with pre-computed varlen indices.
+
+    Passed as attention_mask through transformer block and attention stacks.
+    SDPA backends use only attn_mask. Varlen backends can use the additional 
+    metadata to avoid re-computing indices and cumulative lengths per layer.
+
+    Follows the flash-attention unpad_input pattern: the nonzero call that
+    produces indices_k is made once per forward pass rather than once per layer.
+    """
+
+    attn_mask: torch.Tensor  # [B, 1, 1, S]  1 = valid key, 0 = padding
+    indices_k: torch.Tensor  # [total_valid_k]  int64 flat valid positions
+    cu_seqlens_k: torch.Tensor  # [B+1]  int32 cumulative valid-key counts
+    max_seqlen_k: int
+
+
+def make_attn_mask_with_meta(mask_2d: torch.Tensor) -> AttentionMaskWithMeta:
+    """Build AttentionMaskWithMeta from a [B, S] key-padding mask.
+
+    sum and cumsum are graph-break-free.  nonzero breaks once here; per-layer
+    attention calls use torch.index_select on the pre-computed indices instead.
+    """
+    seqlens_k = mask_2d.sum(-1, dtype=torch.int32)
+    cu_seqlens_k = F.pad(seqlens_k.cumsum(0, dtype=torch.int32), (1, 0))
+    indices_k = mask_2d.flatten().nonzero(as_tuple=False).flatten()
+    max_seqlen_k = int(seqlens_k.max())
+    return AttentionMaskWithMeta(
+        attn_mask=mask_2d[:, None, None, :],
+        indices_k=indices_k,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_k=max_seqlen_k,
+    )

--- a/xfuser/model_executor/layers/attention_mask.py
+++ b/xfuser/model_executor/layers/attention_mask.py
@@ -25,8 +25,9 @@ class AttentionMaskWithMeta:
 def make_attn_mask_with_meta(mask_2d: torch.Tensor) -> AttentionMaskWithMeta:
     """Build AttentionMaskWithMeta from a [B, S] key-padding mask.
 
-    sum and cumsum are graph-break-free.  nonzero breaks once here; per-layer
-    attention calls use torch.index_select on the pre-computed indices instead.
+    sum and cumsum are graph-break-free. nonzero and max().item() each create
+    one graph break. Callers should cache the returned object across denoising
+    steps so these breaks occur only once per unique mask.
     """
     seqlens_k = mask_2d.sum(-1, dtype=torch.int32)
     cu_seqlens_k = F.pad(seqlens_k.cumsum(0, dtype=torch.int32), (1, 0))

--- a/xfuser/model_executor/models/runner_models/krea2.py
+++ b/xfuser/model_executor/models/runner_models/krea2.py
@@ -25,8 +25,7 @@ def _patch_text_encoder_linear_for_rocm(text_encoder: Qwen3VLModel) -> None:
 
     Workaround for ROCm 7.13 bfloat16 GEMMs with large M,N,K shapes that may
     produce NaNs when a split-K kernel is used.
-    Computing in float32 avoids the potential Nan issue in bfloat16 split-K path.
-    """
+    Computing in float32 avoids the potential NaN issue in bfloat16 split-K path.
 
     def _make_f32_forward(m: torch.nn.Linear):
         def _f32_forward(x: torch.Tensor) -> torch.Tensor:

--- a/xfuser/model_executor/models/runner_models/krea2.py
+++ b/xfuser/model_executor/models/runner_models/krea2.py
@@ -90,18 +90,26 @@ class _Krea2BaseModel(xFuserModel):
 
     def _validate_config(self, config) -> None:
         super()._validate_config(config)
-        backend = _parse_attention_backend(
-            config.attention_backend, "attention backend"
-        )
-        if backend is not None and backend not in _KREA2_SUPPORTED_ATTN_BACKENDS:
-            supported = ", ".join(
-                sorted(b.name for b in _KREA2_SUPPORTED_ATTN_BACKENDS)
-            )
-            raise ValueError(
-                f"Krea-2 does not support --attention_backend {backend.name}. "
-                f"The attention mask requires a backend with varlen support. "
-                f"Supported backends: {supported}"
-            )
+        if config.use_hybrid_attn_schedule:
+            specs = [
+                (config.hybrid_attn_high_precision_backend, "hybrid attention high precision backend"),
+                (config.hybrid_attn_low_precision_backend, "hybrid attention low precision backend"),
+            ]
+        else:
+            specs = [(config.attention_backend, "attention backend")]
+
+        backends = [b for v, lbl in specs if (b := _parse_attention_backend(v, lbl)) is not None]
+
+        for backend in backends:
+            if backend not in _KREA2_SUPPORTED_ATTN_BACKENDS:
+                supported = ", ".join(
+                    sorted(b.name for b in _KREA2_SUPPORTED_ATTN_BACKENDS)
+                )
+                raise ValueError(
+                    f"Krea-2 does not support --attention_backend {backend.name}. "
+                    f"The attention mask requires a backend with varlen support. "
+                    f"Supported backends: {supported}"
+                )
 
     def _load_model(self) -> DiffusionPipeline:
         if not has_valid_diffusers_version("krea2"):

--- a/xfuser/model_executor/models/runner_models/krea2.py
+++ b/xfuser/model_executor/models/runner_models/krea2.py
@@ -4,23 +4,44 @@ import torch
 import torch.nn.functional as F
 from diffusers.pipelines.pipeline_utils import DiffusionPipeline
 
-from xfuser.config.diffusers import get_minimum_diffusers_version, has_valid_diffusers_version
+from xfuser.config.diffusers import (
+    get_minimum_diffusers_version,
+    has_valid_diffusers_version,
+)
 from xfuser.core.distributed import get_runtime_state
 from xfuser.core.utils.runner_utils import log
 from xfuser.envs import _is_hip
+from xfuser.core.distributed.attention_backend import AttentionBackendType
 from xfuser.model_executor.models.runner_models.base_model import (
     DefaultInputValues,
     DiffusionOutput,
     ModelCapabilities,
     ModelSettings,
+    _parse_attention_backend,
     register_model,
     xFuserModel,
 )
 
 _QUANT_GEMM_MODULES = ["transformer.transformer_blocks"]
 
+# Backends that implement the _varlen_pack mask path and can correctly exclude
+# padding key positions.  SDPA_FLASH is excluded because
+# aten._scaled_dot_product_flash_attention has no mask parameter.
+# Quantised backends (FP8, SAGE, MLA, etc.) are excluded for the same reason.
+_KREA2_SUPPORTED_ATTN_BACKENDS = frozenset(
+    {
+        AttentionBackendType.AITER,
+        AttentionBackendType.SDPA,
+        AttentionBackendType.SDPA_MATH,
+        AttentionBackendType.SDPA_EFFICIENT,
+        AttentionBackendType.FLASH,
+        AttentionBackendType.FLASH_3,
+        AttentionBackendType.FLASH_4,
+    }
+)
 
-def _patch_text_encoder_linear_for_rocm(text_encoder: Qwen3VLModel) -> None:
+
+def _patch_text_encoder_linear_for_rocm(text_encoder: "torch.nn.Module") -> None:
     """Compute all text encoder linear layers in float32, store in bfloat16.
 
     Workaround for ROCm 7.13 bfloat16 GEMMs with large M,N,K shapes that may
@@ -55,7 +76,7 @@ class _Krea2BaseModel(xFuserModel):
 
     capabilities = ModelCapabilities(
         ulysses_degree=True,
-        ring_degree=True,
+        ring_degree=False,
         pipefusion_parallel_degree=False,
         data_parallel_degree=True,
         use_cfg_parallel=False,
@@ -67,6 +88,21 @@ class _Krea2BaseModel(xFuserModel):
         enable_tiling=True,
         enable_slicing=True,
     )
+
+    def _validate_config(self, config) -> None:
+        super()._validate_config(config)
+        backend = _parse_attention_backend(
+            config.attention_backend, "attention backend"
+        )
+        if backend is not None and backend not in _KREA2_SUPPORTED_ATTN_BACKENDS:
+            supported = ", ".join(
+                sorted(b.name for b in _KREA2_SUPPORTED_ATTN_BACKENDS)
+            )
+            raise ValueError(
+                f"Krea-2 does not support --attention_backend {backend.name}. "
+                f"The attention mask requires a backend with varlen support. "
+                f"Supported backends: {supported}"
+            )
 
     def _load_model(self) -> DiffusionPipeline:
         if not has_valid_diffusers_version("krea2"):

--- a/xfuser/model_executor/models/runner_models/krea2.py
+++ b/xfuser/model_executor/models/runner_models/krea2.py
@@ -1,9 +1,11 @@
 import torch
+import torch.nn.functional as F
 from diffusers.pipelines.krea2 import Krea2Pipeline
 from diffusers.pipelines.pipeline_utils import DiffusionPipeline
 
 from xfuser.core.distributed import get_runtime_state
 from xfuser.core.utils.runner_utils import log
+from xfuser.envs import _is_hip
 from xfuser.model_executor.models.runner_models.base_model import (
     DefaultInputValues,
     DiffusionOutput,
@@ -15,8 +17,39 @@ from xfuser.model_executor.models.runner_models.base_model import (
 from xfuser.model_executor.models.transformers.transformer_krea2 import (
     xFuserKrea2Transformer2DWrapper,
 )
+from transformers import Qwen3VLModel
 
 _QUANT_GEMM_MODULES = ["transformer.transformer_blocks"]
+
+
+def _patch_text_encoder_linear_for_rocm(text_encoder: Qwen3VLModel) -> None:
+    """Compute all text encoder linear layers in float32, store in bfloat16.
+
+    Workaround for ROCm 7.13 bfloat16 GEMMs with large M,N,K shapes that may
+    produce NaNs when a split-K kernel is used.
+    Computing in float32 avoids the potential Nan issue in bfloat16 split-K path.
+    """
+
+    def _make_f32_forward(m: torch.nn.Linear):
+        def _f32_forward(x: torch.Tensor) -> torch.Tensor:
+            return F.linear(
+                x.float(),
+                m.weight.float(),
+                m.bias.float() if m.bias is not None else None,
+            ).to(x.dtype)
+
+        return _f32_forward
+
+    count = 0
+    for module in text_encoder.modules():
+        if isinstance(module, torch.nn.Linear):
+            module.forward = _make_f32_forward(module)
+            count += 1
+
+    log(
+        f"Patched {count} Linear layers to float32 compute "
+        "(ROCm 7.13 bfloat16 split-K NaN fix for Qwen3VL shapes)."
+    )
 
 
 class _Krea2BaseModel(xFuserModel):
@@ -33,6 +66,8 @@ class _Krea2BaseModel(xFuserModel):
         use_fp4_gemms=True,
         use_hybrid_attn_schedule=True,
         fully_shard_degree=True,
+        enable_tiling=True,
+        enable_slicing=True,
     )
 
     def _load_model(self) -> DiffusionPipeline:
@@ -42,14 +77,26 @@ class _Krea2BaseModel(xFuserModel):
             subfolder="transformer",
             torch_dtype=torch.bfloat16,
         )
+
+        # On ROCm 7.13, Qwen3VL bfloat16 GEMM shapes (with max_sequence_length > 448)
+        # may produce non-deterministic NaN via a split-K uninitialized-output issue.
+        pipeline_kwargs: dict = {}
+        if _is_hip():
+            te = Qwen3VLModel.from_pretrained(
+                self.settings.model_name,
+                subfolder="text_encoder",
+                torch_dtype=torch.bfloat16,
+            )
+            _patch_text_encoder_linear_for_rocm(te)
+            pipeline_kwargs["text_encoder"] = te
+
         pipe = Krea2Pipeline.from_pretrained(
             self.settings.model_name,
             transformer=transformer,
             torch_dtype=torch.bfloat16,
+            **pipeline_kwargs,
         )
         # DiTRuntimeState reads backbone_patch_size from transformer.config.patch_size.
-        # Krea2Transformer2DModel stores patch_size on the pipeline, not the transformer
-        # config, so copy it across before the runtime state is initialised.
         pipe.transformer.config.patch_size = pipe.patch_size
         return pipe
 
@@ -57,7 +104,7 @@ class _Krea2BaseModel(xFuserModel):
         batch_size = self.config.batch_size if self.config.batch_size else 1
         max_seq = input_args.get(
             "max_sequence_length",
-            self.default_input_values.max_sequence_length or 256,
+            self.default_input_values.max_sequence_length or 512,
         )
 
         get_runtime_state().set_input_parameters(
@@ -73,6 +120,7 @@ class _Krea2BaseModel(xFuserModel):
             prompt=input_args["prompt"],
             height=input_args["height"],
             width=input_args["width"],
+            negative_prompt=input_args["negative_prompt"],
             num_inference_steps=input_args["num_inference_steps"],
             guidance_scale=input_args["guidance_scale"],
             output_type=input_args.get("output_type", "pil"),
@@ -88,14 +136,14 @@ class _Krea2BaseModel(xFuserModel):
 @register_model("krea/Krea-2-Raw")
 @register_model("Krea-2-Raw")
 class xFuserKrea2RawModel(_Krea2BaseModel):
-    """Krea-2-Raw: undistilled base checkpoint. 28 steps, guidance_scale=3.5."""
+    """Krea-2-Raw: base checkpoint. 52 steps, guidance_scale=3.5."""
 
     default_input_values = DefaultInputValues(
-        height=1024,
-        width=1024,
+        height=2048,
+        width=2048,
         num_inference_steps=52,
         guidance_scale=3.5,
-        max_sequence_length=256,
+        max_sequence_length=512,
     )
 
     settings = ModelSettings(
@@ -122,17 +170,17 @@ class xFuserKrea2RawModel(_Krea2BaseModel):
 @register_model("krea/Krea-2-Turbo")
 @register_model("Krea-2-Turbo")
 class xFuserKrea2TurboModel(_Krea2BaseModel):
-    """Krea-2-Turbo: 8-step CFG-free distilled checkpoint. Supports up to 2048px."""
+    """Krea-2-Turbo: 8-step CFG-free distilled checkpoint."""
 
     _TURBO_STEPS = 8
     _TURBO_GUIDANCE = 0.0
 
     default_input_values = DefaultInputValues(
-        height=1024,
-        width=1024,
+        height=2048,
+        width=2048,
         num_inference_steps=_TURBO_STEPS,
         guidance_scale=_TURBO_GUIDANCE,
-        max_sequence_length=256,
+        max_sequence_length=512,
     )
 
     settings = ModelSettings(

--- a/xfuser/model_executor/models/runner_models/krea2.py
+++ b/xfuser/model_executor/models/runner_models/krea2.py
@@ -69,6 +69,16 @@ class _Krea2BaseModel(xFuserModel):
     )
 
     def _load_model(self) -> DiffusionPipeline:
+        if not has_valid_diffusers_version("krea2"):
+            raise ImportError(
+                f"Krea-2 models require diffusers>={get_minimum_diffusers_version('krea2')}."
+            )
+
+        from diffusers.pipelines.krea2 import Krea2Pipeline
+        from xfuser.model_executor.models.transformers.transformer_krea2 import (
+            xFuserKrea2Transformer2DWrapper,
+        )
+
         log(f"Loading {self.settings.model_name}")
         transformer = xFuserKrea2Transformer2DWrapper.from_pretrained(
             self.settings.model_name,
@@ -80,6 +90,8 @@ class _Krea2BaseModel(xFuserModel):
         # may produce non-deterministic NaN via a split-K uninitialized-output issue.
         pipeline_kwargs: dict = {}
         if _is_hip():
+            from transformers import Qwen3VLModel
+
             te = Qwen3VLModel.from_pretrained(
                 self.settings.model_name,
                 subfolder="text_encoder",

--- a/xfuser/model_executor/models/runner_models/krea2.py
+++ b/xfuser/model_executor/models/runner_models/krea2.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import torch
 import torch.nn.functional as F
-from diffusers.pipelines.krea2 import Krea2Pipeline
 from diffusers.pipelines.pipeline_utils import DiffusionPipeline
 
+from xfuser.config.diffusers import get_minimum_diffusers_version, has_valid_diffusers_version
 from xfuser.core.distributed import get_runtime_state
 from xfuser.core.utils.runner_utils import log
 from xfuser.envs import _is_hip
@@ -14,10 +16,6 @@ from xfuser.model_executor.models.runner_models.base_model import (
     register_model,
     xFuserModel,
 )
-from xfuser.model_executor.models.transformers.transformer_krea2 import (
-    xFuserKrea2Transformer2DWrapper,
-)
-from transformers import Qwen3VLModel
 
 _QUANT_GEMM_MODULES = ["transformer.transformer_blocks"]
 

--- a/xfuser/model_executor/models/runner_models/krea2.py
+++ b/xfuser/model_executor/models/runner_models/krea2.py
@@ -33,7 +33,6 @@ _KREA2_SUPPORTED_ATTN_BACKENDS = frozenset(
         AttentionBackendType.AITER,
         AttentionBackendType.SDPA,
         AttentionBackendType.SDPA_MATH,
-        AttentionBackendType.SDPA_EFFICIENT,
         AttentionBackendType.FLASH,
         AttentionBackendType.FLASH_3,
         AttentionBackendType.FLASH_4,

--- a/xfuser/model_executor/models/runner_models/krea2.py
+++ b/xfuser/model_executor/models/runner_models/krea2.py
@@ -1,0 +1,174 @@
+import torch
+from diffusers.pipelines.krea2 import Krea2Pipeline
+from diffusers.pipelines.pipeline_utils import DiffusionPipeline
+
+from xfuser.core.distributed import get_runtime_state
+from xfuser.core.utils.runner_utils import log
+from xfuser.model_executor.models.runner_models.base_model import (
+    DefaultInputValues,
+    DiffusionOutput,
+    ModelCapabilities,
+    ModelSettings,
+    register_model,
+    xFuserModel,
+)
+from xfuser.model_executor.models.transformers.transformer_krea2 import (
+    xFuserKrea2Transformer2DWrapper,
+)
+
+_QUANT_GEMM_MODULES = ["transformer.transformer_blocks"]
+
+
+class _Krea2BaseModel(xFuserModel):
+    """Shared base for the Krea-2-Raw and Krea-2-Turbo runner models."""
+
+    capabilities = ModelCapabilities(
+        ulysses_degree=True,
+        ring_degree=True,
+        pipefusion_parallel_degree=False,
+        data_parallel_degree=True,
+        use_cfg_parallel=False,
+        use_parallel_vae=False,
+        use_fp8_gemms=True,
+        use_fp4_gemms=True,
+        use_hybrid_attn_schedule=True,
+        fully_shard_degree=True,
+    )
+
+    def _load_model(self) -> DiffusionPipeline:
+        log(f"Loading {self.settings.model_name}")
+        transformer = xFuserKrea2Transformer2DWrapper.from_pretrained(
+            self.settings.model_name,
+            subfolder="transformer",
+            torch_dtype=torch.bfloat16,
+        )
+        pipe = Krea2Pipeline.from_pretrained(
+            self.settings.model_name,
+            transformer=transformer,
+            torch_dtype=torch.bfloat16,
+        )
+        # DiTRuntimeState reads backbone_patch_size from transformer.config.patch_size.
+        # Krea2Transformer2DModel stores patch_size on the pipeline, not the transformer
+        # config, so copy it across before the runtime state is initialised.
+        pipe.transformer.config.patch_size = pipe.patch_size
+        return pipe
+
+    def _run_pipe(self, input_args: dict) -> DiffusionOutput:
+        batch_size = self.config.batch_size if self.config.batch_size else 1
+        max_seq = input_args.get(
+            "max_sequence_length",
+            self.default_input_values.max_sequence_length or 256,
+        )
+
+        get_runtime_state().set_input_parameters(
+            height=input_args["height"],
+            width=input_args["width"],
+            batch_size=batch_size,
+            num_inference_steps=input_args["num_inference_steps"],
+            max_condition_sequence_length=max_seq,
+            split_text_embed_in_sp=False,
+        )
+
+        output = self.pipe(
+            prompt=input_args["prompt"],
+            height=input_args["height"],
+            width=input_args["width"],
+            num_inference_steps=input_args["num_inference_steps"],
+            guidance_scale=input_args["guidance_scale"],
+            output_type=input_args.get("output_type", "pil"),
+            max_sequence_length=max_seq,
+            generator=torch.Generator(device="cuda").manual_seed(input_args["seed"]),
+        )
+
+        images = output.images if output else []
+        return DiffusionOutput(images=images, pipe_args=input_args)
+
+
+@register_model("krea/krea-2-raw")
+@register_model("krea/Krea-2-Raw")
+@register_model("Krea-2-Raw")
+class xFuserKrea2RawModel(_Krea2BaseModel):
+    """Krea-2-Raw: undistilled base checkpoint. 28 steps, guidance_scale=3.5."""
+
+    default_input_values = DefaultInputValues(
+        height=1024,
+        width=1024,
+        num_inference_steps=52,
+        guidance_scale=3.5,
+        max_sequence_length=256,
+    )
+
+    settings = ModelSettings(
+        model_name="krea/krea-2-raw",
+        output_name="krea2_raw",
+        model_output_type="image",
+        mod_value=16,
+        fp8_gemm_module_list=_QUANT_GEMM_MODULES,
+        fp4_gemm_module_list=_QUANT_GEMM_MODULES,
+        fsdp_strategy={
+            "transformer": {
+                "wrap_attrs": ["transformer_blocks"],
+                "dtype": torch.bfloat16,
+            },
+            "text_encoder": {
+                "wrap_attrs": ["model.layers"],
+                "offload_policy": "cpu",
+            },
+        },
+    )
+
+
+@register_model("krea/krea-2-turbo")
+@register_model("krea/Krea-2-Turbo")
+@register_model("Krea-2-Turbo")
+class xFuserKrea2TurboModel(_Krea2BaseModel):
+    """Krea-2-Turbo: 8-step CFG-free distilled checkpoint. Supports up to 2048px."""
+
+    _TURBO_STEPS = 8
+    _TURBO_GUIDANCE = 0.0
+
+    default_input_values = DefaultInputValues(
+        height=1024,
+        width=1024,
+        num_inference_steps=_TURBO_STEPS,
+        guidance_scale=_TURBO_GUIDANCE,
+        max_sequence_length=256,
+    )
+
+    settings = ModelSettings(
+        model_name="krea/krea-2-turbo",
+        output_name="krea2_turbo",
+        model_output_type="image",
+        mod_value=16,
+        fp8_gemm_module_list=_QUANT_GEMM_MODULES,
+        fp4_gemm_module_list=_QUANT_GEMM_MODULES,
+        fsdp_strategy={
+            "transformer": {
+                "wrap_attrs": ["transformer_blocks"],
+                "dtype": torch.bfloat16,
+            },
+            "text_encoder": {
+                "wrap_attrs": ["model.layers"],
+                "offload_policy": "cpu",
+            },
+        },
+    )
+
+    def _validate_args(self, input_args: dict) -> None:
+        super()._validate_args(input_args)
+        steps = input_args.get("num_inference_steps")
+        if steps != self._TURBO_STEPS:
+            raise ValueError(
+                f"Krea-2-Turbo uses a fixed {self._TURBO_STEPS}-step schedule; "
+                f"num_inference_steps must be {self._TURBO_STEPS}, got {steps}."
+            )
+        guidance = input_args.get("guidance_scale")
+        if guidance != self._TURBO_GUIDANCE:
+            log(
+                f"Krea-2-Turbo is a CFG-free distilled model; "
+                f"forcing guidance_scale={self._TURBO_GUIDANCE} (got {guidance})."
+            )
+
+    def _run_pipe(self, input_args: dict) -> DiffusionOutput:
+        # Guidance is baked into the distilled weights; always run CFG-free.
+        return super()._run_pipe({**input_args, "guidance_scale": self._TURBO_GUIDANCE})

--- a/xfuser/model_executor/models/runner_models/krea2.py
+++ b/xfuser/model_executor/models/runner_models/krea2.py
@@ -26,6 +26,7 @@ def _patch_text_encoder_linear_for_rocm(text_encoder: Qwen3VLModel) -> None:
     Workaround for ROCm 7.13 bfloat16 GEMMs with large M,N,K shapes that may
     produce NaNs when a split-K kernel is used.
     Computing in float32 avoids the potential NaN issue in bfloat16 split-K path.
+    """
 
     def _make_f32_forward(m: torch.nn.Linear):
         def _f32_forward(x: torch.Tensor) -> torch.Tensor:

--- a/xfuser/model_executor/models/transformers/__init__.py
+++ b/xfuser/model_executor/models/transformers/__init__.py
@@ -18,15 +18,23 @@ __all__ = [
     "xFuserCogVideoXTransformer3DWrapper",
     "xFuserHunyuanDiT2DWrapper",
     "xFuserConsisIDTransformer3DWrapper",
-    "xFuserSanaTransformer2DWrapper"
+    "xFuserSanaTransformer2DWrapper",
 ]
 
 # Gating some imports based on diffusers version, as they import part of diffusers
 if has_valid_diffusers_version("flux"):
-    from .transformer_flux import xFuserFluxTransformer2DWrapper
+    from .transformer_flux import xFuserFluxTransformer2DWrapper  # noqa: F401
+
     __all__.append("xFuserFluxTransformer2DWrapper")
 
 
 if has_valid_diffusers_version("zimage"):
-    from .transformer_z_image import xFuserZImageTransformer2DWrapper
+    from .transformer_z_image import xFuserZImageTransformer2DWrapper  # noqa: F401
+
     __all__.append("xFuserZImageTransformer2DWrapper")
+
+
+if has_valid_diffusers_version("krea2"):
+    from .transformer_krea2 import xFuserKrea2Transformer2DWrapper  # noqa: F401
+
+    __all__.append("xFuserKrea2Transformer2DWrapper")

--- a/xfuser/model_executor/models/transformers/transformer_krea2.py
+++ b/xfuser/model_executor/models/transformers/transformer_krea2.py
@@ -18,10 +18,7 @@ from xfuser.core.distributed import (
     get_sequence_parallel_world_size,
     get_sp_group,
 )
-from xfuser.logger import init_logger
 from xfuser.model_executor.layers.usp import USP
-
-logger = init_logger(__name__)
 
 
 class xFuserKrea2AttnProcessor:

--- a/xfuser/model_executor/models/transformers/transformer_krea2.py
+++ b/xfuser/model_executor/models/transformers/transformer_krea2.py
@@ -89,6 +89,7 @@ class xFuserKrea2Transformer2DWrapper(Krea2Transformer2DModel):
         super().__init__(*args, **kwargs)
         for block in self.transformer_blocks:
             block.attn.processor = xFuserKrea2AttnProcessor()
+        self._attn_mask_cache: tuple | None = None  # (data_ptr, shape, AttentionMaskWithMeta)
 
     def forward(
         self,
@@ -120,21 +121,27 @@ class xFuserKrea2Transformer2DWrapper(Krea2Transformer2DModel):
         pad_len = (sp_world_size - total_seq % sp_world_size) % sp_world_size
 
         # Build a [B, S] key-padding mask covering text, image, and SP pad tokens
-        # (1 = valid, 0 = excluded). nonzero runs once here via make_attn_mask_with_meta;
-        # per-layer attention uses pre-computed indices instead.
+        # (1 = valid, 0 = excluded). nonzero/item graph breaks occur only on the
+        # first step; subsequent steps hit the cache because encoder_attention_mask
+        # is the same tensor object for the entire denoising loop.
         block_attn_mask = None
         if encoder_attention_mask is not None:
-            B = hidden_states.shape[0]
-            combined = torch.cat(
-                [
-                    encoder_attention_mask[:, : text_projected.shape[1]],
-                    encoder_attention_mask.new_ones(B, image_projected.shape[1]),
-                ],
-                dim=1,
-            )
-            if pad_len > 0:
-                combined = torch.cat([combined, combined.new_zeros(B, pad_len)], dim=1)
-            block_attn_mask = make_attn_mask_with_meta(combined)
+            ptr, shape = encoder_attention_mask.data_ptr(), encoder_attention_mask.shape
+            if self._attn_mask_cache is not None and self._attn_mask_cache[:2] == (ptr, shape):
+                block_attn_mask = self._attn_mask_cache[2]
+            else:
+                B = hidden_states.shape[0]
+                combined = torch.cat(
+                    [
+                        encoder_attention_mask[:, : text_projected.shape[1]],
+                        encoder_attention_mask.new_ones(B, image_projected.shape[1]),
+                    ],
+                    dim=1,
+                )
+                if pad_len > 0:
+                    combined = torch.cat([combined, combined.new_zeros(B, pad_len)], dim=1)
+                block_attn_mask = make_attn_mask_with_meta(combined)
+                self._attn_mask_cache = (ptr, shape, block_attn_mask)
 
         local_seq = chunk_and_pad_sequence(
             full_seq, sp_rank, sp_world_size, pad_len, dim=1

--- a/xfuser/model_executor/models/transformers/transformer_krea2.py
+++ b/xfuser/model_executor/models/transformers/transformer_krea2.py
@@ -1,0 +1,167 @@
+import torch
+import torch.nn.functional as F
+from typing import Any, Dict, Optional, Tuple, Union
+
+from diffusers.models.transformers.transformer_krea2 import (
+    Krea2Attention,
+    Krea2Transformer2DModel,
+)
+from diffusers.models.transformers.transformer_2d import Transformer2DModelOutput
+from diffusers.models.embeddings import apply_rotary_emb
+
+from xfuser.core.distributed import (
+    get_cfg_group,
+    get_classifier_free_guidance_rank,
+    get_classifier_free_guidance_world_size,
+    get_ring_parallel_world_size,
+    get_sequence_parallel_rank,
+    get_sequence_parallel_world_size,
+    get_sp_group,
+)
+from xfuser.logger import init_logger
+from xfuser.model_executor.layers.usp import USP
+
+logger = init_logger(__name__)
+
+
+class xFuserKrea2AttnProcessor:
+    """SP-aware attention processor for Krea2Attention.
+
+    Krea-2 uses GQA (48 query heads, 12 KV heads). KV heads are expanded to
+    match Q heads before the USP call. Valid Ulysses degrees are divisors of
+    12: 1, 2, 3, 4, 6, 12.
+    """
+
+    def __call__(
+        self,
+        attn: Krea2Attention,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        image_rotary_emb: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        query = attn.to_q(hidden_states)
+        key = attn.to_k(hidden_states)
+        value = attn.to_v(hidden_states)
+        gate = attn.to_gate(hidden_states)
+
+        query = query.unflatten(-1, (attn.num_heads, -1))
+        key = key.unflatten(-1, (attn.num_kv_heads, -1))
+        value = value.unflatten(-1, (attn.num_kv_heads, -1))
+
+        query = attn.norm_q(query)
+        key = attn.norm_k(key)
+
+        if image_rotary_emb is not None:
+            query = apply_rotary_emb(query, image_rotary_emb, sequence_dim=1)
+            key = apply_rotary_emb(key, image_rotary_emb, sequence_dim=1)
+
+        query = query.transpose(1, 2)
+        key = key.transpose(1, 2)
+        value = value.transpose(1, 2)
+
+        # Expand KV heads to match Q heads for GQA before passing to USP.
+        if attn.num_heads != attn.num_kv_heads:
+            repeat_factor = attn.num_heads // attn.num_kv_heads
+            key = key.repeat_interleave(repeat_factor, dim=1)
+            value = value.repeat_interleave(repeat_factor, dim=1)
+
+        # combined QKV all-to-all is faster with ring attention
+        # because ring uses Python-mutable rotater that adds graph
+        # breaks and prevents q,k,v A2A overlap with computation
+        combine_qkv_a2a = get_ring_parallel_world_size() > 1
+        out = USP(query, key, value, combine_qkv_a2a=combine_qkv_a2a)
+
+        out = out.transpose(1, 2).flatten(2, 3).to(query.dtype)
+        out = out * torch.sigmoid(gate)
+        out = attn.to_out[0](out)
+        return out
+
+
+class xFuserKrea2Transformer2DWrapper(Krea2Transformer2DModel):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for block in self.transformer_blocks:
+            block.attn.processor = xFuserKrea2AttnProcessor()
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        timestep: torch.Tensor,
+        position_ids: torch.Tensor,
+        encoder_attention_mask: Optional[torch.Tensor] = None,
+        attention_kwargs: Optional[Dict[str, Any]] = None,
+        return_dict: bool = True,
+    ) -> Union[torch.FloatTensor, Transformer2DModelOutput]:
+        sp_world_size = get_sequence_parallel_world_size()
+        sp_rank = get_sequence_parallel_rank()
+        cfg_world_size = get_classifier_free_guidance_world_size()
+        cfg_rank = get_classifier_free_guidance_rank()
+
+        if cfg_world_size > 1:
+            hidden_states = hidden_states.chunk(cfg_world_size, dim=0)[cfg_rank]
+            encoder_hidden_states = encoder_hidden_states.chunk(cfg_world_size, dim=0)[
+                cfg_rank
+            ]
+            if encoder_attention_mask is not None:
+                encoder_attention_mask = encoder_attention_mask.chunk(
+                    cfg_world_size, dim=0
+                )[cfg_rank]
+            timestep = timestep.chunk(cfg_world_size, dim=0)[cfg_rank]
+
+        temb_embed = self.time_embed(timestep, hidden_states.dtype)
+        temb_mod = self.time_mod_proj(F.gelu(temb_embed, approximate="tanh"))
+
+        text_projected = self.txt_in(
+            self.text_fusion(encoder_hidden_states, encoder_attention_mask)
+        )
+        image_projected = self.img_in(hidden_states)
+
+        full_seq = torch.cat([text_projected, image_projected], dim=1)
+        total_seq = full_seq.shape[1]
+
+        pad_len = (sp_world_size - total_seq % sp_world_size) % sp_world_size
+        if pad_len > 0:
+            pad = torch.zeros(
+                full_seq.shape[0],
+                pad_len,
+                full_seq.shape[2],
+                dtype=full_seq.dtype,
+                device=full_seq.device,
+            )
+            full_seq = torch.cat([full_seq, pad], dim=1)
+
+        local_seq = full_seq.chunk(sp_world_size, dim=1)[sp_rank]
+
+        if pad_len > 0:
+            pad_pos = torch.zeros(
+                pad_len, 3, dtype=position_ids.dtype, device=position_ids.device
+            )
+            position_ids_padded = torch.cat([position_ids, pad_pos], dim=0)
+        else:
+            position_ids_padded = position_ids
+        pos_ids_local = position_ids_padded.chunk(sp_world_size, dim=0)[sp_rank]
+
+        image_rotary_emb = self.rotary_emb(pos_ids_local)
+
+        for block in self.transformer_blocks:
+            local_seq = block(
+                hidden_states=local_seq,
+                temb=temb_mod,
+                image_rotary_emb=image_rotary_emb,
+                attention_mask=None,
+            )
+
+        full_out = get_sp_group().all_gather(local_seq, dim=1)
+        if pad_len > 0:
+            full_out = full_out[:, :total_seq, :]
+
+        txt_seq = text_projected.shape[1]
+        image_out = self.final_layer(full_out[:, txt_seq:, :], temb_embed)
+
+        image_out = get_cfg_group().all_gather(image_out, dim=0)
+
+        if return_dict:
+            return Transformer2DModelOutput(sample=image_out)
+        return (image_out,)

--- a/xfuser/model_executor/models/transformers/transformer_krea2.py
+++ b/xfuser/model_executor/models/transformers/transformer_krea2.py
@@ -67,8 +67,8 @@ class xFuserKrea2AttnProcessor:
             value = value.repeat_interleave(repeat_factor, dim=1)
 
         # combined QKV all-to-all is faster with ring attention
-        # because ring uses Python-mutable rotater that adds graph
-        # breaks and prevents q,k,v A2A overlap with computation
+        # because ring adds graph breaks that prevents q,k,v A2A
+        # overlap with computation
         combine_qkv_a2a = get_ring_parallel_world_size() > 1
         out = USP(query, key, value, combine_qkv_a2a=combine_qkv_a2a)
 

--- a/xfuser/model_executor/models/transformers/transformer_krea2.py
+++ b/xfuser/model_executor/models/transformers/transformer_krea2.py
@@ -16,9 +16,12 @@ from xfuser.core.distributed import (
     get_ring_parallel_world_size,
     get_sequence_parallel_rank,
     get_sequence_parallel_world_size,
-    get_sp_group,
 )
 from xfuser.model_executor.layers.usp import USP
+from xfuser.model_executor.models.transformers.transformers_utils import (
+    chunk_and_pad_sequence,
+    gather_and_unpad,
+)
 
 
 class xFuserKrea2AttnProcessor:
@@ -119,26 +122,12 @@ class xFuserKrea2Transformer2DWrapper(Krea2Transformer2DModel):
         total_seq = full_seq.shape[1]
 
         pad_len = (sp_world_size - total_seq % sp_world_size) % sp_world_size
-        if pad_len > 0:
-            pad = torch.zeros(
-                full_seq.shape[0],
-                pad_len,
-                full_seq.shape[2],
-                dtype=full_seq.dtype,
-                device=full_seq.device,
-            )
-            full_seq = torch.cat([full_seq, pad], dim=1)
-
-        local_seq = full_seq.chunk(sp_world_size, dim=1)[sp_rank]
-
-        if pad_len > 0:
-            pad_pos = torch.zeros(
-                pad_len, 3, dtype=position_ids.dtype, device=position_ids.device
-            )
-            position_ids_padded = torch.cat([position_ids, pad_pos], dim=0)
-        else:
-            position_ids_padded = position_ids
-        pos_ids_local = position_ids_padded.chunk(sp_world_size, dim=0)[sp_rank]
+        local_seq = chunk_and_pad_sequence(
+            full_seq, sp_rank, sp_world_size, pad_len, dim=1
+        )
+        pos_ids_local = chunk_and_pad_sequence(
+            position_ids, sp_rank, sp_world_size, pad_len, dim=0
+        )
 
         image_rotary_emb = self.rotary_emb(pos_ids_local)
 
@@ -150,9 +139,7 @@ class xFuserKrea2Transformer2DWrapper(Krea2Transformer2DModel):
                 attention_mask=None,
             )
 
-        full_out = get_sp_group().all_gather(local_seq, dim=1)
-        if pad_len > 0:
-            full_out = full_out[:, :total_seq, :]
+        full_out = gather_and_unpad(local_seq, pad_len, dim=1)
 
         txt_seq = text_projected.shape[1]
         image_out = self.final_layer(full_out[:, txt_seq:, :], temb_embed)

--- a/xfuser/model_executor/models/transformers/transformer_krea2.py
+++ b/xfuser/model_executor/models/transformers/transformer_krea2.py
@@ -25,8 +25,8 @@ class xFuserKrea2AttnProcessor:
     """SP-aware attention processor for Krea2Attention.
 
     Krea-2 uses GQA (48 query heads, 12 KV heads). KV heads are expanded to
-    match Q heads before the USP call. Valid Ulysses degrees are divisors of
-    12: 1, 2, 3, 4, 6, 12.
+    match Q heads before the USP call, so Ulysses degrees must divide
+    `attn.num_heads` (typically 48).
     """
 
     def __call__(

--- a/xfuser/model_executor/models/transformers/transformer_krea2.py
+++ b/xfuser/model_executor/models/transformers/transformer_krea2.py
@@ -10,12 +10,12 @@ from diffusers.models.transformers.transformer_2d import Transformer2DModelOutpu
 from diffusers.models.embeddings import apply_rotary_emb
 
 from xfuser.core.distributed import (
-    get_cfg_group,
-    get_classifier_free_guidance_rank,
-    get_classifier_free_guidance_world_size,
-    get_ring_parallel_world_size,
     get_sequence_parallel_rank,
     get_sequence_parallel_world_size,
+)
+from xfuser.model_executor.layers.attention_mask import (
+    AttentionMaskWithMeta,
+    make_attn_mask_with_meta,
 )
 from xfuser.model_executor.layers.usp import USP
 from xfuser.model_executor.models.transformers.transformers_utils import (
@@ -66,11 +66,17 @@ class xFuserKrea2AttnProcessor:
             key = key.repeat_interleave(repeat_factor, dim=1)
             value = value.repeat_interleave(repeat_factor, dim=1)
 
-        # combined QKV all-to-all is faster with ring attention
-        # because ring adds graph breaks that prevents q,k,v A2A
-        # overlap with computation
-        combine_qkv_a2a = get_ring_parallel_world_size() > 1
-        out = USP(query, key, value, combine_qkv_a2a=combine_qkv_a2a)
+        attn_kw = (
+            {
+                "attn_mask": attention_mask.attn_mask,
+                "indices_k": attention_mask.indices_k,
+                "cu_seqlens_k": attention_mask.cu_seqlens_k,
+                "max_seqlen_k": attention_mask.max_seqlen_k,
+            }
+            if isinstance(attention_mask, AttentionMaskWithMeta)
+            else None
+        )
+        out = USP(query, key, value, attention_kwargs=attn_kw)
 
         out = out.transpose(1, 2).flatten(2, 3).to(query.dtype)
         out = out * torch.sigmoid(gate)
@@ -96,32 +102,40 @@ class xFuserKrea2Transformer2DWrapper(Krea2Transformer2DModel):
     ) -> Union[torch.FloatTensor, Transformer2DModelOutput]:
         sp_world_size = get_sequence_parallel_world_size()
         sp_rank = get_sequence_parallel_rank()
-        cfg_world_size = get_classifier_free_guidance_world_size()
-        cfg_rank = get_classifier_free_guidance_rank()
-
-        if cfg_world_size > 1:
-            hidden_states = hidden_states.chunk(cfg_world_size, dim=0)[cfg_rank]
-            encoder_hidden_states = encoder_hidden_states.chunk(cfg_world_size, dim=0)[
-                cfg_rank
-            ]
-            if encoder_attention_mask is not None:
-                encoder_attention_mask = encoder_attention_mask.chunk(
-                    cfg_world_size, dim=0
-                )[cfg_rank]
-            timestep = timestep.chunk(cfg_world_size, dim=0)[cfg_rank]
 
         temb_embed = self.time_embed(timestep, hidden_states.dtype)
         temb_mod = self.time_mod_proj(F.gelu(temb_embed, approximate="tanh"))
 
+        text_attn_mask = None
+        if encoder_attention_mask is not None:
+            text_attn_mask = encoder_attention_mask[:, None, None, :]
+
         text_projected = self.txt_in(
-            self.text_fusion(encoder_hidden_states, encoder_attention_mask)
+            self.text_fusion(encoder_hidden_states, text_attn_mask)
         )
         image_projected = self.img_in(hidden_states)
 
         full_seq = torch.cat([text_projected, image_projected], dim=1)
         total_seq = full_seq.shape[1]
-
         pad_len = (sp_world_size - total_seq % sp_world_size) % sp_world_size
+
+        # Build a [B, S] key-padding mask covering text, image, and SP pad tokens
+        # (1 = valid, 0 = excluded). nonzero runs once here via make_attn_mask_with_meta;
+        # per-layer attention uses pre-computed indices instead.
+        block_attn_mask = None
+        if encoder_attention_mask is not None:
+            B = hidden_states.shape[0]
+            combined = torch.cat(
+                [
+                    encoder_attention_mask[:, : text_projected.shape[1]],
+                    encoder_attention_mask.new_ones(B, image_projected.shape[1]),
+                ],
+                dim=1,
+            )
+            if pad_len > 0:
+                combined = torch.cat([combined, combined.new_zeros(B, pad_len)], dim=1)
+            block_attn_mask = make_attn_mask_with_meta(combined)
+
         local_seq = chunk_and_pad_sequence(
             full_seq, sp_rank, sp_world_size, pad_len, dim=1
         )
@@ -136,15 +150,13 @@ class xFuserKrea2Transformer2DWrapper(Krea2Transformer2DModel):
                 hidden_states=local_seq,
                 temb=temb_mod,
                 image_rotary_emb=image_rotary_emb,
-                attention_mask=None,
+                attention_mask=block_attn_mask,
             )
 
         full_out = gather_and_unpad(local_seq, pad_len, dim=1)
 
         txt_seq = text_projected.shape[1]
         image_out = self.final_layer(full_out[:, txt_seq:, :], temb_embed)
-
-        image_out = get_cfg_group().all_gather(image_out, dim=0)
 
         if return_dict:
             return Transformer2DModelOutput(sample=image_out)


### PR DESCRIPTION
# Summary

Add parallel inference support for [Krea-2-Raw](https://huggingface.co/krea/Krea-2-Raw) and [Krea-2-Turbo](https://huggingface.co/krea/Krea-2-Turbo). Krea-2 is a high-resolution (up to 2048 x 2048) text-to-image model built on a 28-block single-stream transformer architecture. It uses a Qwen3-VL-4B-Instruct text encoder, a 16-channel VAE with 8× spatial compression, and flow-matching scheduling. Text and image tokens are concatenated into a single sequence (Flux-style) before the transformer blocks.

Support added for two models:

Checkpoint | Steps | Guidance | Notes
-- | -- | -- | --
krea/krea-2-raw | 52 | 3.5 | Undistilled base
krea/krea-2-turbo | 8 | - | CFG-free distilled

Supported task: text-to-image only.

## Features

Capability | Supported | Notes
-- | -- | --
Ulysses SP | ✅ | Valid degrees: 1, 2, 3, 4, 6, 8, 12, 16, 24 (divisors of 48)
Ring attention | ❌ | Not supported
Hybrid USP (Ulysses × Ring) | ❌ | Ring not supported
Data parallelism | ✅ |  
FP8 GEMM | ✅ |  
FP4 GEMM | ✅ |  
FSDP | ✅ |  
VAE tiling / slicing | ✅ |  
torch.compile | ✅ |  
Parallel VAE | ❌ | Not supported
PipeFusion | ❌ | Not applicable
CFG parallelism | ❌ | Turbo has no CFG; skipped for Raw

## Examples

`xdit --model krea/krea-2-turbo --ulysses_degree 8 --width 2048 --height 2048 --prompt "a fox walking in the snow" --use_torch_compile`
<img width="2048" height="2048" alt="krea2_turbo_u1r1_tc_True_2048x2048_0" src="https://github.com/user-attachments/assets/6f5edd31-b409-4424-93e5-8ad790bc9a9b" />

`xdit --model krea/krea-2-raw --ulysses_degree 8 --width 2048 --height 2048 --prompt "a fox walking in the snow" --negative_prompt "bad quality, illustration" --use_torch_compile`
<img width="2048" height="2048" alt="krea2_raw_u1r1_tc_True_2048x2048_0" src="https://github.com/user-attachments/assets/3670e48a-74f0-4294-a686-926c9959a31c" />


## Other

Requires diffusers >= 0.39.0