### PR TITLE
fix: fix version comparisons using packaging.version.parse

### DIFF
--- a/xfuser/core/distributed/runtime_state.py
+++ b/xfuser/core/distributed/runtime_state.py
@@ -10,6 +10,7 @@ from torch.cuda import manual_seed as device_manual_seed
 from torch.cuda import manual_seed_all as device_manual_seed_all
 import diffusers
 from diffusers import DiffusionPipeline
+from packaging import version
 import torch.distributed
 
 try:
@@ -399,7 +400,7 @@ class DiTRuntimeState(RuntimeState):
             )
         else:
             vae_scale_factor = getattr(pipeline, "vae_scale_factor", 0)
-            if pipeline.__class__.__name__.startswith(("Flux", "xFuserFlux")) and diffusers.__version__ >= '0.32':
+            if pipeline.__class__.__name__.startswith(("Flux", "xFuserFlux")) and version.parse(diffusers.__version__) >= version.parse('0.32'):
                 vae_scale_factor *= 2
             self._set_model_parameters(
                 vae_scale_factor=vae_scale_factor,

--- a/xfuser/core/distributed/runtime_state.py
+++ b/xfuser/core/distributed/runtime_state.py
@@ -400,7 +400,7 @@ class DiTRuntimeState(RuntimeState):
             )
         else:
             vae_scale_factor = getattr(pipeline, "vae_scale_factor", 0)
-            if pipeline.__class__.__name__.startswith(("Flux", "xFuserFlux")) and version.parse(diffusers.__version__) >= version.parse('0.32'):
+            if pipeline.__class__.__name__.startswith(("Flux", "xFuserFlux")) and env_info["diffusers_version"] >= version.parse('0.32'):
                 vae_scale_factor *= 2
             self._set_model_parameters(
                 vae_scale_factor=vae_scale_factor,

--- a/xfuser/envs.py
+++ b/xfuser/envs.py
@@ -259,7 +259,7 @@ class PackagesEnvChecker:
                 from flash_attn import flash_attn_func
                 from flash_attn import __version__
 
-                if __version__ < "2.6.0":
+                if version.parse(__version__) < version.parse("2.6.0"):
                     raise ImportError(f"install flash_attn >= 2.6.0")
                 return True
         except ImportError:

--- a/xfuser/model_executor/layers/attention_processor.py
+++ b/xfuser/model_executor/layers/attention_processor.py
@@ -41,8 +41,9 @@ from xfuser.model_executor.layers import xFuserLayerBaseWrapper
 from xfuser.model_executor.layers import xFuserLayerWrappersRegister
 from xfuser.logger import init_logger
 from xfuser.envs import PACKAGES_CHECKER
+from packaging import version
 
-if torch.__version__ >= "2.5.0":
+if version.parse(torch.__version__).release >= version.parse("2.5.0").release:
     from xfuser.model_executor.layers.usp import USP
 else:
     from xfuser.model_executor.layers.usp_legacy import USP

--- a/xfuser/model_executor/layers/attention_processor.py
+++ b/xfuser/model_executor/layers/attention_processor.py
@@ -40,10 +40,10 @@ from xfuser.core.distributed.runtime_state import get_runtime_state
 from xfuser.model_executor.layers import xFuserLayerBaseWrapper
 from xfuser.model_executor.layers import xFuserLayerWrappersRegister
 from xfuser.logger import init_logger
-from xfuser.envs import PACKAGES_CHECKER
+from xfuser.envs import PACKAGES_CHECKER, TORCH_VERSION
 from packaging import version
 
-if version.parse(torch.__version__).release >= version.parse("2.5.0").release:
+if TORCH_VERSION >= version.parse("2.5.0"):
     from xfuser.model_executor.layers.usp import USP
 else:
     from xfuser.model_executor.layers.usp_legacy import USP


### PR DESCRIPTION
Three version checks used string comparison, which is incorrect for multi-digit minor versions (e.g., `"0.100" >= "0.32"` returns `False` since `'1' < '3'` lexicographically). 