### PR TITLE
[VAE] adds --vae_tile_size, fixes config validation and expands DistVAE coverage

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,9 @@
 [pytest]
+# The repo root, so a test importing another as `tests.core.test_x` resolves however pytest was
+# invoked. Some environments also carry an unrelated top-level `tests` package in site-packages,
+# which is why tests/ and tests/core/ carry an __init__.py: a namespace directory loses to an
+# installed package wherever it sits on the path, but a real package on the front of it wins.
+pythonpath = .
 log_format = %(asctime)s %(filename)s:%(lineno)d %(levelname)s %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S
 log_cli = true

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,0 +1,18 @@
+"""Shared setup for the core tests."""
+
+import pytest
+
+from xfuser.core.utils import vae_parallel
+
+
+@pytest.fixture(scope="session", autouse=True)
+def torch_group_norm():
+    """Give the session torch's own GroupNorm, not the one AITER leaves in its place
+
+    On ROCm, importing xfuser swaps torch.nn.GroupNorm for AITER's, which several tests here
+    cannot live with: a VAE built under the swap carries norms DistVAE will not shard, and
+    decoding one on the CPU reaches a kernel that only exists on the GPU. Production reverts
+    before it builds a VAE it means to shard, and nothing here is testing AITER's norm itself,
+    so revert once for the session and let each test see what it expects.
+    """
+    vae_parallel.restore_torch_group_norm()

--- a/tests/core/test_envs.py
+++ b/tests/core/test_envs.py
@@ -3,19 +3,26 @@ from unittest.mock import patch
 import torch
 from xfuser import envs
 
+# get_device reads torch.version.cuda and torch.version.hip, not torch.cuda.is_available, so a test
+# describing a machine names those two. Patching availability instead only ever agreed with the
+# machine it ran on: a ROCm build answers to HIP and reported cuda where cpu was asked for.
+
+
 class TestEnvs(unittest.TestCase):
 
-    @patch('torch.cuda.is_available', return_value=True)
-    def test_get_device_cuda(self, mock_is_available):
+    @patch('xfuser.envs._is_hip', return_value=False)
+    @patch('xfuser.envs._is_cuda', return_value=True)
+    def test_get_device_cuda(self, mock_is_cuda, mock_is_hip):
         device = envs.get_device(0)
         self.assertEqual(device.type, 'cuda')
         self.assertEqual(device.index, 0)
         device_name = envs.get_device_name()
         self.assertEqual(device_name, 'cuda')
 
-    @patch('torch.cuda.is_available', return_value=False)
+    @patch('xfuser.envs._is_hip', return_value=False)
+    @patch('xfuser.envs._is_cuda', return_value=False)
     @patch('xfuser.envs._is_mps', return_value=True)
-    def test_get_device_mps(self, mock_is_mps, mock_is_available):
+    def test_get_device_mps(self, mock_is_mps, mock_is_cuda, mock_is_hip):
         device = envs.get_device(0)
         self.assertEqual(device.type, 'mps')
         device_name = envs.get_device_name()
@@ -24,10 +31,11 @@ class TestEnvs(unittest.TestCase):
         cuda_version = envs.CUDA_VERSION
         self.assertIsNotNone(cuda_version)
 
-    @patch('torch.cuda.is_available', return_value=False)
+    @patch('xfuser.envs._is_hip', return_value=False)
+    @patch('xfuser.envs._is_cuda', return_value=False)
     @patch('xfuser.envs._is_mps', return_value=False)
     @patch('xfuser.envs._is_musa', return_value=False)
-    def test_get_device_cpu(self, mock_is_musa, mock_is_mps, mock_is_available):
+    def test_get_device_cpu(self, mock_is_musa, mock_is_mps, mock_is_cuda, mock_is_hip):
         device = envs.get_device(0)
         self.assertEqual(device.type, 'cpu')
         device_name = envs.get_device_name()

--- a/tests/core/test_gilbert.py
+++ b/tests/core/test_gilbert.py
@@ -8,28 +8,39 @@ from xfuser.core.sparge_attention.gilbert import (
 )
 
 
+def _tridiagonal(n: int) -> torch.Tensor:
+    band = torch.eye(n, dtype=torch.bool)
+    band[:-1, 1:] |= torch.eye(n - 1, dtype=torch.bool)
+    band[1:, :-1] |= torch.eye(n - 1, dtype=torch.bool)
+    return band
+
+
 class TestSlicedGilbertBlockNeighborMapping(unittest.TestCase):
     """Tests for sliced_gilbert_block_neighbor_mapping with known expected results."""
 
-    def test_identity_mapping_gives_block_diagonal_mask(self):
-        """Identity linear_to_hilbert and block_m == block_n -> strictly diagonal mask."""
-        t, h, w = 2, 2, 2
+    # A row of points in identity order, which is the one layout whose neighbours can be written
+    # down by hand: each point touches the one either side of it, so a block touches itself and the
+    # two beside it and nothing else. A 2x2x2 cube cannot show this - every point there is within
+    # one step of every other, so every block neighbours every block.
+    def test_identity_mapping_gives_a_banded_mask(self):
+        """Identity linear_to_hilbert and block_m == block_n -> diagonal and its two neighbours."""
+        t, h, w = 1, 1, 8
         block_m = block_n = 2
         linear_to_hilbert = torch.arange(8, dtype=torch.int64)
         mask = _sliced_gilbert_block_neighbor_mapping(
             t, h, w, block_m, block_n, linear_to_hilbert
         )
-        expected = torch.eye(4, dtype=torch.bool)
+        expected = _tridiagonal(4)
         self.assertEqual(tuple(mask.shape), (4, 4))
         self.assertEqual(mask.dtype, torch.bool)
         self.assertTrue(
             torch.equal(mask, expected),
-            f"Expected block-diagonal mask, got\n{mask}",
+            f"Expected a banded mask, got\n{mask}",
         )
 
-    def test_public_api_identity_mapping_gives_same_block_diagonal_mask(self):
-        """Public API with identity (lth, htl) yields same block-diagonal mask."""
-        t, h, w = 2, 2, 2
+    def test_public_api_identity_mapping_gives_the_same_banded_mask(self):
+        """Public API with identity (lth, htl) yields the same banded mask."""
+        t, h, w = 1, 1, 8
         block_m = block_n = 2
         device = torch.device("cpu")
         linear_to_hilbert = torch.arange(8, dtype=torch.int64)
@@ -38,13 +49,20 @@ class TestSlicedGilbertBlockNeighborMapping(unittest.TestCase):
             t, h, w, block_m, block_n, device,
             gilbert_mapping=(linear_to_hilbert, hilbert_to_linear),
         )
-        expected = torch.eye(4, dtype=torch.bool)
+        expected = _tridiagonal(4)
         self.assertEqual(tuple(mask.shape), (4, 4))
         self.assertEqual(mask.dtype, torch.bool)
         self.assertTrue(
             torch.equal(mask, expected),
-            f"Expected block-diagonal mask, got\n{mask}",
+            f"Expected a banded mask, got\n{mask}",
         )
+
+    def test_a_volume_small_enough_that_everything_touches_is_all_true(self):
+        # The case the two above used to assert a diagonal for: in a 2x2x2 cube every point is a
+        # neighbour of every other, so nothing about the mapping can separate the blocks.
+        linear_to_hilbert = torch.arange(8, dtype=torch.int64)
+        mask = _sliced_gilbert_block_neighbor_mapping(2, 2, 2, 2, 2, linear_to_hilbert)
+        self.assertTrue(bool(mask.all()))
 
     def test_shape_and_dtype_non_square_blocks(self):
         """Shape and dtype for non-square block grid (qblocks != kblocks)."""

--- a/tests/core/test_ring_flash_attn.py
+++ b/tests/core/test_ring_flash_attn.py
@@ -3,8 +3,11 @@ import torch
 import torch.distributed as dist
 from xfuser.core.long_ctx_attention.ring.ring_flash_attn import xdit_ring_flash_attn_func
 from xfuser.core.long_ctx_attention import xFuserLongContextAttention
-from flash_attn import flash_attn_func
+import pytest
 import os
+
+# A ROCm install has no flash-attn, and an import error here stops the whole directory collecting.
+flash_attn_func = pytest.importorskip("flash_attn").flash_attn_func
 
 from xfuser.model_executor.layers.attention_processor import (
     xFuserAttnProcessor2_0,

--- a/tests/core/test_sharding.py
+++ b/tests/core/test_sharding.py
@@ -6,7 +6,7 @@ using pytest conventions. Tests run on CPU with gloo backend for CI compatibilit
 
 Run with:
     pytest tests/test_sharding.py -v
-    pytest tests/test_sharding.py::test_shard_transformer_blocks -v  # Single test
+    pytest tests/test_sharding.py::test_shard_component_basic -v  # Single test
 """
 import pytest
 import torch
@@ -20,7 +20,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from xfuser.core.distributed.sharding import (
-    shard_transformer_blocks,
+    shard_component,
     shard_dit,
     shard_t5_encoder,
 )
@@ -137,17 +137,17 @@ def t5_encoder_model():
 
 
 # ============================================================================
-# Test shard_transformer_blocks
+# Test shard_component
 # ============================================================================
 
-def test_shard_transformer_blocks_basic(setup_distributed, simple_transformer_model):
+def test_shard_component_basic(setup_distributed, simple_transformer_model):
     """Test basic FSDP wrapping of transformer blocks."""
     model = simple_transformer_model
     
     # Shard the model
-    sharded_model = shard_transformer_blocks(
+    sharded_model = shard_component(
         model,
-        block_attr='blocks',
+        wrap_attrs=['blocks'],
         device_id=0,
     )
     
@@ -158,14 +158,14 @@ def test_shard_transformer_blocks_basic(setup_distributed, simple_transformer_mo
     assert hasattr(sharded_model, 'blocks'), "Blocks attribute should exist"
 
 
-def test_shard_transformer_blocks_with_dtype(setup_distributed, simple_transformer_model):
+def test_shard_component_with_dtype(setup_distributed, simple_transformer_model):
     """Test FSDP wrapping with dtype conversion."""
     model = simple_transformer_model
     
     # Shard with bfloat16
-    sharded_model = shard_transformer_blocks(
+    sharded_model = shard_component(
         model,
-        block_attr='blocks',
+        wrap_attrs=['blocks'],
         device_id=0,
         dtype=torch.bfloat16,
     )
@@ -178,26 +178,28 @@ def test_shard_transformer_blocks_with_dtype(setup_distributed, simple_transform
             assert param.dtype == torch.bfloat16, f"Param dtype should be bfloat16, got {param.dtype}"
 
 
-def test_shard_transformer_blocks_invalid_attr(setup_distributed, simple_transformer_model):
+def test_shard_component_invalid_attr(setup_distributed, simple_transformer_model):
     """Test error handling for invalid block attribute."""
     model = simple_transformer_model
-    
-    with pytest.raises(ValueError, match="Model does not have attribute"):
-        shard_transformer_blocks(
+
+    # rgetattr walks the name down the module and lets getattr say what is missing, rather than
+    # checking first and raising a ValueError of its own as the older function did.
+    with pytest.raises(AttributeError, match="nonexistent_blocks"):
+        shard_component(
             model,
-            block_attr='nonexistent_blocks',
+            wrap_attrs=['nonexistent_blocks'],
             device_id=0,
         )
 
 
-def test_shard_transformer_blocks_with_fsdp_kwargs(setup_distributed, simple_transformer_model):
+def test_shard_component_with_fsdp_kwargs(setup_distributed, simple_transformer_model):
     """Test passing additional FSDP kwargs."""
     model = simple_transformer_model
     
     # Should not raise an error
-    sharded_model = shard_transformer_blocks(
+    sharded_model = shard_component(
         model,
-        block_attr='blocks',
+        wrap_attrs=['blocks'],
         device_id=0,
         sync_module_states=True,
         forward_prefetch=True,
@@ -292,9 +294,9 @@ def test_empty_blocks_list(setup_distributed):
     model = EmptyBlockModel()
     
     # Should still work with empty blocks
-    sharded_model = shard_transformer_blocks(
+    sharded_model = shard_component(
         model,
-        block_attr='blocks',
+        wrap_attrs=['blocks'],
         device_id=0,
     )
     
@@ -313,9 +315,9 @@ def test_single_block(setup_distributed):
     
     model = SingleBlockModel()
     
-    sharded_model = shard_transformer_blocks(
+    sharded_model = shard_component(
         model,
-        block_attr='blocks',
+        wrap_attrs=['blocks'],
         device_id=0,
     )
     
@@ -327,9 +329,9 @@ def test_default_device_id(setup_distributed, simple_transformer_model):
     model = simple_transformer_model
     
     # Should use current device (0 in single-GPU test)
-    sharded_model = shard_transformer_blocks(
+    sharded_model = shard_component(
         model,
-        block_attr='blocks',
+        wrap_attrs=['blocks'],
         device_id=None,  # Explicitly pass None
     )
     
@@ -341,9 +343,9 @@ def test_no_dtype_conversion(setup_distributed, simple_transformer_model):
     model = simple_transformer_model
     original_dtype = next(model.parameters()).dtype
     
-    sharded_model = shard_transformer_blocks(
+    sharded_model = shard_component(
         model,
-        block_attr='blocks',
+        wrap_attrs=['blocks'],
         device_id=0,
         dtype=None,  # No conversion
     )
@@ -363,9 +365,9 @@ def test_parameter_count_preserved(setup_distributed, simple_transformer_model):
     # Count params before sharding
     original_param_count = sum(p.numel() for p in model.parameters())
     
-    sharded_model = shard_transformer_blocks(
+    sharded_model = shard_component(
         model,
-        block_attr='blocks',
+        wrap_attrs=['blocks'],
         device_id=0,
     )
     
@@ -384,9 +386,9 @@ def test_end_to_end_forward_pass(setup_distributed, simple_transformer_model):
     """Test complete forward pass through sharded model."""
     model = simple_transformer_model
     
-    sharded_model = shard_transformer_blocks(
+    sharded_model = shard_component(
         model,
-        block_attr='blocks',
+        wrap_attrs=['blocks'],
         device_id=0,
         dtype=torch.float32,
     )

--- a/tests/core/test_vae_parallel.py
+++ b/tests/core/test_vae_parallel.py
@@ -262,5 +262,39 @@ class TestBothHalvesShardTogether(unittest.TestCase):
                 self.assertIsNot(vae.encoder, encoder)
 
 
+class AiterGroupNorm(nn.Module):
+    """Stands in for AITER's replacement: a norm of its own, not a subclass of torch's"""
+
+    # The revert recognises it by where it comes from, which is all this has to reproduce.
+    __module__ = "aiter.ops.groupnorm"
+
+
+class TestGroupNormRevert(unittest.TestCase):
+    """Undoing AITER's swap of torch.nn.GroupNorm, which the adapters cannot see past"""
+
+    def test_a_swapped_group_norm_is_put_back(self):
+        original = nn.GroupNorm
+        try:
+            nn.GroupNorm = AiterGroupNorm
+            self.assertTrue(vae_parallel.restore_torch_group_norm())
+            self.assertIs(nn.GroupNorm, original)
+        finally:
+            nn.GroupNorm = original
+
+    def test_an_untouched_group_norm_is_left_alone(self):
+        original = nn.GroupNorm
+        self.assertFalse(vae_parallel.restore_torch_group_norm())
+        self.assertIs(nn.GroupNorm, original)
+
+    def test_the_swap_is_what_makes_a_2d_decoder_unrecognisable(self):
+        # This is the failure the revert exists for. AITER's norm is not a subclass of torch's,
+        # so a VAE assembled while the swap was in place carries norms that the check for a 2D
+        # decoder does not accept, and the VAE reads as one DistVAE cannot shard.
+        vae = diffusers.AutoencoderKL(**CONFIGS["AutoencoderKL"]).eval()
+        self.assertEqual(vae_parallel.decoder_adapter_name(vae), "DecoderAdapter")
+        vae.decoder.conv_norm_out = AiterGroupNorm()
+        self.assertIsNone(vae_parallel.decoder_adapter_name(vae))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/core/test_vae_parallel.py
+++ b/tests/core/test_vae_parallel.py
@@ -1,16 +1,18 @@
-"""Which VAE classes DistVAE can shard, checked against real decoders rather than a list.
+"""Which VAE classes DistVAE can shard, checked against real VAEs rather than a list.
 
-The adapters assert their block types from inside a half-built replacement decoder, so a VAE they
-cannot take has to be recognised before wrapping. These build each VAE class a runner model loads
-and demand the answer, so a model declaring use_parallel_vae cannot quietly become unshardable
-when diffusers reworks a decoder.
+The adapters assert their block types from inside a half-built replacement, so a VAE they cannot
+take has to be recognised before wrapping. These build each VAE class a runner model loads and
+demand the answer for both halves of it, so a model declaring use_parallel_vae or
+use_parallel_vae_encoder cannot quietly become unshardable when diffusers reworks a block.
 """
 
+import os
 import unittest
 from types import SimpleNamespace
 from unittest import mock
 
 import diffusers
+import torch.distributed as dist
 import torch.nn as nn
 
 from xfuser.core.utils import vae_parallel
@@ -38,6 +40,18 @@ EXPECTED = {
     "AutoencoderKLHunyuanVideo": vae_parallel.HUNYUAN_VIDEO,
     "AutoencoderKLHunyuanVideo15": vae_parallel.HUNYUAN_VIDEO_15,
     "AutoencoderKLLTX2Video": vae_parallel.LTX2_VIDEO,
+}
+
+# The encoder adapter each class needs. DistVAE reached full encoder coverage alongside its
+# decoders, so a None here would mean an encoder adapter was lost rather than never written.
+EXPECTED_ENCODERS = {
+    "AutoencoderKL": vae_parallel.TWO_D_ENCODER,
+    "AutoencoderKLFlux2": vae_parallel.TWO_D_ENCODER,
+    "AutoencoderKLWan": "WanEncoderAdapter",
+    "AutoencoderKLQwenImage": "QwenImageEncoderAdapter",
+    "AutoencoderKLHunyuanVideo": "HunyuanVideoEncoderAdapter",
+    "AutoencoderKLHunyuanVideo15": "HunyuanVideo15EncoderAdapter",
+    "AutoencoderKLLTX2Video": "LTX2VideoEncoderAdapter",
 }
 
 
@@ -72,6 +86,33 @@ class TestDecoderAdapterChoice(unittest.TestCase):
         self.assertIsNone(vae_parallel.decoder_adapter_name(vae))
 
 
+class TestEncoderAdapterChoice(unittest.TestCase):
+    """Which adapter shards each class's encoder, read off the family its decoder names"""
+
+    def test_every_vae_class_gets_the_encoder_adapter_it_needs(self):
+        for name, expected in EXPECTED_ENCODERS.items():
+            with self.subTest(vae=name):
+                vae = getattr(diffusers, name)(**CONFIGS[name])
+                self.assertEqual(vae_parallel.encoder_adapter_name(vae), expected)
+
+    def test_an_encoder_with_no_down_blocks_is_not_shardable(self):
+        class Bare:
+            pass
+
+        self.assertIsNone(vae_parallel.encoder_adapter_name(Bare()))
+
+    def test_the_two_halves_are_recognised_independently(self):
+        # Sharding either half replaces its blocks with adapters, so an encoder read off the
+        # decoder would come back unrecognised once the decoder had been done first, which is the
+        # order the runner models shard them in.
+        vae = diffusers.AutoencoderKLWan(**CONFIGS["AutoencoderKLWan"])
+        expected = vae_parallel.encoder_adapter_name(vae)
+        vae.decoder.conv_norm_out = nn.Identity()
+        vae.decoder.up_blocks = nn.ModuleList()
+        self.assertIsNone(vae_parallel.decoder_adapter_name(vae))
+        self.assertEqual(vae_parallel.encoder_adapter_name(vae), expected)
+
+
 class TestEncoderScaleFactor(unittest.TestCase):
     """The number the encoder adapter shards by, which used to be derived per model"""
 
@@ -90,6 +131,24 @@ class TestEncoderScaleFactor(unittest.TestCase):
         vae = diffusers.AutoencoderKLWan(**CONFIGS["AutoencoderKLWan"])
         vae.register_to_config(scale_factor_spatial=None)
         self.assertEqual(vae_parallel.encoder_scale_factor(vae), 8)
+
+    def test_flux2s_pair_of_patch_sizes_is_not_mistaken_for_a_ratio(self):
+        # Flux.2 names patch_size for how its latents are packed for the transformer, which its
+        # convolutions know nothing about, and names it as a pair. Dividing by that both divides
+        # by the wrong thing and cannot be compared against a number in the first place.
+        vae = diffusers.AutoencoderKLFlux2(**CONFIGS["AutoencoderKLFlux2"])
+        self.assertEqual(vae.config.patch_size, (2, 2))
+        self.assertEqual(vae_parallel.encoder_scale_factor(vae), 8)
+
+    def test_a_two_d_encoder_is_counted_off_its_stages(self):
+        # These VAEs record no ratio, so the four-stage 8 has to be counted rather than assumed.
+        # A three-stage one narrows by 4, and sizing its bands by 8 would leave its last stage
+        # halving a band into a row belonging to the next rank.
+        config = dict(CONFIGS["AutoencoderKL"])
+        config["block_out_channels"] = [8, 8, 16]
+        config["down_block_types"] = ["DownEncoderBlock2D"] * 3
+        config["up_block_types"] = ["UpDecoderBlock2D"] * 3
+        self.assertEqual(vae_parallel.encoder_scale_factor(diffusers.AutoencoderKL(**config)), 4)
 
 
 class _StubAdapter(nn.Module):
@@ -147,13 +206,60 @@ class TestUnshardableIsRefused(unittest.TestCase):
         # Refused before touching anything, so the caller is left a working decode to fall back on.
         self.assertIs(vae.decoder, decoder)
 
-    def test_encoding_is_refused_for_a_vae_the_one_encoder_adapter_does_not_fit(self):
-        # DistVAE has only WanEncoderAdapter, so a 2D VAE it can decode with it cannot encode with.
+    def test_encoding_is_refused_for_a_vae_no_encoder_adapter_fits(self):
+        # Provoked with an encoder taken out of the shape its adapter needs, since DistVAE fits
+        # every VAE class a runner model loads.
         vae = diffusers.AutoencoderKL(**CONFIGS["AutoencoderKL"])
+        vae.encoder.down_blocks = nn.ModuleList()
         encoder = vae.encoder
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as caught:
             vae_parallel.parallelize_encoder(vae, vae_group=None)
+        self.assertIn("Parallel VAE encoding is not available", str(caught.exception))
+        # Refused before touching anything, so the caller is left a working encode.
         self.assertIs(vae.encoder, encoder)
+
+
+class TestBothHalvesShardTogether(unittest.TestCase):
+    """Every VAE class a runner model loads has both halves replaced, in the runner's order
+
+    Naming an adapter and installing it are different things: the adapters rebuild a half in
+    place, so the half done first no longer answers to the blocks it was recognised by. Choosing
+    both names off intact blocks and then wrapping is what these check, over a one-rank gloo
+    group, since a name that resolves is no use if the wrapping it is chosen for cannot run.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.owns_group = not dist.is_initialized()
+        if cls.owns_group:
+            os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+            os.environ.setdefault("MASTER_PORT", "24118")
+            os.environ.setdefault("RANK", "0")
+            os.environ.setdefault("WORLD_SIZE", "1")
+            dist.init_process_group(backend="gloo", init_method="env://")
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.owns_group:
+            dist.destroy_process_group()
+
+    def test_every_vae_class_shards_both_halves(self):
+        for name, config in CONFIGS.items():
+            with self.subTest(vae=name):
+                vae = getattr(diffusers, name)(**config).eval()
+                expected = vae_parallel.encoder_adapter_name(vae)
+                encoder, decoder = vae.encoder, vae.decoder
+                # The runner models shard the decoder first, which is what makes the order matter.
+                self.assertEqual(
+                    vae_parallel.parallelize_decoder(vae, vae_group=None), EXPECTED[name]
+                )
+                self.assertEqual(vae_parallel.encoder_adapter_name(vae), expected)
+                self.assertEqual(
+                    vae_parallel.parallelize_encoder(vae, vae_group=None),
+                    EXPECTED_ENCODERS[name],
+                )
+                self.assertIsNot(vae.decoder, decoder)
+                self.assertIsNot(vae.encoder, encoder)
 
 
 if __name__ == "__main__":

--- a/tests/core/test_vae_parallel.py
+++ b/tests/core/test_vae_parallel.py
@@ -262,6 +262,80 @@ class TestBothHalvesShardTogether(unittest.TestCase):
                 self.assertIsNot(vae.encoder, encoder)
 
 
+class _ConvLosingAdapter(_StubAdapter):
+    """A stand-in that keeps none of the convolutions it replaced, as the real adapters do
+
+    The count a recounting VAE makes is over the convolutions still answering to its own class,
+    and after sharding there are none: that is the whole of what has to be reproduced here.
+    """
+
+    def __init__(self, half, vae_group=None, **kwargs):
+        super().__init__(half, vae_group=vae_group, **kwargs)
+        self.wrapped = nn.Identity()
+
+
+class TestCausalCacheLength(unittest.TestCase):
+    """A causal VAE's feature cache has to keep its length once its convolutions are replaced
+
+    Qwen-Image sizes that cache by counting its causal convolutions on every call, so sharding
+    them away leaves an empty list and the first convolution to want its entry indexes off the
+    end. The failure is an IndexError from inside diffusers on the first decode, well after the
+    point where anything says which VAE stopped being decodable.
+    """
+
+    def _parallelize(self, vae, half="decoder"):
+        with mock.patch.object(vae_parallel, "_adapter", return_value=_ConvLosingAdapter):
+            if half == "decoder":
+                vae_parallel.parallelize_decoder(vae, vae_group=None)
+            else:
+                vae_parallel.parallelize_encoder(vae, vae_group=None)
+
+    def test_a_recounting_vae_still_caches_one_entry_per_convolution(self):
+        vae = diffusers.AutoencoderKLQwenImage(**CONFIGS["AutoencoderKLQwenImage"])
+        vae.clear_cache()
+        expected = vae._conv_num
+        self.assertGreater(expected, 0)
+
+        self._parallelize(vae)
+        vae.clear_cache()
+
+        self.assertEqual(vae._conv_num, expected)
+        self.assertEqual(len(vae._feat_map), expected)
+
+    def test_the_second_half_is_counted_before_the_first_is_replaced(self):
+        # Both halves are counted on the first call, because by the time the encoder is sharded
+        # the decoder has been, and a count taken then would already be short.
+        vae = diffusers.AutoencoderKLQwenImage(**CONFIGS["AutoencoderKLQwenImage"])
+        vae.clear_cache()
+        expected = vae._enc_conv_num
+        self.assertGreater(expected, 0)
+
+        self._parallelize(vae, "decoder")
+        self._parallelize(vae, "encoder")
+        vae.clear_cache()
+
+        self.assertEqual(vae._enc_conv_num, expected)
+        self.assertEqual(len(vae._enc_feat_map), expected)
+
+    def test_a_vae_that_counts_once_when_built_is_left_as_it_is(self):
+        # Wan caches its counts at construction, so nothing here has to hold them; this is that
+        # the holding does not disturb the ones that never needed it.
+        vae = diffusers.AutoencoderKLWan(**CONFIGS["AutoencoderKLWan"])
+        vae.clear_cache()
+        expected = (vae._conv_num, vae._enc_conv_num)
+
+        self._parallelize(vae)
+        vae.clear_cache()
+
+        self.assertEqual((vae._conv_num, vae._enc_conv_num), expected)
+
+    def test_a_vae_with_no_cache_at_all_is_wrapped_anyway(self):
+        vae = diffusers.AutoencoderKL(**CONFIGS["AutoencoderKL"])
+        self.assertFalse(hasattr(vae, "clear_cache"))
+        self._parallelize(vae)
+        self.assertIsInstance(vae.decoder, _ConvLosingAdapter)
+
+
 class AiterGroupNorm(nn.Module):
     """Stands in for AITER's replacement: a norm of its own, not a subclass of torch's"""
 

--- a/tests/core/test_vae_parallel.py
+++ b/tests/core/test_vae_parallel.py
@@ -7,6 +7,8 @@ when diffusers reworks a decoder.
 """
 
 import unittest
+from types import SimpleNamespace
+from unittest import mock
 
 import diffusers
 import torch.nn as nn
@@ -77,6 +79,45 @@ class TestEncoderScaleFactor(unittest.TestCase):
         vae = diffusers.AutoencoderKLWan(**CONFIGS["AutoencoderKLWan"])
         vae.register_to_config(scale_factor_spatial=None)
         self.assertEqual(vae_parallel.encoder_scale_factor(vae), 8)
+
+
+class _StubAdapter(nn.Module):
+    """Stands in for a DistVAE adapter, which needs a process group to build"""
+
+    def __init__(self, decoder, vae_group=None, **kwargs):
+        super().__init__()
+        self.wrapped = decoder
+        self.kwargs = kwargs
+        # WanDecoderAdapter crops by the factor it upsamples; the 2D one has no such step.
+        self.patchify = SimpleNamespace(scale_factor=1)
+
+
+class TestWrappingReadsEveryVAEConfig(unittest.TestCase):
+    """Wrapping reads the VAE's config, so it has to survive how each class spells it"""
+
+    def _parallelize(self, vae):
+        with mock.patch.object(vae_parallel, "_adapter", return_value=_StubAdapter):
+            vae_parallel.parallelize_decoder(vae, vae_group=None)
+        return vae.decoder
+
+    def test_every_shardable_vae_class_can_be_wrapped(self):
+        for name, adapter in EXPECTED.items():
+            if adapter is None:
+                continue
+            with self.subTest(vae=name):
+                vae = getattr(diffusers, name)(**CONFIGS[name])
+                self.assertIsInstance(self._parallelize(vae), _StubAdapter)
+
+    def test_a_patching_vae_tells_the_adapter_its_factor(self):
+        vae = diffusers.AutoencoderKLWan(**CONFIGS["AutoencoderKLWan"])
+        vae.register_to_config(patch_size=2)
+        self.assertEqual(self._parallelize(vae).patchify.scale_factor, 2)
+
+    def test_flux_2s_patching_is_not_read_as_a_factor(self):
+        # Flux 2 declares patch_size (2, 2) for the pixel unshuffle at its boundary, which is not
+        # the single factor an adapter's patchify takes.
+        vae = diffusers.AutoencoderKLFlux2(**CONFIGS["AutoencoderKLFlux2"])
+        self.assertEqual(self._parallelize(vae).patchify.scale_factor, 1)
 
 
 class TestUnshardableIsRefused(unittest.TestCase):

--- a/tests/core/test_vae_parallel.py
+++ b/tests/core/test_vae_parallel.py
@@ -27,15 +27,17 @@ CONFIGS = {
 }
 
 # The adapter each class needs, or None where DistVAE has nothing for its decoder. A None here is
-# what --use_parallel_vae refuses, and what a new DistVAE adapter would change.
+# what --use_parallel_vae refuses. Every class a runner model loads is shardable as of DistVAE's
+# QwenImage, HunyuanVideo and LTX-2 adapters, so a None appearing here again would mean a newly
+# supported model arrived ahead of the adapter for its VAE.
 EXPECTED = {
     "AutoencoderKL": vae_parallel.TWO_D,
     "AutoencoderKLFlux2": vae_parallel.TWO_D,
     "AutoencoderKLWan": vae_parallel.WAN,
-    "AutoencoderKLQwenImage": None,
-    "AutoencoderKLHunyuanVideo": None,
-    "AutoencoderKLHunyuanVideo15": None,
-    "AutoencoderKLLTX2Video": None,
+    "AutoencoderKLQwenImage": vae_parallel.QWEN_IMAGE,
+    "AutoencoderKLHunyuanVideo": vae_parallel.HUNYUAN_VIDEO,
+    "AutoencoderKLHunyuanVideo15": vae_parallel.HUNYUAN_VIDEO_15,
+    "AutoencoderKLLTX2Video": vae_parallel.LTX2_VIDEO,
 }
 
 
@@ -52,6 +54,15 @@ class TestDecoderAdapterChoice(unittest.TestCase):
             pass
 
         self.assertIsNone(vae_parallel.decoder_adapter_name(Bare()))
+
+    def test_an_ltx2_decoder_that_injects_noise_is_not_shardable(self):
+        # Every rank would draw noise for its own rows, and together they would not reconstruct
+        # what one rank draws, so the decode could not match an unsharded one. No released LTX-2
+        # checkpoint enables this, which is why the shardable config above is the shipped shape.
+        vae = diffusers.AutoencoderKLLTX2Video(
+            **CONFIGS["AutoencoderKLLTX2Video"], decoder_inject_noise=True
+        )
+        self.assertIsNone(vae_parallel.decoder_adapter_name(vae))
 
     def test_a_two_d_decoder_without_group_norm_is_not_shardable(self):
         # DecoderAdapter replaces conv_norm_out with a sharded GroupNorm and asserts it found one,
@@ -123,7 +134,10 @@ class TestWrappingReadsEveryVAEConfig(unittest.TestCase):
 class TestUnshardableIsRefused(unittest.TestCase):
 
     def test_it_names_the_flag_and_points_at_the_alternative(self):
-        vae = diffusers.AutoencoderKLQwenImage(**CONFIGS["AutoencoderKLQwenImage"])
+        # DistVAE now fits every VAE class a runner model loads, so the refusal is provoked with
+        # a decoder taken out of the shape its adapter needs rather than with a real VAE.
+        vae = diffusers.AutoencoderKL(**CONFIGS["AutoencoderKL"])
+        vae.decoder.conv_norm_out = nn.Identity()
         decoder = vae.decoder
         with self.assertRaises(ValueError) as caught:
             vae_parallel.parallelize_decoder(vae, vae_group=None)

--- a/tests/core/test_vae_parallel.py
+++ b/tests/core/test_vae_parallel.py
@@ -54,7 +54,6 @@ EXPECTED_ENCODERS = {
     "AutoencoderKLLTX2Video": "LTX2VideoEncoderAdapter",
 }
 
-
 class TestDecoderAdapterChoice(unittest.TestCase):
 
     def test_every_vae_class_gets_the_adapter_it_needs(self):
@@ -346,19 +345,23 @@ class AiterGroupNorm(nn.Module):
 class TestGroupNormRevert(unittest.TestCase):
     """Undoing AITER's swap of torch.nn.GroupNorm, which the adapters cannot see past"""
 
+    def setUp(self):
+        # Whichever class is in place when a test starts, torch's own is what the revert should
+        # arrive at, and whatever a test puts there is its own business alone.
+        from xfuser.envs import _TORCH_GROUPNORM
+
+        self.torch_group_norm = _TORCH_GROUPNORM
+        self.addCleanup(setattr, nn, "GroupNorm", nn.GroupNorm)
+
     def test_a_swapped_group_norm_is_put_back(self):
-        original = nn.GroupNorm
-        try:
-            nn.GroupNorm = AiterGroupNorm
-            self.assertTrue(vae_parallel.restore_torch_group_norm())
-            self.assertIs(nn.GroupNorm, original)
-        finally:
-            nn.GroupNorm = original
+        nn.GroupNorm = AiterGroupNorm
+        self.assertTrue(vae_parallel.restore_torch_group_norm())
+        self.assertIs(nn.GroupNorm, self.torch_group_norm)
 
     def test_an_untouched_group_norm_is_left_alone(self):
-        original = nn.GroupNorm
+        nn.GroupNorm = self.torch_group_norm
         self.assertFalse(vae_parallel.restore_torch_group_norm())
-        self.assertIs(nn.GroupNorm, original)
+        self.assertIs(nn.GroupNorm, self.torch_group_norm)
 
     def test_the_swap_is_what_makes_a_2d_decoder_unrecognisable(self):
         # This is the failure the revert exists for. AITER's norm is not a subclass of torch's,

--- a/tests/core/test_vae_parallel.py
+++ b/tests/core/test_vae_parallel.py
@@ -1,0 +1,105 @@
+"""Which VAE classes DistVAE can shard, checked against real decoders rather than a list.
+
+The adapters assert their block types from inside a half-built replacement decoder, so a VAE they
+cannot take has to be recognised before wrapping. These build each VAE class a runner model loads
+and demand the answer, so a model declaring use_parallel_vae cannot quietly become unshardable
+when diffusers reworks a decoder.
+"""
+
+import unittest
+
+import diffusers
+import torch.nn as nn
+
+from xfuser.core.utils import vae_parallel
+
+from tests.core import test_vae_tiling
+
+# The same tiny builds the tiling tests decode through, taken from there rather than repeated, so
+# one VAE class is described in one place. Imported as a module, since binding its TestCase here
+# would have unittest collect and run those decodes a second time. Only the config is needed:
+# picking an adapter reads the decoder's block types and never runs it.
+CONFIGS = {
+    name: config
+    for name, (config, _, _) in test_vae_tiling.TestEveryVAEARunnerLoads.VAES.items()
+}
+
+# The adapter each class needs, or None where DistVAE has nothing for its decoder. A None here is
+# what --use_parallel_vae refuses, and what a new DistVAE adapter would change.
+EXPECTED = {
+    "AutoencoderKL": vae_parallel.TWO_D,
+    "AutoencoderKLFlux2": vae_parallel.TWO_D,
+    "AutoencoderKLWan": vae_parallel.WAN,
+    "AutoencoderKLQwenImage": None,
+    "AutoencoderKLHunyuanVideo": None,
+    "AutoencoderKLHunyuanVideo15": None,
+    "AutoencoderKLLTX2Video": None,
+}
+
+
+class TestDecoderAdapterChoice(unittest.TestCase):
+
+    def test_every_vae_class_gets_the_adapter_it_needs(self):
+        for name, expected in EXPECTED.items():
+            with self.subTest(vae=name):
+                vae = getattr(diffusers, name)(**CONFIGS[name])
+                self.assertEqual(vae_parallel.decoder_adapter_name(vae), expected)
+
+    def test_a_vae_with_no_decoder_is_not_shardable(self):
+        class Bare:
+            pass
+
+        self.assertIsNone(vae_parallel.decoder_adapter_name(Bare()))
+
+    def test_a_two_d_decoder_without_group_norm_is_not_shardable(self):
+        # DecoderAdapter replaces conv_norm_out with a sharded GroupNorm and asserts it found one,
+        # so a decoder normalising some other way is out even with the right up blocks.
+        vae = diffusers.AutoencoderKL(**CONFIGS["AutoencoderKL"])
+        vae.decoder.conv_norm_out = nn.Identity()
+        self.assertIsNone(vae_parallel.decoder_adapter_name(vae))
+
+
+class TestEncoderScaleFactor(unittest.TestCase):
+    """The number the encoder adapter shards by, which used to be derived per model"""
+
+    def test_a_vae_that_does_not_patch_uses_its_spatial_ratio(self):
+        vae = diffusers.AutoencoderKLWan(**CONFIGS["AutoencoderKLWan"])
+        self.assertEqual(vae_parallel.encoder_scale_factor(vae), 8)
+
+    def test_patching_is_divided_out(self):
+        # Cosmos 3's 16 is 8 from the encoder's convolutions and 2 from patching, and the adapter
+        # shards the convolutions.
+        vae = diffusers.AutoencoderKLWan(**CONFIGS["AutoencoderKLWan"])
+        vae.register_to_config(scale_factor_spatial=16, patch_size=2)
+        self.assertEqual(vae_parallel.encoder_scale_factor(vae), 8)
+
+    def test_a_vae_with_no_spatial_ratio_falls_back(self):
+        vae = diffusers.AutoencoderKLWan(**CONFIGS["AutoencoderKLWan"])
+        vae.register_to_config(scale_factor_spatial=None)
+        self.assertEqual(vae_parallel.encoder_scale_factor(vae), 8)
+
+
+class TestUnshardableIsRefused(unittest.TestCase):
+
+    def test_it_names_the_flag_and_points_at_the_alternative(self):
+        vae = diffusers.AutoencoderKLQwenImage(**CONFIGS["AutoencoderKLQwenImage"])
+        decoder = vae.decoder
+        with self.assertRaises(ValueError) as caught:
+            vae_parallel.parallelize_decoder(vae, vae_group=None)
+        message = str(caught.exception)
+        self.assertIn("--use_parallel_vae", message)
+        self.assertIn("--vae_tile_size", message)
+        # Refused before touching anything, so the caller is left a working decode to fall back on.
+        self.assertIs(vae.decoder, decoder)
+
+    def test_encoding_is_refused_for_a_vae_the_one_encoder_adapter_does_not_fit(self):
+        # DistVAE has only WanEncoderAdapter, so a 2D VAE it can decode with it cannot encode with.
+        vae = diffusers.AutoencoderKL(**CONFIGS["AutoencoderKL"])
+        encoder = vae.encoder
+        with self.assertRaises(ValueError):
+            vae_parallel.parallelize_encoder(vae, vae_group=None)
+        self.assertIs(vae.encoder, encoder)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/core/test_vae_tiling.py
+++ b/tests/core/test_vae_tiling.py
@@ -407,17 +407,19 @@ class TestTileBatching(unittest.TestCase):
         area = 128 * 128
         self.assertEqual(vae_tiling.tile_batch_budget(area, area), area)
 
-    def test_a_narrower_window_lowers_the_area_a_call_carries_and_raises_the_tiles(self):
-        # Both of the things --vae_tile_size is asked for have to keep improving as it shrinks:
-        # less area per call than the VAE's own window, and more tiles sharing each round of
-        # collectives. Quartering the window's area does both by two.
-        default_area = 128 * 128
-        for latent, tiles, carried in ((64, 2, 8192), (32, 4, 4096), (16, 8, 2048), (8, 16, 1024)):
-            with self.subTest(latent_window=latent):
-                budget = vae_tiling.tile_batch_budget(default_area, latent * latent)
+    def test_halving_the_window_halves_the_area_a_call_carries(self):
+        # What --vae_tile_size promises, in the units it is set in: it is an edge, so halving the
+        # number halves the memory a decoder call needs. The tiles sharing each round of
+        # collectives double at the same time, which is the other half of the bargain.
+        default_edge = 128
+        default_area = default_edge**2
+        for edge, tiles, carried in ((64, 2, 8192), (32, 4, 4096), (16, 8, 2048), (8, 16, 1024)):
+            with self.subTest(latent_window=edge):
+                budget = vae_tiling.tile_batch_budget(default_area, edge * edge)
                 self.assertEqual(budget, carried)
-                self.assertEqual(budget // (latent * latent), tiles)
-                self.assertLess(budget, default_area)
+                self.assertEqual(budget // (edge * edge), tiles)
+                # Linear in the edge: an eighth of the window is an eighth of the area per call.
+                self.assertEqual(budget * default_edge, default_area * edge)
 
     def test_a_vae_with_no_square_window_is_not_batched(self):
         self.assertIsNone(vae_tiling.tile_batch_budget(None, 1024))

--- a/tests/core/test_vae_tiling.py
+++ b/tests/core/test_vae_tiling.py
@@ -53,6 +53,17 @@ def asymmetric_vae():
     )
 
 
+def overlap_factor_vae():
+    """AutoencoderKL and friends again, carrying the blending the batched decode reuses"""
+    return StubVAE(
+        tile_sample_min_size=256,
+        tile_latent_min_size=32,
+        tile_overlap_factor=0.25,
+        blend_v=lambda above, tile, extent: tile,
+        blend_h=lambda left, tile, extent: tile,
+    )
+
+
 def per_axis_overlap_vae():
     """A square window whose two axes carry their own overlap fractions"""
     return StubVAE(
@@ -366,6 +377,175 @@ class TestEveryVAEARunnerLoads(unittest.TestCase):
                 self.assertEqual(
                     got, expected, f"{name} decoded at a {pixels}px tile window"
                 )
+
+
+class TestTileBatching(unittest.TestCase):
+    """Decoding same-shaped tiles in one call, which has to leave the image exactly as it was"""
+
+    # The two VAE classes that tile by overlap fraction, reusing the stand-ins above.
+    FAMILY = ("AutoencoderKL", "AutoencoderKLFlux2")
+    # Three windows of latents across, so a run holds several tiles of the full shape alongside
+    # the clipped ones at the right and bottom edges.
+    WINDOWS_ACROSS = 3
+
+    def test_only_the_overlap_factor_family_is_batched(self):
+        # The others walk a stride they store outright, over a loop with its own blending and,
+        # for the video VAEs, a frame axis this knows nothing about.
+        self.assertTrue(vae_tiling.tiles_by_overlap_factor(overlap_factor_vae()))
+        self.assertFalse(vae_tiling.tiles_by_overlap_factor(stride_vae()))
+        self.assertFalse(vae_tiling.tiles_by_overlap_factor(overlap_hw_vae()))
+        self.assertIsNone(vae_tiling.batched_tiled_decode(stride_vae(), 4096))
+        self.assertIsNotNone(vae_tiling.batched_tiled_decode(overlap_factor_vae(), 4096))
+
+    def test_the_budget_is_the_area_of_the_vaes_own_tile(self):
+        self.assertEqual(vae_tiling.default_tile_area(overlap_factor_vae()), 32 * 32)
+        self.assertIsNone(vae_tiling.default_tile_area(stride_vae()))
+
+    def _tiled_vae(self, name, batch=1):
+        """A small VAE of class `name` at a narrowed window, and latents several tiles across"""
+        import torch
+        import diffusers
+
+        cls = getattr(diffusers, name, None)
+        if cls is None:
+            self.skipTest(f"{name} is not in diffusers {diffusers.__version__}")
+        kwargs, _, channels = TestEveryVAEARunnerLoads.VAES[name]
+        vae = cls(**kwargs).eval()
+        if not hasattr(vae, "use_tiling"):
+            self.skipTest(f"diffusers {diffusers.__version__} cannot tile {name}")
+        vae.enable_tiling()
+
+        window = vae_tiling.tile_window(vae)
+        pixels, plan = vae_tiling.snap_tile_window(vae, window // 4)
+        self.assertIsNotNone(plan, f"{name} refused every window at or below {window // 4}")
+        vae_tiling.apply_tile_plan(vae, plan)
+        self.assertTrue(
+            vae_tiling.tiles_by_overlap_factor(vae),
+            f"{name} was expected to tile by overlap fraction",
+        )
+
+        grid = vae.tile_latent_min_size * self.WINDOWS_ACROSS
+        torch.manual_seed(0)
+        return vae, torch.randn(batch, channels, grid, grid)
+
+    def _counted(self, vae):
+        """Replace the decoder with one that records the shape of every call"""
+        import torch.nn as nn
+
+        class CountingDecoder(nn.Module):
+            def __init__(self, decoder):
+                super().__init__()
+                self.decoder = decoder
+                self.shapes = []
+
+            def forward(self, x):
+                self.shapes.append(tuple(x.shape))
+                return self.decoder(x)
+
+            @property
+            def rows(self):
+                """The rows each call carried: one tile each, at a latent batch of one"""
+                return [shape[0] for shape in self.shapes]
+
+        counted = CountingDecoder(vae.decoder)
+        vae.decoder = counted
+        return counted
+
+    def test_a_batched_decode_gives_the_image_an_unbatched_one_gives(self):
+        import torch
+
+        for name in self.FAMILY:
+            with self.subTest(vae=name):
+                vae, latents = self._tiled_vae(name)
+                with torch.no_grad():
+                    expected = vae.tiled_decode(latents).sample
+                    counted = self._counted(vae)
+                    batched = vae_tiling.batched_tiled_decode(
+                        vae, vae.tile_latent_min_size**2 * 8
+                    )
+                    got = batched(latents).sample
+                # Nothing here changes what is summed, only how many rows a kernel is handed at
+                # once, and a convolution picks its blocking off that. The residue is around
+                # 1e-5 on an image in [-1, 1]; a tile put back in the wrong place would be off by
+                # order one, which this still catches.
+                self.assertEqual(got.shape, expected.shape)
+                torch.testing.assert_close(got, expected, rtol=0, atol=1e-4)
+                self.assertTrue(
+                    any(rows > 1 for rows in counted.rows),
+                    f"{name} decoded every tile on its own, so this proved nothing",
+                )
+
+    def test_a_latent_batch_is_taken_apart_again(self):
+        import torch
+
+        # Each tile carries every sample in the batch, so a call decodes tiles x samples rows and
+        # the split back out has to step by the batch and not by one.
+        vae, latents = self._tiled_vae("AutoencoderKL", batch=2)
+        with torch.no_grad():
+            expected = vae.tiled_decode(latents).sample
+            got = vae_tiling.batched_tiled_decode(
+                vae, vae.tile_latent_min_size**2 * 8
+            )(latents).sample
+        torch.testing.assert_close(got, expected, rtol=0, atol=1e-4)
+
+    def test_a_budget_of_one_tile_decodes_exactly_as_upstream_does(self):
+        import torch
+
+        # This is what the default window gets: the budget is that window's own area, so nothing
+        # about the decode changes for a run that did not ask for a smaller tile.
+        vae, latents = self._tiled_vae("AutoencoderKL")
+        with torch.no_grad():
+            expected = vae.tiled_decode(latents).sample
+            counted = self._counted(vae)
+            got = vae_tiling.batched_tiled_decode(
+                vae, vae.tile_latent_min_size**2
+            )(latents).sample
+        self.assertEqual(set(counted.rows), {1})
+        torch.testing.assert_close(got, expected, rtol=0, atol=0)
+
+    def test_a_budget_of_zero_decodes_exactly_as_upstream_does(self):
+        import torch
+
+        vae, latents = self._tiled_vae("AutoencoderKL")
+        with torch.no_grad():
+            expected = vae.tiled_decode(latents).sample
+            counted = self._counted(vae)
+            got = vae_tiling.batched_tiled_decode(vae, 0)(latents).sample
+        self.assertEqual(set(counted.rows), {1})
+        torch.testing.assert_close(got, expected, rtol=0, atol=0)
+
+    def test_the_budget_caps_the_area_one_call_carries(self):
+        import torch
+
+        vae, latents = self._tiled_vae("AutoencoderKL")
+        window = vae.tile_latent_min_size
+        decoder = vae.decoder
+        for tiles_per_call in (1, 2, 4):
+            with self.subTest(tiles_per_call=tiles_per_call):
+                budget = window**2 * tiles_per_call
+                vae.decoder = decoder
+                counted = self._counted(vae)
+                with torch.no_grad():
+                    vae_tiling.batched_tiled_decode(vae, budget)(latents)
+                # No call may carry more latent area than the budget, which is what holds peak
+                # memory where the VAE's own window put it.
+                for shape in counted.shapes:
+                    self.assertLessEqual(shape[0] * shape[-2] * shape[-1], budget)
+                # The full-shape tiles spend the budget exactly, so the batch tracks it. Tiles
+                # clipped by the latent bounds are smaller, and group larger for the same area.
+                self.assertEqual(max(counted.rows), tiles_per_call)
+        vae.decoder = decoder
+
+    def test_a_tiled_decode_that_fits_in_one_tile_still_works(self):
+        import torch
+
+        # A single tile means one shape, one group, and no blending pass at all.
+        vae, _ = self._tiled_vae("AutoencoderKL")
+        latents = torch.randn(1, vae.config.latent_channels, 4, 4)
+        with torch.no_grad():
+            expected = vae.tiled_decode(latents).sample
+            got = vae_tiling.batched_tiled_decode(vae, 1 << 20)(latents).sample
+        torch.testing.assert_close(got, expected, rtol=0, atol=0)
 
 
 if __name__ == "__main__":

--- a/tests/core/test_vae_tiling.py
+++ b/tests/core/test_vae_tiling.py
@@ -397,9 +397,36 @@ class TestTileBatching(unittest.TestCase):
         self.assertIsNone(vae_tiling.batched_tiled_decode(stride_vae(), 4096))
         self.assertIsNotNone(vae_tiling.batched_tiled_decode(overlap_factor_vae(), 4096))
 
-    def test_the_budget_is_the_area_of_the_vaes_own_tile(self):
-        self.assertEqual(vae_tiling.default_tile_area(overlap_factor_vae()), 32 * 32)
-        self.assertIsNone(vae_tiling.default_tile_area(stride_vae()))
+    def test_the_tile_area_is_read_off_the_square_latent_window(self):
+        self.assertEqual(vae_tiling.tile_latent_area(overlap_factor_vae()), 32 * 32)
+        self.assertIsNone(vae_tiling.tile_latent_area(stride_vae()))
+
+    def test_an_unnarrowed_window_budgets_exactly_one_tile(self):
+        # The area a run gets when it asked for no window of its own, where batching has to be a
+        # no-op: the two areas are the same, so their geometric mean is that area, so one tile.
+        area = 128 * 128
+        self.assertEqual(vae_tiling.tile_batch_budget(area, area), area)
+
+    def test_a_narrower_window_lowers_the_area_a_call_carries_and_raises_the_tiles(self):
+        # Both of the things --vae_tile_size is asked for have to keep improving as it shrinks:
+        # less area per call than the VAE's own window, and more tiles sharing each round of
+        # collectives. Quartering the window's area does both by two.
+        default_area = 128 * 128
+        for latent, tiles, carried in ((64, 2, 8192), (32, 4, 4096), (16, 8, 2048), (8, 16, 1024)):
+            with self.subTest(latent_window=latent):
+                budget = vae_tiling.tile_batch_budget(default_area, latent * latent)
+                self.assertEqual(budget, carried)
+                self.assertEqual(budget // (latent * latent), tiles)
+                self.assertLess(budget, default_area)
+
+    def test_a_vae_with_no_square_window_is_not_batched(self):
+        self.assertIsNone(vae_tiling.tile_batch_budget(None, 1024))
+        self.assertIsNone(vae_tiling.tile_batch_budget(16384, None))
+
+    def test_the_budget_never_falls_below_a_single_tile(self):
+        # A tile larger than the VAE's own window cannot happen through --vae_tile_size, which
+        # refuses one, but a budget under a tile would decode nothing at all rather than one tile.
+        self.assertEqual(vae_tiling.tile_batch_budget(64, 4096), 4096)
 
     def _tiled_vae(self, name, batch=1):
         """A small VAE of class `name` at a narrowed window, and latents several tiles across"""
@@ -535,6 +562,35 @@ class TestTileBatching(unittest.TestCase):
                 # clipped by the latent bounds are smaller, and group larger for the same area.
                 self.assertEqual(max(counted.rows), tiles_per_call)
         vae.decoder = decoder
+
+    def test_the_narrowed_window_sets_the_batch_and_leaves_the_image_alone(self):
+        import torch
+        import diffusers
+
+        # The two ends of the rule joined up: the budget the runner computes from the VAE's own
+        # window and the narrowed one, spent by the decode that window produced.
+        kwargs, _, _ = TestEveryVAEARunnerLoads.VAES["AutoencoderKL"]
+        untouched = diffusers.AutoencoderKL(**kwargs).eval()
+        untouched.enable_tiling()
+        default_area = vae_tiling.tile_latent_area(untouched)
+
+        vae, latents = self._tiled_vae("AutoencoderKL")
+        narrowed_area = vae_tiling.tile_latent_area(vae)
+        budget = vae_tiling.tile_batch_budget(default_area, narrowed_area)
+        # Stated as the property rather than the numbers this particular stub lands on: the
+        # budget is the geometric mean, so it sits between the two areas it was taken from.
+        self.assertEqual(budget**2, default_area * narrowed_area)
+        self.assertLess(narrowed_area, budget)
+        self.assertLess(budget, default_area)
+
+        with torch.no_grad():
+            expected = vae.tiled_decode(latents).sample
+            counted = self._counted(vae)
+            got = vae_tiling.batched_tiled_decode(vae, budget)(latents).sample
+        self.assertEqual(max(counted.rows), budget // narrowed_area)
+        for shape in counted.shapes:
+            self.assertLess(shape[0] * shape[-2] * shape[-1], default_area)
+        torch.testing.assert_close(got, expected, rtol=0, atol=1e-4)
 
     def test_a_tiled_decode_that_fits_in_one_tile_still_works(self):
         import torch

--- a/tests/core/test_vae_tiling.py
+++ b/tests/core/test_vae_tiling.py
@@ -11,6 +11,60 @@ class StubVAE:
             setattr(self, name, value)
 
 
+def legacy_pair_vae():
+    """AutoencoderKL and friends: a pixel window, a latent window, an overlap fraction"""
+    return StubVAE(
+        tile_sample_min_size=256, tile_latent_min_size=32, tile_overlap_factor=0.25
+    )
+
+
+def stride_vae():
+    """Wan, Qwen-Image, the video VAEs: a pixel window and an explicit pixel stride"""
+    return StubVAE(
+        tile_sample_min_height=256,
+        tile_sample_min_width=256,
+        tile_sample_stride_height=192,
+        tile_sample_stride_width=192,
+        spatial_compression_ratio=8,
+    )
+
+
+def overlap_hw_vae():
+    """CogVideoX-style: pixel and latent windows keyed by height and width, plus fractions"""
+    return StubVAE(
+        tile_sample_min_height=256,
+        tile_sample_min_width=256,
+        tile_latent_min_height=32,
+        tile_latent_min_width=32,
+        tile_overlap_factor_height=0.25,
+        tile_overlap_factor_width=0.25,
+    )
+
+
+def asymmetric_vae():
+    """CogVideoX-style: a window taller than it is wide, which one edge cannot describe"""
+    return StubVAE(
+        tile_sample_min_height=240,
+        tile_sample_min_width=360,
+        tile_latent_min_height=30,
+        tile_latent_min_width=45,
+        tile_overlap_factor_height=1 / 6,
+        tile_overlap_factor_width=0.2,
+    )
+
+
+def per_axis_overlap_vae():
+    """A square window whose two axes carry their own overlap fractions"""
+    return StubVAE(
+        tile_sample_min_height=256,
+        tile_sample_min_width=256,
+        tile_latent_min_height=32,
+        tile_latent_min_width=40,
+        tile_overlap_factor_height=0.25,
+        tile_overlap_factor_width=0.2,
+    )
+
+
 class TestSupportProbe(unittest.TestCase):
 
     def test_the_method_alone_does_not_count_as_support(self):
@@ -27,6 +81,266 @@ class TestSupportProbe(unittest.TestCase):
         vae_tiling.require_vae_support(
             StubVAE(use_slicing=False), "slicing", "--enable_slicing"
         )
+
+
+class TestTileWindow(unittest.TestCase):
+
+    def test_reads_the_pixel_window_of_each_family(self):
+        self.assertEqual(vae_tiling.tile_window(legacy_pair_vae()), 256)
+        self.assertEqual(vae_tiling.tile_window(stride_vae()), 256)
+        self.assertEqual(vae_tiling.tile_window(overlap_hw_vae()), 256)
+
+    def test_a_vae_without_a_window_reports_none(self):
+        self.assertIsNone(vae_tiling.tile_window(StubVAE(tile_overlap_h=0.25)))
+        self.assertIsNone(vae_tiling.tile_plan(StubVAE(tile_overlap_h=0.25), 128))
+
+    def test_a_window_that_is_not_square_reports_none(self):
+        # One edge cannot set a 240x360 window: moving both to one number would leave the latent
+        # window on one axis describing a different region than the pixel window above it.
+        self.assertIsNone(vae_tiling.tile_window(asymmetric_vae()))
+        self.assertIsNone(vae_tiling.tile_plan(asymmetric_vae(), 240))
+
+    def test_spatial_ratio_falls_back_from_config_to_the_module(self):
+        self.assertEqual(vae_tiling.spatial_ratio(stride_vae()), 8)
+        self.assertIsNone(vae_tiling.spatial_ratio(legacy_pair_vae()))
+
+
+class TestTilePlan(unittest.TestCase):
+
+    def test_every_attribute_is_rescaled_by_the_same_factor(self):
+        plan = vae_tiling.tile_plan(stride_vae(), 128)
+        self.assertEqual(
+            plan,
+            {
+                "tile_sample_min_height": 128,
+                "tile_sample_min_width": 128,
+                "tile_sample_stride_height": 96,
+                "tile_sample_stride_width": 96,
+            },
+        )
+
+    def test_a_window_that_does_not_divide_whole_is_refused(self):
+        # 100px would put the latent window at 12.5, which no VAE can hold.
+        self.assertIsNone(vae_tiling.tile_plan(legacy_pair_vae(), 100))
+
+    def test_an_overlap_that_does_not_land_whole_is_refused(self):
+        # 200px gives a latent window of 25, and 25 x 0.75 truncates to a stride the pixel crop
+        # does not agree with, which assembles an image of the wrong size.
+        self.assertIsNone(vae_tiling.tile_plan(legacy_pair_vae(), 200))
+        self.assertIsNone(vae_tiling.tile_plan(overlap_hw_vae(), 200))
+        self.assertIsNotNone(vae_tiling.tile_plan(legacy_pair_vae(), 192))
+
+    def test_each_overlap_fraction_is_checked_against_its_own_axis(self):
+        # 32 x 0.75 and 40 x 0.8 both land whole, so the window stands. Checking every fraction
+        # against every latent window instead would fail it on 32 x 0.8 = 25.6.
+        self.assertIsNotNone(vae_tiling.tile_plan(per_axis_overlap_vae(), 256))
+        # 224px puts the width latent at 35, and 35 x 0.8 = 28 is whole, but the height latent
+        # lands at 28 and 28 x 0.75 = 21 is whole too, so this one stands on both axes.
+        self.assertIsNotNone(vae_tiling.tile_plan(per_axis_overlap_vae(), 224))
+
+    def test_an_unkeyed_overlap_fraction_covers_both_axes(self):
+        vae = StubVAE(
+            tile_sample_min_height=256,
+            tile_sample_min_width=256,
+            tile_latent_min_height=16,
+            tile_latent_min_width=16,
+            tile_overlap_factor=0.25,
+        )
+        self.assertIsNotNone(vae_tiling.tile_plan(vae, 64))
+        # 32px puts each latent window at 2, and 2 x 0.75 truncates to a stride of 1.
+        self.assertIsNone(vae_tiling.tile_plan(vae, 32))
+
+    def test_a_stride_below_one_latent_pixel_is_refused(self):
+        # 8px would leave a 6px stride, under this VAE's 8px latent pixel, and diffusers steps
+        # through the latents in a range() that would then be empty.
+        self.assertIsNone(vae_tiling.tile_plan(stride_vae(), 8))
+
+    def test_a_window_above_the_default_still_plans(self):
+        # _apply_vae_tile_size declines these itself, having the config to say why.
+        plan = vae_tiling.tile_plan(stride_vae(), 512)
+        self.assertEqual(plan["tile_sample_stride_height"], 384)
+
+
+class TestLatentRows(unittest.TestCase):
+    """What a planned tile leaves for --use_parallel_vae, which splits those rows across ranks"""
+
+    def test_rows_come_from_the_latent_window_where_the_vae_carries_one(self):
+        vae = legacy_pair_vae()
+        self.assertEqual(
+            vae_tiling.latent_rows(vae, vae_tiling.tile_plan(vae, 128)), 16
+        )
+
+    def test_rows_come_from_the_compression_ratio_otherwise(self):
+        vae = stride_vae()
+        self.assertEqual(
+            vae_tiling.latent_rows(vae, vae_tiling.tile_plan(vae, 128)), 16
+        )
+
+    def test_a_vae_that_says_neither_reports_none(self):
+        vae = StubVAE(tile_sample_min_height=256, tile_sample_min_width=256)
+        self.assertIsNone(vae_tiling.latent_rows(vae, vae_tiling.tile_plan(vae, 128)))
+
+    def test_the_smallest_window_can_be_asked_to_hold_a_row_per_rank(self):
+        vae = legacy_pair_vae()
+        # This VAE tiles at multiples of 32px, so 32 is the smallest that works at all, but eight
+        # ranks each need a latent row of their own and 32px only comes to four.
+        self.assertEqual(vae_tiling.smallest_tile_window(vae, 8, 256), 32)
+        self.assertEqual(
+            vae_tiling.smallest_tile_window(vae, 8, 256, min_latent_rows=8), 64
+        )
+
+
+class TestSnapping(unittest.TestCase):
+
+    def test_snapping_lands_on_the_next_workable_window_down(self):
+        pixels, plan = vae_tiling.snap_tile_window(legacy_pair_vae(), 200)
+        self.assertEqual(pixels, 192)
+        self.assertEqual(plan["tile_latent_min_size"], 24)
+
+    def test_snapping_keeps_a_window_that_already_works(self):
+        pixels, _ = vae_tiling.snap_tile_window(stride_vae(), 128)
+        self.assertEqual(pixels, 128)
+
+    def test_snapping_never_returns_a_larger_window(self):
+        for requested in range(1, 257):
+            pixels, _ = vae_tiling.snap_tile_window(overlap_hw_vae(), requested)
+            if pixels is not None:
+                self.assertLessEqual(pixels, requested)
+
+    def test_a_request_under_the_smallest_window_snaps_to_nothing(self):
+        pixels, plan = vae_tiling.snap_tile_window(stride_vae(), 8)
+        self.assertIsNone(pixels)
+        self.assertIsNone(plan)
+
+    def test_the_smallest_workable_window_is_reported_for_the_error_path(self):
+        self.assertEqual(vae_tiling.smallest_tile_window(stride_vae(), 8, 256), 12)
+        self.assertIsNone(vae_tiling.smallest_tile_window(StubVAE(), 8, 256))
+
+    def test_a_vae_with_unequal_height_and_width_windows_takes_no_size(self):
+        # One edge cannot describe a 240x360 window, so every size is refused and the caller is
+        # told that rather than being sent looking for a smaller one.
+        vae = asymmetric_vae()
+        self.assertIsNone(vae_tiling.smallest_tile_window(vae, 1, 240))
+        self.assertIsNone(vae_tiling.snap_tile_window(vae, 240)[0])
+
+
+class TestEveryVAEARunnerLoads(unittest.TestCase):
+    """Every VAE class the runner models load takes a --vae_tile_size and still decodes to the
+    size an untiled decode gives"""
+
+    # A tiny stand-in per class, small enough to decode on CPU. LTX2 pins its compression ratio
+    # because the config default describes more encoder stages than its decoder upsamples.
+    VAES = {
+        "AutoencoderKL": (
+            dict(
+                block_out_channels=[8, 8, 16, 16],
+                layers_per_block=1,
+                latent_channels=4,
+                norm_num_groups=8,
+                sample_size=256,
+                down_block_types=["DownEncoderBlock2D"] * 4,
+                up_block_types=["UpDecoderBlock2D"] * 4,
+            ),
+            False,
+            4,
+        ),
+        "AutoencoderKLFlux2": (
+            dict(
+                block_out_channels=[8, 8, 16, 16],
+                layers_per_block=1,
+                latent_channels=4,
+                norm_num_groups=8,
+                sample_size=256,
+            ),
+            False,
+            4,
+        ),
+        "AutoencoderKLWan": (
+            dict(base_dim=8, z_dim=4, dim_mult=[1, 2, 4, 4], num_res_blocks=1),
+            True,
+            4,
+        ),
+        "AutoencoderKLQwenImage": (
+            dict(base_dim=8, z_dim=4, dim_mult=[1, 2, 4, 4], num_res_blocks=1),
+            True,
+            4,
+        ),
+        "AutoencoderKLHunyuanVideo": (
+            dict(
+                block_out_channels=(8, 8, 16, 16),
+                layers_per_block=1,
+                latent_channels=4,
+                norm_num_groups=8,
+            ),
+            True,
+            4,
+        ),
+        "AutoencoderKLHunyuanVideo15": (
+            dict(
+                block_out_channels=(8, 8, 16, 16, 16),
+                layers_per_block=1,
+                latent_channels=4,
+            ),
+            True,
+            4,
+        ),
+        "AutoencoderKLLTX2Video": (
+            dict(
+                block_out_channels=(8, 16, 32, 32),
+                latent_channels=8,
+                layers_per_block=(1, 1, 1, 1, 1),
+                spatial_compression_ratio=32,
+            ),
+            True,
+            8,
+        ),
+    }
+    # Large enough that the output is several tiles across once the window is halved, since a
+    # decode that fits in one tile would pass without tiling anything.
+    LATENT_GRID = 16
+
+    def test_a_halved_window_decodes_to_the_same_size(self):
+        import torch
+        import diffusers
+
+        for name, (kwargs, video, channels) in self.VAES.items():
+            with self.subTest(vae=name):
+                cls = getattr(diffusers, name, None)
+                if cls is None:
+                    self.skipTest(f"{name} is not in diffusers {diffusers.__version__}")
+                vae = cls(**kwargs).eval()
+                if not hasattr(vae, "enable_tiling"):
+                    self.skipTest(
+                        f"diffusers {diffusers.__version__} cannot tile {name}"
+                    )
+
+                grid = self.LATENT_GRID
+                shape = (
+                    (1, channels, 1, grid, grid) if video else (1, channels, grid, grid)
+                )
+                torch.manual_seed(0)
+                latents = torch.randn(*shape)
+                with torch.no_grad():
+                    vae.disable_tiling()
+                    expected = vae.decode(latents).sample.shape[-2:]
+
+                # Same order as the runner: turn tiling on, then size its window.
+                vae.enable_tiling()
+                window = vae_tiling.tile_window(vae)
+                self.assertIsNotNone(
+                    window, f"{name} tiles but exposes no window this can read"
+                )
+                pixels, plan = vae_tiling.snap_tile_window(vae, window // 2)
+                self.assertIsNotNone(
+                    plan, f"{name} refused every window at or below {window // 2}"
+                )
+                for attr, value in plan.items():
+                    setattr(vae, attr, value)
+                with torch.no_grad():
+                    got = vae.decode(latents).sample.shape[-2:]
+                self.assertEqual(
+                    got, expected, f"{name} decoded at a {pixels}px tile window"
+                )
 
 
 if __name__ == "__main__":

--- a/tests/core/test_vae_tiling.py
+++ b/tests/core/test_vae_tiling.py
@@ -83,6 +83,31 @@ class TestSupportProbe(unittest.TestCase):
         )
 
 
+class TestTilePaddingError(unittest.TestCase):
+    """The padding failure a too-thin tile causes, told apart from failures with other causes"""
+
+    # Verbatim from AutoencoderKLLTX2Video decoding a 16x16 latent at a 128px window.
+    REAL = (
+        "Argument #4: Padding size should be less than the corresponding input dimension, "
+        "but got: padding (1, 1) at dimension 4 of input [1, 8, 3, 4, 1]"
+    )
+
+    def test_the_padding_failure_is_recognised(self):
+        self.assertTrue(vae_tiling.is_tile_padding_error(RuntimeError(self.REAL)))
+
+    def test_other_decode_failures_are_not(self):
+        for message in (
+            "expected scalar type BFloat16 but found Float",
+            "Expected all tensors to be on the same device",
+            "shape '[1, 8, 16, 16]' is invalid for input of size 1024",
+            "CUDA error: an illegal memory access was encountered",
+        ):
+            with self.subTest(error=message):
+                self.assertFalse(
+                    vae_tiling.is_tile_padding_error(RuntimeError(message))
+                )
+
+
 class TestTileWindow(unittest.TestCase):
 
     def test_reads_the_pixel_window_of_each_family(self):

--- a/tests/core/test_vae_tiling.py
+++ b/tests/core/test_vae_tiling.py
@@ -1,0 +1,33 @@
+import unittest
+
+from xfuser.core.utils import vae_tiling
+
+
+class StubVAE:
+    """Stands in for a diffusers VAE, carrying only the tiling attributes one would set"""
+
+    def __init__(self, **attrs):
+        for name, value in attrs.items():
+            setattr(self, name, value)
+
+
+class TestSupportProbe(unittest.TestCase):
+
+    def test_the_method_alone_does_not_count_as_support(self):
+        # Diffusers hands out enable_tiling from a mixin whether or not the class implements it,
+        # so a VAE can carry the method and still raise NotImplementedError when called.
+        unsupported = StubVAE(enable_tiling=lambda: None)
+        with self.assertRaises(ValueError):
+            vae_tiling.require_vae_support(unsupported, "tiling", "--enable_tiling")
+
+    def test_the_state_flag_counts_as_support(self):
+        vae_tiling.require_vae_support(
+            StubVAE(use_tiling=False), "tiling", "--enable_tiling"
+        )
+        vae_tiling.require_vae_support(
+            StubVAE(use_slicing=False), "slicing", "--enable_slicing"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/core/test_xfuser_attn.py
+++ b/tests/core/test_xfuser_attn.py
@@ -6,8 +6,11 @@ from xfuser.core.long_ctx_attention.ring.ring_flash_attn import (
     xdit_ring_flash_attn_func,
 )
 from xfuser.core.long_ctx_attention import xFuserLongContextAttention
-from flash_attn import flash_attn_func
+import pytest
 import os
+
+# A ROCm install has no flash-attn, and an import error here stops the whole directory collecting.
+flash_attn_func = pytest.importorskip("flash_attn").flash_attn_func
 
 from xfuser.model_executor.layers.attention_processor import (
     xFuserAttnProcessor2_0,

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -122,6 +122,7 @@ class xFuserArgs:
     enable_sequential_cpu_offload: bool = False
     enable_tiling: bool = False
     enable_slicing: bool = False
+    vae_tile_size: Optional[int] = None
     # DiTFastAttn arguments
     use_fast_attn: bool = False
     n_calib: int = 8
@@ -399,6 +400,15 @@ class xFuserArgs:
                  "batch size 1.",
         )
         runtime_group.add_argument(
+            "--vae_tile_size",
+            type=int,
+            default=None,
+            help="Edge, in output pixels, of each tile the VAE decodes. Smaller = less peak VRAM "
+                 "at VAE decode, more tiles. Turns tiling on by itself. A size the VAE cannot tile "
+                 "with exactly is rounded down to the next one that works, and a size above the "
+                 "VAE's own window is ignored.",
+        )
+        runtime_group.add_argument(
             "--use_fp8_t5_encoder",
             action="store_true",
             help="Quantize the T5 text encoder.",
@@ -614,6 +624,15 @@ class xFuserArgs:
             action="store_true",
             help="Making VAE decode one batch item at a time to save GPU memory. No effect at "
                  "batch size 1.",
+        )
+        parser.add_argument(
+            "--vae_tile_size",
+            type=int,
+            default=None,
+            help="Edge, in output pixels, of each tile the VAE decodes. Smaller = less peak VRAM "
+                 "at VAE decode, more tiles. Turns tiling on by itself. A size the VAE cannot tile "
+                 "with exactly is rounded down to the next one that works, and a size above the "
+                 "VAE's own window is ignored.",
         )
         parser.add_argument(
             "--use_int8_gemms",

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -406,7 +406,9 @@ class xFuserArgs:
             help="Edge, in output pixels, of each tile the VAE decodes. Smaller = less peak VRAM "
                  "at VAE decode, more tiles. Turns tiling on by itself. A size the VAE cannot tile "
                  "with exactly is rounded down to the next one that works, and a size above the "
-                 "VAE's own window is ignored.",
+                 "VAE's own window is ignored. Step down one size at a time and watch peak VRAM: "
+                 "the saving stops once the VAE is no longer what peaks, while small tiles visibly "
+                 "degrade the image, each one being normalized over less context than the last.",
         )
         runtime_group.add_argument(
             "--use_fp8_t5_encoder",
@@ -632,7 +634,9 @@ class xFuserArgs:
             help="Edge, in output pixels, of each tile the VAE decodes. Smaller = less peak VRAM "
                  "at VAE decode, more tiles. Turns tiling on by itself. A size the VAE cannot tile "
                  "with exactly is rounded down to the next one that works, and a size above the "
-                 "VAE's own window is ignored.",
+                 "VAE's own window is ignored. Step down one size at a time and watch peak VRAM: "
+                 "the saving stops once the VAE is no longer what peaks, while small tiles visibly "
+                 "degrade the image, each one being normalized over less context than the last.",
         )
         parser.add_argument(
             "--use_int8_gemms",

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -395,7 +395,8 @@ class xFuserArgs:
         runtime_group.add_argument(
             "--enable_slicing",
             action="store_true",
-            help="Making VAE decode a tile at a time to save GPU memory.",
+            help="Making VAE decode one batch item at a time to save GPU memory. No effect at "
+                 "batch size 1.",
         )
         runtime_group.add_argument(
             "--use_fp8_t5_encoder",
@@ -611,7 +612,8 @@ class xFuserArgs:
         parser.add_argument(
             "--enable_slicing",
             action="store_true",
-            help="Enable VAE slicing to save GPU memory.",
+            help="Making VAE decode one batch item at a time to save GPU memory. No effect at "
+                 "batch size 1.",
         )
         parser.add_argument(
             "--use_int8_gemms",

--- a/xfuser/core/utils/vae_parallel.py
+++ b/xfuser/core/utils/vae_parallel.py
@@ -1,0 +1,120 @@
+"""Which DistVAE adapter, if any, can shard a given diffusers VAE, and how to size it.
+
+DistVAE shards a VAE by rebuilding it out of sharded convolutions, norms and upsampling, so an
+adapter only fits a decoder or encoder assembled from the blocks it was written against. Which
+adapter fits which VAE class, and the numbers an adapter has to be told about the VAE, are knowledge
+about those two libraries and nothing else. Keeping it here means a runner model adds support by
+declaring it rather than by carrying its own copy of the wiring.
+"""
+
+import importlib
+from typing import Optional, Tuple
+
+import torch.nn as nn
+
+DECODER_MODULE = "distvae.modules.adapters.vae.decoder_adapters"
+ENCODER_MODULE = "distvae.modules.adapters.vae.encoder_adapters"
+# Adapters by name rather than import, so an installed DistVAE predating one of them fails naming
+# the adapter it lacks instead of on importing this module.
+TWO_D = "DecoderAdapter"
+WAN = "WanDecoderAdapter"
+WAN_ENCODER = "WanEncoderAdapter"
+
+
+def _wan_blocks() -> Tuple[type, ...]:
+    """The Wan decoder's block classes present in the installed diffusers"""
+    # Wan's VAE arrived in 0.34 and its residual up block later still, so both are optional.
+    try:
+        from diffusers.models.autoencoders import autoencoder_kl_wan
+    except ImportError:
+        return ()
+    found = (
+        getattr(autoencoder_kl_wan, name, None)
+        for name in ("WanUpBlock", "WanResidualUpBlock", "WanMidBlock")
+    )
+    return tuple(block for block in found if isinstance(block, type))
+
+
+def decoder_adapter_name(vae) -> Optional[str]:
+    """The DistVAE adapter that fits this VAE's decoder, None when none does"""
+    # The adapters assert this themselves, from inside a half-built replacement decoder. Asking
+    # first keeps an unsupported VAE from reaching that point, and lets a model be told it is
+    # unsupported rather than shown an assertion from a library it did not name.
+    decoder = getattr(vae, "decoder", None)
+    up_blocks = tuple(getattr(decoder, "up_blocks", None) or ())
+    if not up_blocks:
+        return None
+
+    from diffusers.models.unets.unet_2d_blocks import UpDecoderBlock2D
+
+    if all(isinstance(block, UpDecoderBlock2D) for block in up_blocks) and isinstance(
+        getattr(decoder, "conv_norm_out", None), nn.GroupNorm
+    ):
+        return TWO_D
+
+    wan_blocks = _wan_blocks()
+    if wan_blocks and all(isinstance(block, wan_blocks) for block in up_blocks):
+        if isinstance(getattr(decoder, "mid_block", None), wan_blocks):
+            return WAN
+    return None
+
+
+def _patch_size(vae) -> Optional[int]:
+    """The VAE's own patching factor, where it patches on top of its conv stack"""
+    patch_size = getattr(vae.config, "patch_size", None)
+    return patch_size if patch_size and patch_size > 1 else None
+
+
+def encoder_scale_factor(vae) -> int:
+    """The encoder's own spatial downsampling, which is what the encoder adapter shards by"""
+    # A VAE that patches folds that factor into its spatial ratio, and the adapter needs the conv
+    # stack's share of it alone: Cosmos 3's 16 is 8 from the encoder and 2 from patching.
+    factor = getattr(vae.config, "scale_factor_spatial", None) or 8
+    patch_size = _patch_size(vae)
+    return factor // patch_size if patch_size else factor
+
+
+def _adapter(module: str, name: str, vae) -> type:
+    try:
+        return getattr(importlib.import_module(module), name)
+    except (ImportError, AttributeError) as e:
+        raise ValueError(
+            f"The installed DistVAE does not provide {name}, which this VAE "
+            f"({type(vae).__name__}) needs. Try installing the latest DistVAE from "
+            f"https://github.com/xdit-project/DistVAE."
+        ) from e
+
+
+def parallelize_decoder(vae, vae_group) -> str:
+    """Replace this VAE's decoder with a sharded one, returning the adapter that did it"""
+    name = decoder_adapter_name(vae)
+    if name is None:
+        raise ValueError(
+            f"--use_parallel_vae cannot shard this VAE ({type(vae).__name__}): DistVAE has no "
+            f"adapter for its decoder blocks. Use --vae_tile_size to lower VAE decode memory "
+            f"instead."
+        )
+    decoder = _adapter(DECODER_MODULE, name, vae)(vae.decoder, vae_group=vae_group)
+    patch_size = _patch_size(vae)
+    # The adapter crops its output by the ratio it upsamples, and its patchify assumes no patching
+    # because Wan does none. A VAE that patches upsamples by that much again.
+    if patch_size and hasattr(decoder, "patchify"):
+        decoder.patchify.scale_factor = patch_size
+    vae.decoder = decoder.to(vae.device)
+    return name
+
+
+def parallelize_encoder(vae, vae_group) -> str:
+    """Replace this VAE's encoder with a sharded one, returning the adapter that did it"""
+    # DistVAE ships one encoder adapter, written for Wan's blocks, so the VAEs it can encode with
+    # are the ones it can decode with.
+    if decoder_adapter_name(vae) != WAN:
+        raise ValueError(
+            f"Parallel VAE encoding is not available for this VAE ({type(vae).__name__}): DistVAE "
+            f"only has {WAN_ENCODER}."
+        )
+    adapter = _adapter(ENCODER_MODULE, WAN_ENCODER, vae)
+    vae.encoder = adapter(
+        vae.encoder, vae_group=vae_group, vae_scale_factor=encoder_scale_factor(vae)
+    ).to(vae.device)
+    return WAN_ENCODER

--- a/xfuser/core/utils/vae_parallel.py
+++ b/xfuser/core/utils/vae_parallel.py
@@ -244,6 +244,38 @@ def _adapter(module: str, name: str, vae) -> type:
         ) from e
 
 
+def _keep_causal_cache_length(vae) -> None:
+    """Hold a recounting feature cache at the length the unsharded VAE would have given it
+
+    A causal VAE threads a list of cached frames through a call, one entry per causal
+    convolution, and Qwen-Image sizes that list by counting those convolutions afresh every
+    time, asking isinstance against its own class. Sharding replaces every one of them with an
+    adapter, so the count comes to zero, the list is empty, and the first convolution to reach
+    for its entry indexes off the end of it. Wan counts once when it is built and never notices.
+
+    Counting before the replacement and holding the answer is what the VAE would have done for
+    itself had it cached the count, and has to happen before either half is replaced, which is
+    why both entry points call it first and only the first call does anything.
+    """
+    if getattr(vae, "_distvae_cache_length_kept", False) or not hasattr(vae, "clear_cache"):
+        return
+    recount = vae.clear_cache
+    recount()
+    counts = {name: value for name, value in vars(vae).items() if name.endswith("conv_num")}
+    if not counts:
+        return
+
+    def clear_cache():
+        recount()
+        for name, count in counts.items():
+            setattr(vae, name, count)
+            # _conv_num goes with _feat_map, _enc_conv_num with _enc_feat_map.
+            setattr(vae, f"{name[: -len('conv_num')]}feat_map", [None] * count)
+
+    vae.clear_cache = clear_cache
+    vae._distvae_cache_length_kept = True
+
+
 def parallelize_decoder(vae, vae_group) -> str:
     """Replace this VAE's decoder with a sharded one, returning the adapter that did it"""
     name = decoder_adapter_name(vae)
@@ -253,6 +285,7 @@ def parallelize_decoder(vae, vae_group) -> str:
             f"adapter for its decoder blocks. Use --vae_tile_size to lower VAE decode memory "
             f"instead."
         )
+    _keep_causal_cache_length(vae)
     decoder = _adapter(DECODER_MODULE, name, vae)(vae.decoder, vae_group=vae_group)
     patch_size = _patch_size(vae)
     # The adapter crops its output by the ratio it upsamples, and its patchify assumes no patching
@@ -271,6 +304,7 @@ def parallelize_encoder(vae, vae_group) -> str:
             f"Parallel VAE encoding is not available for this VAE ({type(vae).__name__}): "
             f"DistVAE has no adapter for its encoder blocks."
         )
+    _keep_causal_cache_length(vae)
     adapter = _adapter(ENCODER_MODULE, name, vae)
     vae.encoder = adapter(
         vae.encoder, vae_group=vae_group, vae_scale_factor=encoder_scale_factor(vae)

--- a/xfuser/core/utils/vae_parallel.py
+++ b/xfuser/core/utils/vae_parallel.py
@@ -61,8 +61,11 @@ def decoder_adapter_name(vae) -> Optional[str]:
 
 def _patch_size(vae) -> Optional[int]:
     """The VAE's own patching factor, where it patches on top of its conv stack"""
+    # A single factor is Wan's spelling and the only one either adapter can act on. Flux 2 spells
+    # the pixel unshuffle at its boundary `(2, 2)`, which is not that and is not something an
+    # adapter takes, so anything other than one number reads as no patching.
     patch_size = getattr(vae.config, "patch_size", None)
-    return patch_size if patch_size and patch_size > 1 else None
+    return patch_size if isinstance(patch_size, int) and patch_size > 1 else None
 
 
 def encoder_scale_factor(vae) -> int:

--- a/xfuser/core/utils/vae_parallel.py
+++ b/xfuser/core/utils/vae_parallel.py
@@ -18,21 +18,45 @@ ENCODER_MODULE = "distvae.modules.adapters.vae.encoder_adapters"
 # the adapter it lacks instead of on importing this module.
 TWO_D = "DecoderAdapter"
 WAN = "WanDecoderAdapter"
+QWEN_IMAGE = "QwenImageDecoderAdapter"
+HUNYUAN_VIDEO = "HunyuanVideoDecoderAdapter"
+HUNYUAN_VIDEO_15 = "HunyuanVideo15DecoderAdapter"
+LTX2_VIDEO = "LTX2VideoDecoderAdapter"
 WAN_ENCODER = "WanEncoderAdapter"
 
+# Each family's decoder is recognised by the classes its up blocks and mid block are built from,
+# named here rather than imported: a VAE that arrived after the installed diffusers leaves its
+# entry empty and matches nothing, instead of failing this module's import for every other VAE.
+_FAMILIES = (
+    (WAN, "autoencoder_kl_wan", ("WanUpBlock", "WanResidualUpBlock"), ("WanMidBlock",)),
+    (QWEN_IMAGE, "autoencoder_kl_qwenimage", ("QwenImageUpBlock",), ("QwenImageMidBlock",)),
+    (
+        HUNYUAN_VIDEO,
+        "autoencoder_kl_hunyuan_video",
+        ("HunyuanVideoUpBlock3D",),
+        ("HunyuanVideoMidBlock3D",),
+    ),
+    (
+        HUNYUAN_VIDEO_15,
+        "autoencoder_kl_hunyuanvideo15",
+        ("HunyuanVideo15UpBlock3D",),
+        ("HunyuanVideo15MidBlock",),
+    ),
+    (LTX2_VIDEO, "autoencoder_kl_ltx2", ("LTX2VideoUpBlock3d",), ("LTX2VideoMidBlock3d",)),
+)
 
-def _wan_blocks() -> Tuple[type, ...]:
-    """The Wan decoder's block classes present in the installed diffusers"""
-    # Wan's VAE arrived in 0.34 and its residual up block later still, so both are optional.
+
+def _blocks(module: str, names: Tuple[str, ...]) -> Tuple[type, ...]:
+    """Those of these block classes the installed diffusers has"""
     try:
-        from diffusers.models.autoencoders import autoencoder_kl_wan
+        found = importlib.import_module(f"diffusers.models.autoencoders.{module}")
     except ImportError:
         return ()
-    found = (
-        getattr(autoencoder_kl_wan, name, None)
-        for name in ("WanUpBlock", "WanResidualUpBlock", "WanMidBlock")
+    return tuple(
+        block
+        for block in (getattr(found, name, None) for name in names)
+        if isinstance(block, type)
     )
-    return tuple(block for block in found if isinstance(block, type))
 
 
 def decoder_adapter_name(vae) -> Optional[str]:
@@ -52,11 +76,28 @@ def decoder_adapter_name(vae) -> Optional[str]:
     ):
         return TWO_D
 
-    wan_blocks = _wan_blocks()
-    if wan_blocks and all(isinstance(block, wan_blocks) for block in up_blocks):
-        if isinstance(getattr(decoder, "mid_block", None), wan_blocks):
-            return WAN
+    mid_block = getattr(decoder, "mid_block", None)
+    for name, module, up_names, mid_names in _FAMILIES:
+        up_types = _blocks(module, up_names)
+        mid_types = _blocks(module, mid_names)
+        # The mid block is checked too because these families fork one another closely enough
+        # that up blocks alone would not tell two of them apart.
+        if up_types and mid_types and all(isinstance(b, up_types) for b in up_blocks):
+            if isinstance(mid_block, mid_types):
+                return None if name == LTX2_VIDEO and _injects_noise(decoder) else name
     return None
+
+
+def _injects_noise(decoder) -> bool:
+    """Whether an LTX-2 decoder adds noise inside its residual blocks"""
+    # DistVAE cannot shard one that does: each rank would draw noise for its own rows, and the
+    # ranks together would not reconstruct what one rank draws. It refuses from inside a decoder
+    # it has already half-replaced, so this asks first. No released LTX-2 checkpoint turns it on.
+    return any(
+        getattr(block, "per_channel_scale1", None) is not None
+        or getattr(block, "per_channel_scale2", None) is not None
+        for block in decoder.modules()
+    )
 
 
 def _patch_size(vae) -> Optional[int]:

--- a/xfuser/core/utils/vae_parallel.py
+++ b/xfuser/core/utils/vae_parallel.py
@@ -101,6 +101,28 @@ def _blocks(module: str, names: Tuple[str, ...]) -> Tuple[type, ...]:
     )
 
 
+def restore_torch_group_norm() -> bool:
+    """Put torch.nn.GroupNorm back where AITER replaced it, reporting whether it had to
+
+    On ROCm, importing xfuser swaps torch.nn.GroupNorm for AITER's, a faster drop-in everywhere
+    but here. DistVAE finds the norms it has to shard by asking isinstance against torch's class,
+    and so does the check below for a 2D decoder; AITER's is not a subclass, so a VAE assembled
+    after the swap either reads as unsupported or keeps norms that reduce over one rank's band of
+    rows rather than over the whole image. Neither says so at the time.
+
+    The revert has to land before the VAE is built, so a caller that means to shard one calls
+    this while it is still deciding to.
+    """
+    # Imported here rather than at module scope: envs owns the swap, and it must not need
+    # anything under xfuser.core to be importable itself.
+    from xfuser.envs import _TORCH_GROUPNORM
+
+    if nn.GroupNorm.__module__ != "aiter.ops.groupnorm":
+        return False
+    nn.GroupNorm = _TORCH_GROUPNORM
+    return True
+
+
 def _family_of(half, attr: str) -> Optional[_Family]:
     """The family this half of a VAE belongs to, by the blocks it is assembled from
 

--- a/xfuser/core/utils/vae_parallel.py
+++ b/xfuser/core/utils/vae_parallel.py
@@ -8,7 +8,7 @@ declaring it rather than by carrying its own copy of the wiring.
 """
 
 import importlib
-from typing import Optional, Tuple
+from typing import NamedTuple, Optional, Tuple
 
 import torch.nn as nn
 
@@ -22,27 +22,69 @@ QWEN_IMAGE = "QwenImageDecoderAdapter"
 HUNYUAN_VIDEO = "HunyuanVideoDecoderAdapter"
 HUNYUAN_VIDEO_15 = "HunyuanVideo15DecoderAdapter"
 LTX2_VIDEO = "LTX2VideoDecoderAdapter"
-WAN_ENCODER = "WanEncoderAdapter"
 
-# Each family's decoder is recognised by the classes its up blocks and mid block are built from,
-# named here rather than imported: a VAE that arrived after the installed diffusers leaves its
-# entry empty and matches nothing, instead of failing this module's import for every other VAE.
+TWO_D_ENCODER = "EncoderAdapter"
+
+
+class _Family(NamedTuple):
+    """One VAE family: the adapters that fit its two halves, and the blocks that identify them"""
+
+    decoder: str
+    encoder: str
+    module: str
+    up_blocks: Tuple[str, ...]
+    down_blocks: Tuple[str, ...]
+    mid_block: Tuple[str, ...]
+
+
+# Each half of a family is recognised by the classes its blocks are built from, named here rather
+# than imported: a VAE that arrived after the installed diffusers leaves its entry empty and
+# matches nothing, instead of failing this module's import for every other VAE. The two halves are
+# recognised separately rather than one from the other, because sharding either one replaces its
+# blocks with adapters, and the half already sharded would no longer answer to anything.
 _FAMILIES = (
-    (WAN, "autoencoder_kl_wan", ("WanUpBlock", "WanResidualUpBlock"), ("WanMidBlock",)),
-    (QWEN_IMAGE, "autoencoder_kl_qwenimage", ("QwenImageUpBlock",), ("QwenImageMidBlock",)),
-    (
+    _Family(
+        WAN,
+        "WanEncoderAdapter",
+        "autoencoder_kl_wan",
+        ("WanUpBlock", "WanResidualUpBlock"),
+        # Wan 2.2 groups each encoder stage into a WanResidualDownBlock; 2.1 lays the same
+        # residual blocks, attentions and resamples out flat in one list.
+        ("WanResidualDownBlock", "WanResidualBlock", "WanAttentionBlock", "WanResample"),
+        ("WanMidBlock",),
+    ),
+    _Family(
+        QWEN_IMAGE,
+        "QwenImageEncoderAdapter",
+        "autoencoder_kl_qwenimage",
+        ("QwenImageUpBlock",),
+        ("QwenImageResidualBlock", "QwenImageAttentionBlock", "QwenImageResample"),
+        ("QwenImageMidBlock",),
+    ),
+    _Family(
         HUNYUAN_VIDEO,
+        "HunyuanVideoEncoderAdapter",
         "autoencoder_kl_hunyuan_video",
         ("HunyuanVideoUpBlock3D",),
+        ("HunyuanVideoDownBlock3D",),
         ("HunyuanVideoMidBlock3D",),
     ),
-    (
+    _Family(
         HUNYUAN_VIDEO_15,
+        "HunyuanVideo15EncoderAdapter",
         "autoencoder_kl_hunyuanvideo15",
         ("HunyuanVideo15UpBlock3D",),
+        ("HunyuanVideo15DownBlock3D",),
         ("HunyuanVideo15MidBlock",),
     ),
-    (LTX2_VIDEO, "autoencoder_kl_ltx2", ("LTX2VideoUpBlock3d",), ("LTX2VideoMidBlock3d",)),
+    _Family(
+        LTX2_VIDEO,
+        "LTX2VideoEncoderAdapter",
+        "autoencoder_kl_ltx2",
+        ("LTX2VideoUpBlock3d",),
+        ("LTX2VideoDownBlock3D",),
+        ("LTX2VideoMidBlock3d",),
+    ),
 )
 
 
@@ -57,6 +99,25 @@ def _blocks(module: str, names: Tuple[str, ...]) -> Tuple[type, ...]:
         for block in (getattr(found, name, None) for name in names)
         if isinstance(block, type)
     )
+
+
+def _family_of(half, attr: str) -> Optional[_Family]:
+    """The family this half of a VAE belongs to, by the blocks it is assembled from
+
+    Named for the attribute holding them, up_blocks or down_blocks, which is what _Family calls
+    the classes it expects to find there too.
+    """
+    blocks = tuple(getattr(half, attr, None) or ())
+    mid_block = getattr(half, "mid_block", None)
+    for family in _FAMILIES:
+        types = _blocks(family.module, getattr(family, attr))
+        mid_types = _blocks(family.module, family.mid_block)
+        # The mid block is checked too because these families fork one another closely enough
+        # that the blocks either side of it would not tell two of them apart.
+        if types and mid_types and all(isinstance(block, types) for block in blocks):
+            if isinstance(mid_block, mid_types):
+                return family
+    return None
 
 
 def decoder_adapter_name(vae) -> Optional[str]:
@@ -76,27 +137,43 @@ def decoder_adapter_name(vae) -> Optional[str]:
     ):
         return TWO_D
 
-    mid_block = getattr(decoder, "mid_block", None)
-    for name, module, up_names, mid_names in _FAMILIES:
-        up_types = _blocks(module, up_names)
-        mid_types = _blocks(module, mid_names)
-        # The mid block is checked too because these families fork one another closely enough
-        # that up blocks alone would not tell two of them apart.
-        if up_types and mid_types and all(isinstance(b, up_types) for b in up_blocks):
-            if isinstance(mid_block, mid_types):
-                return None if name == LTX2_VIDEO and _injects_noise(decoder) else name
-    return None
+    family = _family_of(decoder, "up_blocks")
+    if family is None:
+        return None
+    return None if _injects_noise(decoder) else family.decoder
 
 
-def _injects_noise(decoder) -> bool:
-    """Whether an LTX-2 decoder adds noise inside its residual blocks"""
+def encoder_adapter_name(vae) -> Optional[str]:
+    """The DistVAE adapter that fits this VAE's encoder, None when none does"""
+    encoder = getattr(vae, "encoder", None)
+    down_blocks = tuple(getattr(encoder, "down_blocks", None) or ())
+    if not down_blocks:
+        return None
+
+    from diffusers.models.unets.unet_2d_blocks import DownEncoderBlock2D
+
+    # The 2D encoder adapter asks only this of it: everything after the down blocks runs whole on
+    # every rank, so the norm it ends on is its own business in a way the decoder's is not.
+    if all(isinstance(block, DownEncoderBlock2D) for block in down_blocks):
+        return TWO_D_ENCODER
+
+    family = _family_of(encoder, "down_blocks")
+    if family is None:
+        return None
+    # No LTX-2 encoder injects noise, since only its decoder is offered the option, but the
+    # residual block adapter refuses either half that does and this is what asks first.
+    return None if _injects_noise(encoder) else family.encoder
+
+
+def _injects_noise(half) -> bool:
+    """Whether this half of an LTX-2 VAE adds noise inside its residual blocks"""
     # DistVAE cannot shard one that does: each rank would draw noise for its own rows, and the
-    # ranks together would not reconstruct what one rank draws. It refuses from inside a decoder
-    # it has already half-replaced, so this asks first. No released LTX-2 checkpoint turns it on.
+    # ranks together would not reconstruct what one rank draws. It refuses from inside a half it
+    # has already half-replaced, so this asks first. No released LTX-2 checkpoint turns it on.
     return any(
         getattr(block, "per_channel_scale1", None) is not None
         or getattr(block, "per_channel_scale2", None) is not None
-        for block in decoder.modules()
+        for block in half.modules()
     )
 
 
@@ -109,8 +186,24 @@ def _patch_size(vae) -> Optional[int]:
     return patch_size if isinstance(patch_size, int) and patch_size > 1 else None
 
 
+def _two_d_scale_factor(vae) -> Optional[int]:
+    """A 2D encoder's ratio, counted off its stages rather than read from its config"""
+    # These VAEs record no spatial ratio, and the 8 every shipped one comes to is a consequence of
+    # having four stages rather than a number stated anywhere. Counting the stages that downsample
+    # gets it right for a checkpoint with some other number of them.
+    from diffusers.models.unets.unet_2d_blocks import DownEncoderBlock2D
+
+    blocks = tuple(getattr(getattr(vae, "encoder", None), "down_blocks", None) or ())
+    if not blocks or not all(isinstance(block, DownEncoderBlock2D) for block in blocks):
+        return None
+    return 2 ** sum(1 for block in blocks if block.downsamplers)
+
+
 def encoder_scale_factor(vae) -> int:
     """The encoder's own spatial downsampling, which is what the encoder adapter shards by"""
+    counted = _two_d_scale_factor(vae)
+    if counted is not None:
+        return counted
     # A VAE that patches folds that factor into its spatial ratio, and the adapter needs the conv
     # stack's share of it alone: Cosmos 3's 16 is 8 from the encoder and 2 from patching.
     factor = getattr(vae.config, "scale_factor_spatial", None) or 8
@@ -150,15 +243,14 @@ def parallelize_decoder(vae, vae_group) -> str:
 
 def parallelize_encoder(vae, vae_group) -> str:
     """Replace this VAE's encoder with a sharded one, returning the adapter that did it"""
-    # DistVAE ships one encoder adapter, written for Wan's blocks, so the VAEs it can encode with
-    # are the ones it can decode with.
-    if decoder_adapter_name(vae) != WAN:
+    name = encoder_adapter_name(vae)
+    if name is None:
         raise ValueError(
-            f"Parallel VAE encoding is not available for this VAE ({type(vae).__name__}): DistVAE "
-            f"only has {WAN_ENCODER}."
+            f"Parallel VAE encoding is not available for this VAE ({type(vae).__name__}): "
+            f"DistVAE has no adapter for its encoder blocks."
         )
-    adapter = _adapter(ENCODER_MODULE, WAN_ENCODER, vae)
+    adapter = _adapter(ENCODER_MODULE, name, vae)
     vae.encoder = adapter(
         vae.encoder, vae_group=vae_group, vae_scale_factor=encoder_scale_factor(vae)
     ).to(vae.device)
-    return WAN_ENCODER
+    return name

--- a/xfuser/core/utils/vae_tiling.py
+++ b/xfuser/core/utils/vae_tiling.py
@@ -52,6 +52,16 @@ def require_vae_support(vae, feature: str, flag: str) -> None:
         )
 
 
+def is_tile_padding_error(error: BaseException) -> bool:
+    """Whether a decode failure is the padding error a too-narrow tile window causes"""
+    # Torch raises this from a pad deep inside the decoder, where a tile arrives thinner than the
+    # convolution's own padding: "Padding size should be less than the corresponding input
+    # dimension, but got: padding (1, 1) at dimension 4 of input [1, 8, 3, 4, 1]". Text is all
+    # there is to key on, and a rewording upstream only costs the hint, since anything unmatched
+    # reaches the caller as the decoder wrote it.
+    return "padding size should be less than" in str(error).lower()
+
+
 def tile_window(vae) -> Optional[int]:
     """The VAE's pixel-space tile edge, None if one number cannot describe it"""
     windows = [

--- a/xfuser/core/utils/vae_tiling.py
+++ b/xfuser/core/utils/vae_tiling.py
@@ -1,0 +1,21 @@
+"""What the installed diffusers can tile or slice.
+
+Everything here is knowledge about diffusers VAEs: which tiling attributes a class carries, how
+they relate, and which releases have them. Nothing reads xDiT config or touches a pipeline, so
+the policy around these numbers lives with the runner instead.
+"""
+
+import diffusers
+
+
+def require_vae_support(vae, feature: str, flag: str) -> None:
+    """Raise unless the installed diffusers really implements `feature` for this VAE"""
+    # Diffusers hands every autoencoder the enable_tiling and enable_slicing methods through a
+    # shared mixin, implemented or not, so their presence proves nothing. The state flag the mixin
+    # itself checks does. Both features also arrived class by class over several releases, Wan's in
+    # 0.34, one past the floor setup.py asks for.
+    if not hasattr(vae, f"use_{feature}"):
+        raise ValueError(
+            f"{flag} is not supported by this VAE ({type(vae).__name__}) in the installed "
+            f"diffusers {diffusers.__version__}."
+        )

--- a/xfuser/core/utils/vae_tiling.py
+++ b/xfuser/core/utils/vae_tiling.py
@@ -208,17 +208,18 @@ def tile_latent_area(vae) -> Optional[int]:
 def tile_batch_budget(default_area: Optional[int], tile_area: Optional[int]) -> Optional[int]:
     """The latent area one decoder call should carry, given the VAE's window and the narrowed one
 
-    Two costs pull against each other. Activation memory follows the area a call carries, so a
-    narrow window only saves memory if the batch leaves that area below the VAE's own. A round of
-    collectives costs the same whatever the call carries, so a narrow window only stays fast if
-    the batch is large enough to spread that cost over many tiles. Holding the area at the VAE's
-    own window would be fastest and would hand back every byte --vae_tile_size was asked to save;
-    batching a fixed number of tiles would save the most and give a small window back its
-    per-tile collective tax.
+    Halve --vae_tile_size and this halves: the budget is the geometric mean of the two areas,
+    which is the product of their two edges, so it is linear in the edge the caller asked for.
+    Equivalently, a batched decode at window W costs what an unbatched decode at the geometric
+    mean of W and the VAE's own window costs. At the VAE's own window the two are equal, the
+    budget is one tile, and a run that asked for nothing decodes exactly as it always did.
 
-    The geometric mean of the two areas moves both ways at once: halving the window's area halves
-    the area a call carries and doubles the tiles it carries. At the VAE's own window the two
-    areas are equal and this is one tile, so a run that asked for nothing decodes as it always did.
+    Two costs pull against each other, which is why the budget is neither of the obvious ones.
+    Activation memory follows the area a call carries, so holding that area at the VAE's own
+    window - the fastest choice - would hand back every byte a narrower window was set to save.
+    A round of collectives costs the same whatever the call carries, so batching a fixed number
+    of tiles - the thriftiest choice - would give a narrow window back the per-tile collective
+    tax that makes it slow. Scaling with the edge moves both ways at once.
     """
     if not default_area or not tile_area:
         return None

--- a/xfuser/core/utils/vae_tiling.py
+++ b/xfuser/core/utils/vae_tiling.py
@@ -5,6 +5,7 @@ they relate, and which releases have them. Nothing reads xDiT config or touches 
 the policy around these numbers lives with the runner instead.
 """
 
+import math
 from typing import Callable, Optional, Tuple
 
 import diffusers
@@ -194,14 +195,34 @@ def smallest_tile_window(
     return None
 
 
-def default_tile_area(vae) -> Optional[int]:
-    """The latent area of the VAE's own tile, None where the VAE has no square latent window"""
-    # Read before a narrower window is applied: this is the area the VAE was built to decode in
-    # one call, which is what makes it the right budget for a batch of tiles.
+def tile_latent_area(vae) -> Optional[int]:
+    """The latent area of the VAE's current tile, None where it has no square latent window"""
+    # Read either side of a narrowing to get both areas the batch budget is derived from: before,
+    # it is the area the VAE was built to decode in one call; after, the area the caller asked for.
     size = getattr(vae, "tile_latent_min_size", None)
     if not isinstance(size, int) or isinstance(size, bool) or size <= 0:
         return None
     return size * size
+
+
+def tile_batch_budget(default_area: Optional[int], tile_area: Optional[int]) -> Optional[int]:
+    """The latent area one decoder call should carry, given the VAE's window and the narrowed one
+
+    Two costs pull against each other. Activation memory follows the area a call carries, so a
+    narrow window only saves memory if the batch leaves that area below the VAE's own. A round of
+    collectives costs the same whatever the call carries, so a narrow window only stays fast if
+    the batch is large enough to spread that cost over many tiles. Holding the area at the VAE's
+    own window would be fastest and would hand back every byte --vae_tile_size was asked to save;
+    batching a fixed number of tiles would save the most and give a small window back its
+    per-tile collective tax.
+
+    The geometric mean of the two areas moves both ways at once: halving the window's area halves
+    the area a call carries and doubles the tiles it carries. At the VAE's own window the two
+    areas are equal and this is one tile, so a run that asked for nothing decodes as it always did.
+    """
+    if not default_area or not tile_area:
+        return None
+    return max(tile_area, math.isqrt(default_area * tile_area))
 
 
 def tiles_by_overlap_factor(vae) -> bool:
@@ -230,8 +251,9 @@ def batched_tiled_decode(vae, budget_elems: int) -> Optional[Callable]:
     much slower than the VAE's own. Tiles are independent and, away from the right and bottom
     edges, identically shaped, so they can be stacked on the batch dimension and share all of it.
 
-    `budget_elems` caps the latent area one call may carry. At 0, or wherever the budget only
-    fits one tile, this decodes a tile at a time and does exactly what upstream does.
+    `budget_elems` caps the latent area one call may carry; `tile_batch_budget` is what the runner
+    sizes it with. At 0, or wherever the budget only fits one tile, this decodes a tile at a time
+    and does exactly what upstream does.
     """
     if not tiles_by_overlap_factor(vae):
         return None
@@ -270,9 +292,8 @@ def batched_tiled_decode(vae, budget_elems: int) -> Optional[Callable]:
         for shape, indices in by_shape.items():
             # Budget by area rather than by tile count. Activation memory follows the area being
             # decoded, so one count would batch the widest tiles into an allocation the VAE was
-            # never sized for while barely helping the narrow ones. Area instead holds peak memory
-            # near where the VAE's own window already put it, and lets the batch grow as the
-            # window shrinks, which is where the fixed cost hurts.
+            # never sized for while barely helping the narrow ones. Edge tiles are clipped by the
+            # latent bounds and so group larger than the full-shape ones for the same area.
             area = max(1, shape[0] * shape[-2] * shape[-1])
             per_call = max(1, budget_elems // area) if budget_elems > 0 else 1
             for start in range(0, len(indices), per_call):

--- a/xfuser/core/utils/vae_tiling.py
+++ b/xfuser/core/utils/vae_tiling.py
@@ -1,11 +1,42 @@
-"""What the installed diffusers can tile or slice.
+"""What the installed diffusers can tile or slice, and how wide a window it can decode.
 
 Everything here is knowledge about diffusers VAEs: which tiling attributes a class carries, how
 they relate, and which releases have them. Nothing reads xDiT config or touches a pipeline, so
 the policy around these numbers lives with the runner instead.
 """
 
+from typing import Optional, Tuple
+
 import diffusers
+
+# The tiling window as diffusers spells it, across the shapes its VAEs use: a latent/pixel pair
+# (AutoencoderKL and friends), a pixel window plus a stride (Wan, Qwen-Image, the video VAEs), and
+# either of those keyed by height and width. Frame tiling is left out on purpose, being unrelated
+# to a spatial tile edge.
+PIXEL_ATTRS = (
+    "tile_sample_min_size",
+    "tile_sample_min_height",
+    "tile_sample_min_width",
+)
+LATENT_ATTRS = (
+    "tile_latent_min_size",
+    "tile_latent_min_height",
+    "tile_latent_min_width",
+)
+STRIDE_ATTRS = ("tile_sample_stride_height", "tile_sample_stride_width")
+SCALED_ATTRS = LATENT_ATTRS + STRIDE_ATTRS
+OVERLAP_ATTRS = (
+    "tile_overlap_factor",
+    "tile_overlap_factor_height",
+    "tile_overlap_factor_width",
+)
+# Which overlap fraction governs which latent window. A VAE that carries one unkeyed fraction
+# applies it to both axes.
+OVERLAP_AXES = {
+    "tile_latent_min_height": "tile_overlap_factor_height",
+    "tile_latent_min_width": "tile_overlap_factor_width",
+    "tile_latent_min_size": "tile_overlap_factor",
+}
 
 
 def require_vae_support(vae, feature: str, flag: str) -> None:
@@ -19,3 +50,134 @@ def require_vae_support(vae, feature: str, flag: str) -> None:
             f"{flag} is not supported by this VAE ({type(vae).__name__}) in the installed "
             f"diffusers {diffusers.__version__}."
         )
+
+
+def tile_window(vae) -> Optional[int]:
+    """The VAE's pixel-space tile edge, None if one number cannot describe it"""
+    windows = [
+        value
+        for attr in PIXEL_ATTRS
+        if isinstance(value := getattr(vae, attr, None), int) and value > 0
+    ]
+    if not windows:
+        return None
+    # A VAE that sizes height and width apart, as CogVideoX does at 240x360, has no single edge to
+    # set: moving both to one number would leave the latent window on one axis describing a
+    # different region than the pixel window above it.
+    if len(set(windows)) > 1:
+        return None
+    return windows[0]
+
+
+def _tile_defaults(vae) -> dict:
+    """Every tiling attribute the VAE carries, as the reference to rescale from"""
+    defaults = {}
+    for attr in PIXEL_ATTRS + SCALED_ATTRS + OVERLAP_ATTRS:
+        value = getattr(vae, attr, None)
+        if (
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and value > 0
+        ):
+            defaults[attr] = value
+    return defaults
+
+
+def spatial_ratio(vae) -> Optional[int]:
+    """Pixels per latent pixel, where the VAE says so; config first, since reading a config key
+    off the module is deprecated"""
+    for source in (getattr(vae, "config", None), vae):
+        ratio = (
+            getattr(source, "spatial_compression_ratio", None)
+            if source is not None
+            else None
+        )
+        if isinstance(ratio, int) and ratio > 0:
+            return ratio
+    return None
+
+
+def _is_whole(value: float) -> bool:
+    """Whole within float error, so 30 x (1 - 1/3) counts as 20 and not 20.000000000000004"""
+    return abs(value - round(value)) < 1e-9
+
+
+def tile_plan(vae, pixels: int) -> Optional[dict]:
+    """Every tiling attribute rescaled to a `pixels` window, or None if it can't land whole"""
+    # One knob, applied by scaling the whole set by the same factor, which keeps the pixel and
+    # latent windows describing the same region and keeps each VAE's own tile overlap.
+    window = tile_window(vae)
+    if window is None:
+        return None
+    defaults = _tile_defaults(vae)
+    plan = {attr: pixels for attr in PIXEL_ATTRS if attr in defaults}
+    for attr in SCALED_ATTRS:
+        if attr not in defaults:
+            continue
+        scaled = pixels * defaults[attr] / window
+        if scaled < 1 or not _is_whole(scaled):
+            return None
+        plan[attr] = round(scaled)
+    # Decoders that store an overlap fraction rather than a stride derive the stride by truncating
+    # latent x (1 - overlap) while cropping tiles on a separately truncated pixel width. Unless
+    # that product lands whole the two disagree and the assembled image comes out the wrong size,
+    # with nothing downstream to catch it.
+    for latent_attr, factor_attr in OVERLAP_AXES.items():
+        latent = plan.get(latent_attr)
+        factor = defaults.get(factor_attr, defaults.get("tile_overlap_factor"))
+        if latent is None or not isinstance(factor, float) or factor >= 1.0:
+            continue
+        if not _is_whole(latent * (1.0 - factor)):
+            return None
+    # A stride below one latent pixel divides down to a zero step, which raises out of range()
+    # inside diffusers rather than producing anything.
+    ratio = spatial_ratio(vae)
+    strides = [plan[attr] for attr in STRIDE_ATTRS if attr in plan]
+    if ratio is not None and min([pixels] + strides) < ratio:
+        return None
+    return plan
+
+
+def apply_tile_plan(vae, plan: dict) -> None:
+    """Set a planned window on the VAE"""
+    # Newer VAE classes also take these through enable_tiling(), but only some of them, with a
+    # different signature each, and the body is a plain assignment either way.
+    for attr, value in plan.items():
+        setattr(vae, attr, value)
+
+
+def latent_rows(vae, plan: dict) -> Optional[int]:
+    """How many latent rows a planned tile holds, None where the VAE does not say"""
+    latents = [plan[attr] for attr in LATENT_ATTRS if attr in plan]
+    if latents:
+        return min(latents)
+    ratio = spatial_ratio(vae)
+    pixels = [plan[attr] for attr in PIXEL_ATTRS if attr in plan]
+    if ratio is None or not pixels:
+        return None
+    return min(pixels) // ratio
+
+
+def snap_tile_window(vae, pixels: int) -> Tuple[Optional[int], Optional[dict]]:
+    """The largest workable window at or below `pixels`, and the attributes that set it"""
+    for candidate in range(pixels, 0, -1):
+        plan = tile_plan(vae, candidate)
+        if plan is not None:
+            return candidate, plan
+    return None, None
+
+
+def smallest_tile_window(
+    vae, floor: int, ceiling: int, min_latent_rows: int = 1
+) -> Optional[int]:
+    """The first window from `floor` up that works and holds `min_latent_rows` latent rows, so a
+    refusal can name a size that would be accepted
+    """
+    for pixels in range(floor, ceiling + 1):
+        plan = tile_plan(vae, pixels)
+        if plan is None:
+            continue
+        rows = latent_rows(vae, plan)
+        if rows is None or rows >= min_latent_rows:
+            return pixels
+    return None

--- a/xfuser/core/utils/vae_tiling.py
+++ b/xfuser/core/utils/vae_tiling.py
@@ -5,9 +5,10 @@ they relate, and which releases have them. Nothing reads xDiT config or touches 
 the policy around these numbers lives with the runner instead.
 """
 
-from typing import Optional, Tuple
+from typing import Callable, Optional, Tuple
 
 import diffusers
+import torch
 
 # The tiling window as diffusers spells it, across the shapes its VAEs use: a latent/pixel pair
 # (AutoencoderKL and friends), a pixel window plus a stride (Wan, Qwen-Image, the video VAEs), and
@@ -191,3 +192,123 @@ def smallest_tile_window(
         if rows is None or rows >= min_latent_rows:
             return pixels
     return None
+
+
+def default_tile_area(vae) -> Optional[int]:
+    """The latent area of the VAE's own tile, None where the VAE has no square latent window"""
+    # Read before a narrower window is applied: this is the area the VAE was built to decode in
+    # one call, which is what makes it the right budget for a batch of tiles.
+    size = getattr(vae, "tile_latent_min_size", None)
+    if not isinstance(size, int) or isinstance(size, bool) or size <= 0:
+        return None
+    return size * size
+
+
+def tiles_by_overlap_factor(vae) -> bool:
+    """Whether this VAE tiles with the loop `batched_tiled_decode` reimplements"""
+    # AutoencoderKL and AutoencoderKLFlux2 walk one square latent window at a stride derived from
+    # an overlap fraction. Wan, Qwen-Image and the video VAEs walk a stride they store outright,
+    # over a loop with different blending and a frame axis, and keep their own tiled_decode.
+    if any(getattr(vae, attr, None) for attr in STRIDE_ATTRS):
+        return False
+    return (
+        isinstance(getattr(vae, "tile_latent_min_size", None), int)
+        and isinstance(getattr(vae, "tile_sample_min_size", None), int)
+        and isinstance(getattr(vae, "tile_overlap_factor", None), float)
+        and callable(getattr(vae, "blend_v", None))
+        and callable(getattr(vae, "blend_h", None))
+    )
+
+
+def batched_tiled_decode(vae, budget_elems: int) -> Optional[Callable]:
+    """A tiled_decode for `vae` that decodes same-shaped tiles in one call, None where it can't
+
+    Upstream decodes one tile per decoder call, and under --use_parallel_vae every one of those
+    calls pays a cost that does not shrink with the tile: a Patchify, a halo exchange per
+    convolution, a reduction per norm, and a DePatchify to gather the result. Narrowing the window
+    to save memory therefore multiplies a fixed cost, which is what makes a small tile size so
+    much slower than the VAE's own. Tiles are independent and, away from the right and bottom
+    edges, identically shaped, so they can be stacked on the batch dimension and share all of it.
+
+    `budget_elems` caps the latent area one call may carry. At 0, or wherever the budget only
+    fits one tile, this decodes a tile at a time and does exactly what upstream does.
+    """
+    if not tiles_by_overlap_factor(vae):
+        return None
+
+    from diffusers.models.autoencoders.vae import DecoderOutput
+
+    # Some classes hold the flag and a None conv, others only the conv; both spellings mean the
+    # same thing, and a class carrying neither has no post-quant step.
+    use_post_quant_conv = getattr(getattr(vae, "config", None), "use_post_quant_conv", None)
+    if use_post_quant_conv is None:
+        use_post_quant_conv = getattr(vae, "post_quant_conv", None) is not None
+
+    def tiled_decode(z, return_dict: bool = True):
+        overlap_size = int(vae.tile_latent_min_size * (1 - vae.tile_overlap_factor))
+        blend_extent = int(vae.tile_sample_min_size * vae.tile_overlap_factor)
+        row_limit = vae.tile_sample_min_size - blend_extent
+
+        tiles = []
+        for i in range(0, z.shape[2], overlap_size):
+            for j in range(0, z.shape[3], overlap_size):
+                tile = z[
+                    :,
+                    :,
+                    i : i + vae.tile_latent_min_size,
+                    j : j + vae.tile_latent_min_size,
+                ]
+                if use_post_quant_conv:
+                    tile = vae.post_quant_conv(tile)
+                tiles.append(tile)
+
+        by_shape = {}
+        for index, tile in enumerate(tiles):
+            by_shape.setdefault(tuple(tile.shape), []).append(index)
+
+        decoded = [None] * len(tiles)
+        for shape, indices in by_shape.items():
+            # Budget by area rather than by tile count. Activation memory follows the area being
+            # decoded, so one count would batch the widest tiles into an allocation the VAE was
+            # never sized for while barely helping the narrow ones. Area instead holds peak memory
+            # near where the VAE's own window already put it, and lets the batch grow as the
+            # window shrinks, which is where the fixed cost hurts.
+            area = max(1, shape[0] * shape[-2] * shape[-1])
+            per_call = max(1, budget_elems // area) if budget_elems > 0 else 1
+            for start in range(0, len(indices), per_call):
+                group = indices[start : start + per_call]
+                # One tile is handed over as it stands, so a budget that fits one tile leaves the
+                # decoder the same tensor upstream would have given it.
+                batched = (
+                    tiles[group[0]]
+                    if len(group) == 1
+                    else torch.cat([tiles[k] for k in group], dim=0)
+                )
+                out = vae.decoder(batched)
+                stride = out.shape[0] // len(group)
+                for n, k in enumerate(group):
+                    decoded[k] = out[n * stride : (n + 1) * stride]
+
+        columns = len(range(0, z.shape[3], overlap_size))
+        rows = [decoded[k : k + columns] for k in range(0, len(decoded), columns)]
+
+        # Upstream's assembly, unchanged. blend_v and blend_h write into the tile they are given,
+        # so each tile is blended against neighbours that were themselves already blended, and the
+        # scan order that produces is part of the result.
+        result_rows = []
+        for i, row in enumerate(rows):
+            result_row = []
+            for j, tile in enumerate(row):
+                if i > 0:
+                    tile = vae.blend_v(rows[i - 1][j], tile, blend_extent)
+                if j > 0:
+                    tile = vae.blend_h(row[j - 1], tile, blend_extent)
+                result_row.append(tile[:, :, :row_limit, :row_limit])
+            result_rows.append(torch.cat(result_row, dim=3))
+
+        dec = torch.cat(result_rows, dim=2)
+        if not return_dict:
+            return (dec,)
+        return DecoderOutput(sample=dec)
+
+    return tiled_decode

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -346,7 +346,11 @@ class xFuserModel(abc.ABC):
                 vae_tiling.require_vae_support(vae, "tiling", tiling_flag)
                 log(f"Enabling VAE tiling on {type(vae).__name__}...")
                 vae.enable_tiling()
+                # Read the VAE's own window before the next line can narrow it: that window is
+                # the batch budget, so tiling smaller costs the same per call as not tiling.
+                budget_elems = vae_tiling.default_tile_area(vae)
                 tile_window = self._apply_vae_tile_size(vae)
+                self._install_vae_tile_batching(vae, budget_elems)
             # Installed either way, so a decode that OOMs with tiling off still says so.
             self._install_vae_decode_guard(vae, tile_window)
 
@@ -1145,6 +1149,22 @@ class xFuserModel(abc.ABC):
              if smallest else
              f", and no size up to this VAE's own {window}px window gives them one each.")
         )
+
+    def _install_vae_tile_batching(self, vae, budget_elems: Optional[int]) -> None:
+        """Decode a tiled VAE's same-shaped tiles together, within one tile's worth of area"""
+        # Every decoder call costs the same whatever the tile, and under --use_parallel_vae that
+        # cost is a round of collectives rather than arithmetic, so a narrow window pays it over
+        # and over. Batching spends the VAE's own tile area per call instead of one tile, which
+        # leaves the default window decoding exactly as it did and stops the smaller windows
+        # paying for their size twice.
+        if budget_elems is None:
+            return
+        batched = vae_tiling.batched_tiled_decode(vae, budget_elems)
+        if batched is None:
+            return
+        vae.tiled_decode = batched
+        log(f"VAE tiled decode will batch tiles up to {budget_elems} latent elements per call "
+            f"on {type(vae).__name__}.")
 
     def _install_vae_decode_guard(self, vae, tile_window: Optional[int] = None) -> None:
         # Point a failed VAE decode at the knob that fixes it. Success path untouched.

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -344,7 +344,9 @@ class xFuserModel(abc.ABC):
         """ Validate if the model supports requested config """
         for key in ModelCapabilities.__annotations__.keys():
             config_value = getattr(config, key, None)  # Some config options might not be set in the CLI, such as support for specific attention backends.
-            if isinstance(config_value, int):
+            # bool subclasses int, so a boolean flag reaching the degree branch below is
+            # tested with True > 1 and never refused.
+            if isinstance(config_value, int) and not isinstance(config_value, bool):
                 if not getattr(self.capabilities, key) and config_value > 1:
                     raise ValueError(f"Model {self.settings.model_name} does not support {key}.")
             else:

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -345,11 +345,13 @@ class xFuserModel(abc.ABC):
                 vae_tiling.require_vae_support(vae, "tiling", tiling_flag)
                 log(f"Enabling VAE tiling on {type(vae).__name__}...")
                 vae.enable_tiling()
-                # Read the VAE's own window before the next line can narrow it: that window is
-                # the batch budget, so tiling smaller costs the same per call as not tiling.
-                budget_elems = vae_tiling.default_tile_area(vae)
+                # Read the VAE's own window before the next line can narrow it: the budget is
+                # derived from both areas, so both have to be read either side of the narrowing.
+                default_area = vae_tiling.tile_latent_area(vae)
                 tile_window = self._apply_vae_tile_size(vae)
-                self._install_vae_tile_batching(vae, budget_elems)
+                self._install_vae_tile_batching(
+                    vae, default_area, vae_tiling.tile_latent_area(vae)
+                )
             # Installed either way, so a decode that OOMs with tiling off still says so.
             self._install_vae_decode_guard(vae, tile_window)
 
@@ -1149,13 +1151,15 @@ class xFuserModel(abc.ABC):
              f", and no size up to this VAE's own {window}px window gives them one each.")
         )
 
-    def _install_vae_tile_batching(self, vae, budget_elems: Optional[int]) -> None:
-        """Decode a tiled VAE's same-shaped tiles together, within one tile's worth of area"""
+    def _install_vae_tile_batching(
+        self, vae, default_area: Optional[int], tile_area: Optional[int]
+    ) -> None:
+        """Decode a tiled VAE's same-shaped tiles together, within a budget the window sets"""
         # Every decoder call costs the same whatever the tile, and under --use_parallel_vae that
         # cost is a round of collectives rather than arithmetic, so a narrow window pays it over
-        # and over. Batching spends the VAE's own tile area per call instead of one tile, which
-        # leaves the default window decoding exactly as it did and stops the smaller windows
-        # paying for their size twice.
+        # and over. Batching spreads one round over many tiles without taking back all of the
+        # memory the narrow window was asked for; tile_batch_budget is where that balance is set.
+        budget_elems = vae_tiling.tile_batch_budget(default_area, tile_area)
         if budget_elems is None:
             return
         batched = vae_tiling.batched_tiled_decode(vae, budget_elems)
@@ -1163,7 +1167,7 @@ class xFuserModel(abc.ABC):
             return
         vae.tiled_decode = batched
         log(f"VAE tiled decode will batch tiles up to {budget_elems} latent elements per call "
-            f"on {type(vae).__name__}.")
+            f"on {type(vae).__name__} (its own window carries {default_area}).")
 
     def _install_vae_decode_guard(self, vae, tile_window: Optional[int] = None) -> None:
         # Point a failed VAE decode at the knob that fixes it. Success path untouched.

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -325,15 +325,16 @@ class xFuserModel(abc.ABC):
         if getattr(self.config, "use_spargeattn_head_balance", False):
             log("Enabling Sparge block-sparse head balancing...")
 
-        if self.config.enable_slicing:
-            vae_tiling.require_vae_support(self.pipe.vae, "slicing", "--enable_slicing")
-            log("Enabling VAE slicing...")
-            self.pipe.vae.enable_slicing()
+        for vae in self._decoding_vaes():
+            if self.config.enable_slicing:
+                vae_tiling.require_vae_support(vae, "slicing", "--enable_slicing")
+                log(f"Enabling VAE slicing on {type(vae).__name__}...")
+                vae.enable_slicing()
 
-        if self.config.enable_tiling:
-            vae_tiling.require_vae_support(self.pipe.vae, "tiling", "--enable_tiling")
-            log("Enabling VAE tiling...")
-            self.pipe.vae.enable_tiling()
+            if self.config.enable_tiling:
+                vae_tiling.require_vae_support(vae, "tiling", "--enable_tiling")
+                log(f"Enabling VAE tiling on {type(vae).__name__}...")
+                vae.enable_tiling()
 
         if self.config.enable_sequential_cpu_offload:
             log("Enabling sequential CPU offload...")
@@ -342,6 +343,19 @@ class xFuserModel(abc.ABC):
             log("Enabling model CPU offload...")
             self.pipe.enable_model_cpu_offload()
 
+    def _decoding_vaes(self) -> List:
+        """ Every VAE a run decodes through, staged models included """
+        # A model that decodes in stages loads a second pipeline with its own VAE, and the later
+        # stage is the one at full resolution, so leaving it out would aim VAE options at the
+        # smaller decode. Collected here by name rather than left to each subclass, since a
+        # subclass that forgets gets no error, only options that miss the largest decode.
+        vaes = []
+        for pipe in (self.pipe, getattr(self, "second_pipe", None)):
+            vae = getattr(pipe, "vae", None)
+            # Stages sometimes share one VAE, which must not be wrapped or sized twice.
+            if vae is not None and not any(vae is seen for seen in vaes):
+                vaes.append(vae)
+        return vaes
 
     def _validate_config(self, config: xFuserArgs) -> None:
         """ Validate if the model supports requested config """

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -21,8 +21,10 @@ from xfuser.envs import (
     _is_hip,
     _is_cuda,
 )
-from xfuser.core.distributed.parallel_state import get_fs_group
-from xfuser.core.utils import vae_tiling
+from xfuser.core.distributed.parallel_state import (
+    get_fs_group,
+    get_vae_parallel_world_size,
+)
 from xfuser.core.utils.runner_utils import (
     log,
     load_dataset_prompts,
@@ -35,6 +37,7 @@ from xfuser.core.utils.runner_utils import (
     _use_aiter_fp8_rdna4,
     rgetattr,
 )
+from xfuser.core.utils import vae_tiling
 
 from xfuser.core.distributed import (
     get_world_group,
@@ -325,16 +328,23 @@ class xFuserModel(abc.ABC):
         if getattr(self.config, "use_spargeattn_head_balance", False):
             log("Enabling Sparge block-sparse head balancing...")
 
+        # A tile size is a request to tile, so it turns tiling on by itself. LTX 2.3 tiles its
+        # stage-2 VAE at load, and without this the only way to size that window would be
+        # --enable_tiling, which tiles every stage to reach the one that ran out of memory.
+        tiling = self.config.enable_tiling or self.config.vae_tile_size is not None
+        tiling_flag = "--enable_tiling" if self.config.enable_tiling else "--vae_tile_size"
+
         for vae in self._decoding_vaes():
             if self.config.enable_slicing:
                 vae_tiling.require_vae_support(vae, "slicing", "--enable_slicing")
                 log(f"Enabling VAE slicing on {type(vae).__name__}...")
                 vae.enable_slicing()
 
-            if self.config.enable_tiling:
-                vae_tiling.require_vae_support(vae, "tiling", "--enable_tiling")
+            if tiling:
+                vae_tiling.require_vae_support(vae, "tiling", tiling_flag)
                 log(f"Enabling VAE tiling on {type(vae).__name__}...")
                 vae.enable_tiling()
+                self._apply_vae_tile_size(vae)
 
         if self.config.enable_sequential_cpu_offload:
             log("Enabling sequential CPU offload...")
@@ -343,12 +353,13 @@ class xFuserModel(abc.ABC):
             log("Enabling model CPU offload...")
             self.pipe.enable_model_cpu_offload()
 
+
     def _decoding_vaes(self) -> List:
         """ Every VAE a run decodes through, staged models included """
         # A model that decodes in stages loads a second pipeline with its own VAE, and the later
-        # stage is the one at full resolution, so leaving it out would aim VAE options at the
+        # stage is the one at full resolution, so leaving it out would aim --vae_tile_size at the
         # smaller decode. Collected here by name rather than left to each subclass, since a
-        # subclass that forgets gets no error, only options that miss the largest decode.
+        # subclass that forgets gets no error, only a flag that misses the largest decode.
         vaes = []
         for pipe in (self.pipe, getattr(self, "second_pipe", None)):
             vae = getattr(pipe, "vae", None)
@@ -361,8 +372,6 @@ class xFuserModel(abc.ABC):
         """ Validate if the model supports requested config """
         for key in ModelCapabilities.__annotations__.keys():
             config_value = getattr(config, key, None)  # Some config options might not be set in the CLI, such as support for specific attention backends.
-            # bool subclasses int, so a boolean flag reaching the degree branch below is
-            # tested with True > 1 and never refused.
             if isinstance(config_value, int) and not isinstance(config_value, bool):
                 if not getattr(self.capabilities, key) and config_value > 1:
                     raise ValueError(f"Model {self.settings.model_name} does not support {key}.")
@@ -457,6 +466,13 @@ class xFuserModel(abc.ABC):
         if config.distilled_transformer_path or config.distilled_transformer_2_path:
             if not self.capabilities.supports_distilled_weights:
                 raise ValueError(f"Model {self.settings.model_name} does not support distilled_transformer_path or distilled_transformer_2_path params.")
+
+        if config.vae_tile_size is not None:
+            if config.vae_tile_size <= 0:
+                raise ValueError(f"--vae_tile_size must be positive, got {config.vae_tile_size}.")
+            if not self.capabilities.enable_tiling:
+                raise ValueError(f"--vae_tile_size decodes the VAE in tiles, which model "
+                                 f"{self.settings.model_name} does not support.")
 
 
     def _get_compile_mode(self) -> str:
@@ -1054,6 +1070,63 @@ class xFuserModel(abc.ABC):
             return output
 
         self.pipe.vae.decode = decode_wrapper
+
+    def _apply_vae_tile_size(self, vae) -> None:
+        """ Narrow this VAE's tile window to --vae_tile_size, where one was asked for """
+        # The default window tracks the VAE's training resolution and never shrinks for an
+        # above-training-res decode, so a single tile can outgrow free VRAM. This shrinks it.
+        requested = self.config.vae_tile_size
+        if requested is None:
+            return
+        window = vae_tiling.tile_window(vae)
+        if window is None:
+            raise ValueError(
+                f"Model {self.settings.model_name} does not support --vae_tile_size: its VAE "
+                f"({type(vae).__name__}) has no single pixel-space tile window that one size sets."
+            )
+        if requested > window:
+            log(f"--vae_tile_size {requested} is larger than this VAE's {window}px tile window, "
+                f"which would raise peak memory rather than lower it; leaving it at {window}px.")
+            return
+        pixels, plan = vae_tiling.snap_tile_window(vae, requested)
+        if plan is None:
+            smallest = vae_tiling.smallest_tile_window(vae, requested, window)
+            raise ValueError(
+                f"--vae_tile_size {requested} is not a window this VAE ({type(vae).__name__}) "
+                f"can tile with" + (f"; the smallest that works is {smallest}px."
+                                    if smallest else
+                                    f", and neither is any size up to its own {window}px window.")
+            )
+        if pixels != requested:
+            log(f"--vae_tile_size {requested} is not a window this VAE can tile with exactly; "
+                f"using the next one down at {pixels}px.")
+        self._check_vae_tile_size_against_parallel_vae(vae, pixels, plan, window)
+        vae_tiling.apply_tile_plan(vae, plan)
+        log(f"VAE tile window set to {pixels}px "
+            f"({', '.join(f'{a}={v}' for a, v in sorted(plan.items()))})")
+
+    def _check_vae_tile_size_against_parallel_vae(
+        self, vae, pixels: int, plan: dict, window: int
+    ) -> None:
+        # The two knobs divide the same axis: diffusers hands the decoder one tile, and DistVAE
+        # then splits that tile's latent rows across the VAE group. Under a row per rank it splits
+        # into fewer patches than there are ranks, and the surplus ranks index off the end of the
+        # split rather than reporting anything.
+        if not (self.config.use_parallel_vae and self.capabilities.use_parallel_vae):
+            return
+        ranks = get_vae_parallel_world_size()
+        rows = vae_tiling.latent_rows(vae, plan)
+        if ranks < 2 or rows is None or rows >= ranks:
+            return
+        smallest = vae_tiling.smallest_tile_window(vae, pixels, window, min_latent_rows=ranks)
+        raise ValueError(
+            f"--vae_tile_size {pixels} leaves {rows} latent rows for the {ranks} ranks "
+            f"--use_parallel_vae splits each tile across" +
+            (f"; the smallest window with a row per rank is {smallest}px."
+             if smallest else
+             f", and no size up to this VAE's own {window}px window gives them one each.")
+        )
+
 
     @abc.abstractmethod
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -22,6 +22,7 @@ from xfuser.envs import (
     _is_cuda,
 )
 from xfuser.core.distributed.parallel_state import get_fs_group
+from xfuser.core.utils import vae_tiling
 from xfuser.core.utils.runner_utils import (
     log,
     load_dataset_prompts,
@@ -325,10 +326,12 @@ class xFuserModel(abc.ABC):
             log("Enabling Sparge block-sparse head balancing...")
 
         if self.config.enable_slicing:
+            vae_tiling.require_vae_support(self.pipe.vae, "slicing", "--enable_slicing")
             log("Enabling VAE slicing...")
             self.pipe.vae.enable_slicing()
 
         if self.config.enable_tiling:
+            vae_tiling.require_vae_support(self.pipe.vae, "tiling", "--enable_tiling")
             log("Enabling VAE tiling...")
             self.pipe.vae.enable_tiling()
 

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -16,7 +16,6 @@ from xfuser.compat import is_diffusers_import_error
 from xfuser.config import args, xFuserArgs
 from xfuser.envs import (
     PACKAGES_CHECKER,
-    _TORCH_GROUPNORM,
     get_platform,
     _is_hip,
     _is_cuda,
@@ -481,9 +480,9 @@ class xFuserModel(abc.ABC):
         if config.use_parallel_vae:
             if not packages_info.get("has_distvae", False):
                 raise ValueError("DistVAE is not installed. Please install it before using parallel VAE.")
-            if torch.nn.GroupNorm.__module__ == "aiter.ops.groupnorm":
-                log("AITER GroupNorm is not supported with parallel VAE. Reverting to torch GroupNorm.")
-                torch.nn.GroupNorm = _TORCH_GROUPNORM
+            if vae_parallel.restore_torch_group_norm():
+                log("AITER GroupNorm cannot be sharded. Reverting to torch GroupNorm so that "
+                    "--use_parallel_vae can recognise the norms it has to replace.")
         
         if config.distilled_transformer_path or config.distilled_transformer_2_path:
             if not self.capabilities.supports_distilled_weights:

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -1214,8 +1214,13 @@ class xFuserModel(abc.ABC):
         if target is None:
             return (f"VAE tiled decode ran out of memory at a {window}px tile window, the smallest "
                     "this VAE can tile with.")
+        # One step, and say what to look at, rather than leaving halving to look like a free knob
+        # that can be turned again. It cannot: the VAE stops being what peaks after a step or two,
+        # and from there a narrower window costs image quality and buys no memory at all.
         return (f"VAE tiled decode ran out of memory at a {window}px tile window. Shrink it with "
-                f"--vae_tile_size {target}, then re-run.")
+                f"--vae_tile_size {target}, then re-run. Take one step at a time and compare peak "
+                f"VRAM: if it barely moves, the VAE is no longer what peaks and a narrower window "
+                f"will cost image quality without saving memory.")
 
     @abc.abstractmethod
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -340,11 +340,14 @@ class xFuserModel(abc.ABC):
                 log(f"Enabling VAE slicing on {type(vae).__name__}...")
                 vae.enable_slicing()
 
+            tile_window = None
             if tiling:
                 vae_tiling.require_vae_support(vae, "tiling", tiling_flag)
                 log(f"Enabling VAE tiling on {type(vae).__name__}...")
                 vae.enable_tiling()
-                self._apply_vae_tile_size(vae)
+                tile_window = self._apply_vae_tile_size(vae)
+            # Installed either way, so a decode that OOMs with tiling off still says so.
+            self._install_vae_decode_guard(vae, tile_window)
 
         if self.config.enable_sequential_cpu_offload:
             log("Enabling sequential CPU offload...")
@@ -1071,13 +1074,13 @@ class xFuserModel(abc.ABC):
 
         self.pipe.vae.decode = decode_wrapper
 
-    def _apply_vae_tile_size(self, vae) -> None:
-        """ Narrow this VAE's tile window to --vae_tile_size, where one was asked for """
+    def _apply_vae_tile_size(self, vae) -> Optional[int]:
+        """ The window set on this VAE, None where the VAE keeps its own """
         # The default window tracks the VAE's training resolution and never shrinks for an
         # above-training-res decode, so a single tile can outgrow free VRAM. This shrinks it.
         requested = self.config.vae_tile_size
         if requested is None:
-            return
+            return None
         window = vae_tiling.tile_window(vae)
         if window is None:
             raise ValueError(
@@ -1087,7 +1090,7 @@ class xFuserModel(abc.ABC):
         if requested > window:
             log(f"--vae_tile_size {requested} is larger than this VAE's {window}px tile window, "
                 f"which would raise peak memory rather than lower it; leaving it at {window}px.")
-            return
+            return None
         pixels, plan = vae_tiling.snap_tile_window(vae, requested)
         if plan is None:
             smallest = vae_tiling.smallest_tile_window(vae, requested, window)
@@ -1104,6 +1107,7 @@ class xFuserModel(abc.ABC):
         vae_tiling.apply_tile_plan(vae, plan)
         log(f"VAE tile window set to {pixels}px "
             f"({', '.join(f'{a}={v}' for a, v in sorted(plan.items()))})")
+        return pixels
 
     def _check_vae_tile_size_against_parallel_vae(
         self, vae, pixels: int, plan: dict, window: int
@@ -1127,6 +1131,57 @@ class xFuserModel(abc.ABC):
              f", and no size up to this VAE's own {window}px window gives them one each.")
         )
 
+    def _install_vae_decode_guard(self, vae, tile_window: Optional[int] = None) -> None:
+        # Point a failed VAE decode at the knob that fixes it. Success path untouched.
+        original_decode = vae.decode
+
+        @functools.wraps(original_decode)
+        def decode_guard(*args, **kwargs):
+            try:
+                return original_decode(*args, **kwargs)
+            except torch.cuda.OutOfMemoryError as e:
+                raise torch.cuda.OutOfMemoryError(f"{self._vae_decode_oom_hint(vae)}\n{e}") from e
+            except RuntimeError as e:
+                # Two things have to hold before the window gets the blame: this run narrowed it,
+                # and the decoder failed the way a narrow window makes it fail. A dtype or device
+                # error is failing for reasons of its own, as is a VAE still at its own window.
+                if tile_window is None or not vae_tiling.is_tile_padding_error(e):
+                    raise
+                # Whether a window leaves a tile the decoder cannot pad depends on the output size,
+                # so this cannot be caught when the window is set; name the window, being the part
+                # the caller can change, and keep the decoder's own words underneath.
+                raise RuntimeError(
+                    f"VAE tiled decode failed at the {tile_window}px tile window set by "
+                    f"--vae_tile_size: at this output size the window leaves a tile too thin for "
+                    f"the decoder to pad. A larger window can fail where a smaller one works, so "
+                    f"try another --vae_tile_size, or drop it to decode at this VAE's own "
+                    f"window.\n{e}"
+                ) from e
+
+        vae.decode = decode_guard
+
+    def _vae_decode_oom_hint(self, vae) -> str:
+        # Read from the VAE, since a model can arrive with tiling on and no flag set.
+        if not getattr(vae, "use_tiling", False):
+            if self.capabilities.enable_tiling:
+                return ("VAE decode ran out of memory with tiling disabled. Re-run with "
+                        "--enable_tiling to decode in tiles.")
+            return (f"VAE decode ran out of memory, and model {self.settings.model_name} does not "
+                    "support VAE tiling.")
+
+        window = vae_tiling.tile_window(vae)
+        if window is None:
+            return ("VAE tiled decode ran out of memory. This model's VAE "
+                    f"({type(vae).__name__}) has no single tile window to size, so "
+                    "--vae_tile_size does not apply.")
+        # Halve the window through the same snap the override uses, so the guard can never name a
+        # size that the next run would turn around and refuse.
+        target, _ = vae_tiling.snap_tile_window(vae, max(window // 2, 1))
+        if target is None:
+            return (f"VAE tiled decode ran out of memory at a {window}px tile window, the smallest "
+                    "this VAE can tile with.")
+        return (f"VAE tiled decode ran out of memory at a {window}px tile window. Shrink it with "
+                f"--vae_tile_size {target}, then re-run.")
 
     @abc.abstractmethod
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -23,6 +23,7 @@ from xfuser.envs import (
 )
 from xfuser.core.distributed.parallel_state import (
     get_fs_group,
+    get_vae_parallel_group,
     get_vae_parallel_world_size,
 )
 from xfuser.core.utils.runner_utils import (
@@ -37,7 +38,7 @@ from xfuser.core.utils.runner_utils import (
     _use_aiter_fp8_rdna4,
     rgetattr,
 )
-from xfuser.core.utils import vae_tiling
+from xfuser.core.utils import vae_parallel, vae_tiling
 
 from xfuser.core.distributed import (
     get_world_group,
@@ -370,6 +371,20 @@ class xFuserModel(abc.ABC):
             if vae is not None and not any(vae is seen for seen in vaes):
                 vaes.append(vae)
         return vaes
+
+    def _setup_parallel_vae(self) -> None:
+        """ Shard VAE decode, and encode where the model declares it, across the VAE group """
+        vae_group = get_vae_parallel_group().device_group
+        log(f"VAE parallel group: world_size={torch.distributed.get_world_size(vae_group)}, "
+            f"rank={torch.distributed.get_rank(vae_group)}", debug=True)
+        for vae in self._decoding_vaes():
+            adapter = vae_parallel.parallelize_decoder(vae, vae_group)
+            log(f"Parallel VAE decoder enabled on {type(vae).__name__} via {adapter}.")
+            # Only an I2V or V2V model encodes anything worth sharding, so this is a capability
+            # rather than a flag: there is nothing for a user to decide.
+            if self.capabilities.use_parallel_vae_encoder:
+                adapter = vae_parallel.parallelize_encoder(vae, vae_group)
+                log(f"Parallel VAE encoder enabled on {type(vae).__name__} via {adapter}.")
 
     def _validate_config(self, config: xFuserArgs) -> None:
         """ Validate if the model supports requested config """

--- a/xfuser/model_executor/models/runner_models/causal_wan.py
+++ b/xfuser/model_executor/models/runner_models/causal_wan.py
@@ -33,6 +33,9 @@ class xFuserCausalWanModel(xFuserModel):
         fully_shard_degree=True,
         use_fp8_gemms=True,
         use_parallel_vae=True,
+        # The i2v task encodes its first frame to seed the KV cache, at the generation size, which
+        # mod_value holds to a multiple of the VAE ratio.
+        use_parallel_vae_encoder=True,
         enable_tiling=True,
         enable_slicing=True,
     )

--- a/xfuser/model_executor/models/runner_models/causal_wan.py
+++ b/xfuser/model_executor/models/runner_models/causal_wan.py
@@ -31,7 +31,7 @@ class xFuserCausalWanModel(xFuserModel):
         ulysses_degree=False,   # SP incompatible with KV cache initially
         ring_degree=False,
         fully_shard_degree=True,
-        use_fp8_gemms=False,
+        use_fp8_gemms=True,
         use_parallel_vae=False,
         enable_tiling=True,
         enable_slicing=True,

--- a/xfuser/model_executor/models/runner_models/causal_wan.py
+++ b/xfuser/model_executor/models/runner_models/causal_wan.py
@@ -32,7 +32,7 @@ class xFuserCausalWanModel(xFuserModel):
         ring_degree=False,
         fully_shard_degree=True,
         use_fp8_gemms=True,
-        use_parallel_vae=False,
+        use_parallel_vae=True,
         enable_tiling=True,
         enable_slicing=True,
     )
@@ -130,6 +130,11 @@ class xFuserCausalWanModel(xFuserModel):
             scheduler=scheduler,
         )
         return pipe
+
+    def _post_load_and_state_initialization(self, input_args: dict) -> None:
+        super()._post_load_and_state_initialization(input_args)
+        if self.config.use_parallel_vae:
+            self._setup_parallel_vae()
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
         output = self.pipe(

--- a/xfuser/model_executor/models/runner_models/cosmos3.py
+++ b/xfuser/model_executor/models/runner_models/cosmos3.py
@@ -14,7 +14,6 @@ from xfuser.model_executor.models.runner_models.base_model import (
     DiffusionOutput,
     _parse_attention_backend,
 )
-from xfuser.core.distributed.parallel_state import get_vae_parallel_group
 from xfuser.core.distributed.attention_backend import AttentionBackendType
 from xfuser.core.utils.runner_utils import log, resize_and_crop_image
 
@@ -39,49 +38,6 @@ COSMOS3_FSDP_STRATEGY = {
         "dtype": torch.bfloat16,
     },
 }
-
-
-def _setup_parallel_vae(vae, enable_parallel_encoder=True):
-    if enable_parallel_encoder:
-        try:
-            from distvae.modules.adapters.vae.encoder_adapters import WanEncoderAdapter
-            # scale_factor_spatial includes patch_size (e.g. 16 = 8x from encoder + 2x
-            # from patching). The encoder adapter needs just the encoder's own
-            # downsampling ratio, excluding the patching step.
-            vae_scale_factor = getattr(vae.config, 'scale_factor_spatial', 8)
-            patch_size = getattr(vae.config, 'patch_size', None)
-            if patch_size and patch_size > 1:
-                vae_scale_factor = vae_scale_factor // patch_size
-            patched_encoder = WanEncoderAdapter(
-                vae.encoder,
-                vae_group=get_vae_parallel_group().device_group,
-                vae_scale_factor=vae_scale_factor,
-            ).to(vae.device)
-            vae.encoder = patched_encoder
-            log("Parallel VAE encoder enabled.")
-        except ImportError:
-            log("DistVAE not available for encoder. Defaulting to single-rank.")
-        except Exception as e:
-            raise ValueError(f"Failed to patch VAE encoder: {e}")
-    try:
-        from distvae.modules.adapters.vae.decoder_adapters import WanDecoderAdapter
-        patched_decoder = WanDecoderAdapter(
-            vae.decoder, vae_group=get_vae_parallel_group().device_group
-        ).to(vae.device)
-        # Cosmos3 VAE has patch_size=2 (extra 2x spatial upsampling from
-        # unpatching). The decoder adapter's scale_factor defaults to 1 in
-        # its Patchify, which is correct for Wan (patch_size=None). For
-        # Cosmos3 we need to account for the extra factor so that the
-        # narrow in _forward crops to the right size.
-        patch_size = getattr(vae.config, 'patch_size', None)
-        if patch_size and patch_size > 1:
-            patched_decoder.patchify.scale_factor = patch_size
-        vae.decoder = patched_decoder
-        log("Parallel VAE decoder enabled.")
-    except ImportError:
-        log("DistVAE not available for decoder. Defaulting to single-rank.")
-    except Exception as e:
-        raise ValueError(f"Failed to patch VAE decoder: {e}")
 
 
 @register_model("nvidia/Cosmos3-Super")
@@ -222,7 +178,7 @@ class xFuserCosmos3SuperModel(xFuserModel):
             if hasattr(self.pipe.transformer, '_patch_time_embedder_for_fsdp'):
                 self.pipe.transformer._patch_time_embedder_for_fsdp()
         if self.config.use_parallel_vae:
-            _setup_parallel_vae(self.pipe.vae, self.capabilities.use_parallel_vae_encoder)
+            self._setup_parallel_vae()
 
 
 @register_model("nvidia/Cosmos3-Nano")

--- a/xfuser/model_executor/models/runner_models/flux.py
+++ b/xfuser/model_executor/models/runner_models/flux.py
@@ -129,6 +129,8 @@ class xFuserFluxKontextModel(xFuserModel):
         enable_tiling=True,
         enable_slicing=True,
         use_parallel_vae=True,
+        # Kontext encodes the image it is editing, sized to a multiple of the VAE ratio.
+        use_parallel_vae_encoder=True,
         fully_shard_degree=True,
     )
     default_input_values = DefaultInputValues(
@@ -245,6 +247,9 @@ class xFuserFlux2Model(xFuserModel):
         enable_tiling=True,
         enable_slicing=True,
         use_parallel_vae=True,
+        # FLUX.2 encodes any reference images it is given, cropped to a multiple of the VAE
+        # ratio. A prompt-only generation passes none and the sharded encoder never runs.
+        use_parallel_vae_encoder=True,
         use_fbcache=True,
         pipefusion_parallel_degree=True,
     )
@@ -394,6 +399,8 @@ class xFuserFlux2Klein9BModel(xFuserModel):
         enable_tiling=True,
         enable_slicing=True,
         use_parallel_vae=True,
+        # Klein encodes reference images the same way FLUX.2 does, when it is given any.
+        use_parallel_vae_encoder=True,
         fully_shard_degree=True,
         use_fbcache=True,
         pipefusion_parallel_degree=True,

--- a/xfuser/model_executor/models/runner_models/flux.py
+++ b/xfuser/model_executor/models/runner_models/flux.py
@@ -16,27 +16,7 @@ from xfuser.core.utils.runner_utils import (
     quantize_linear_layers_to_fp8,
 )
 from xfuser.core.distributed import get_runtime_state, get_pipeline_parallel_world_size
-from xfuser.core.distributed.parallel_state import get_vae_parallel_group
 from xfuser import xFuserFluxPipeline, xFuserArgs
-
-
-def _setup_parallel_vae(vae) -> None:
-    """Parallalizes the VAE decoder using distvae"""
-    try:
-        from distvae.modules.adapters.vae.decoder_adapters import DecoderAdapter
-
-        patched_decoder = DecoderAdapter(
-            vae.decoder, vae_group=get_vae_parallel_group().device_group
-        ).to(vae.device)
-        vae.decoder = patched_decoder
-        log(f"Parallel VAE decoder enabled successfully.")
-    except ImportError:
-        raise ValueError(
-            "DistVAE library is missing or does not support DecoderAdapter. "
-            "Try installing latest DistVAE from https://github.com/xdit-project/DistVAE."
-        )
-    except Exception as e:
-        raise ValueError(f"Failed to patch VAE decoder. {e}")
 
 
 @register_model("black-forest-labs/FLUX.1-dev")
@@ -83,7 +63,7 @@ class xFuserFluxModel(xFuserModel):
     def _post_load_and_state_initialization(self, input_args: dict) -> None:
         super()._post_load_and_state_initialization(input_args)
         if self.config.use_parallel_vae:
-            _setup_parallel_vae(self.pipe.vae)
+            self._setup_parallel_vae()
 
     def _get_compile_mode(self) -> str:
         if PACKAGES_CHECKER._on_rdna4():
@@ -180,7 +160,7 @@ class xFuserFluxKontextModel(xFuserModel):
     def _post_load_and_state_initialization(self, input_args: dict) -> None:
         super()._post_load_and_state_initialization(input_args)
         if self.config.use_parallel_vae:
-            _setup_parallel_vae(self.pipe.vae)
+            self._setup_parallel_vae()
 
     def _load_model(self) -> DiffusionPipeline:
         from diffusers import FluxKontextPipeline
@@ -302,7 +282,7 @@ class xFuserFlux2Model(xFuserModel):
     def _post_load_and_state_initialization(self, input_args: dict) -> None:
         super()._post_load_and_state_initialization(input_args)
         if self.config.use_parallel_vae:
-            _setup_parallel_vae(self.pipe.vae)
+            self._setup_parallel_vae()
 
         if self.config.use_fbcache:
             from xfuser.model_executor.cache.diffusers_adapters.flux2 import (
@@ -446,7 +426,7 @@ class xFuserFlux2Klein9BModel(xFuserModel):
     def _post_load_and_state_initialization(self, input_args: dict) -> None:
         super()._post_load_and_state_initialization(input_args)
         if self.config.use_parallel_vae:
-            _setup_parallel_vae(self.pipe.vae)
+            self._setup_parallel_vae()
 
     def _get_compile_mode(self) -> str:
         # CUDA graphs incompatible with FBCache cross-step caching,

--- a/xfuser/model_executor/models/runner_models/hunyuan.py
+++ b/xfuser/model_executor/models/runner_models/hunyuan.py
@@ -128,6 +128,10 @@ class xFuserHunyuanvideo15Model(xFuserModel):
         enable_tiling=True,
         use_fp8_gemms=True,
         use_parallel_vae=True,
+        # The i2v task encodes its conditioning frame at the generation size, which mod_value
+        # holds to a multiple of the VAE's spatial ratio. The t2v task encodes nothing, and
+        # sharding an encoder it never calls costs it nothing.
+        use_parallel_vae_encoder=True,
     )
     default_input_values = DefaultInputValues(
         height=720,
@@ -288,6 +292,8 @@ class xFuserHunyuanvideo15SparseModel(xFuserHunyuanvideo15Model):
         enable_tiling=True,
         supports_sparse_attention_backends=True,
         use_parallel_vae=True,
+        # This one only runs i2v, so the conditioning frame is always encoded.
+        use_parallel_vae_encoder=True,
     )
 
     def _validate_ssta_attention_kwargs(self, attn_param: dict) -> None:

--- a/xfuser/model_executor/models/runner_models/hunyuan.py
+++ b/xfuser/model_executor/models/runner_models/hunyuan.py
@@ -39,6 +39,7 @@ class xFuserHunyuanvideoModel(xFuserModel):
         enable_tiling=True,
         use_hybrid_attn_schedule=True,
         use_fp8_gemms=True,
+        use_parallel_vae=True,
     )
     default_input_values = DefaultInputValues(
         height=720,
@@ -75,6 +76,11 @@ class xFuserHunyuanvideoModel(xFuserModel):
         )
         fix_llama_tokenizer_pretokenizer(pipe, self.settings.model_name, revision="refs/pr/18")
         return pipe
+
+    def _post_load_and_state_initialization(self, input_args: dict) -> None:
+        super()._post_load_and_state_initialization(input_args)
+        if self.config.use_parallel_vae:
+            self._setup_parallel_vae()
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
         output = self.pipe(
@@ -121,6 +127,7 @@ class xFuserHunyuanvideo15Model(xFuserModel):
         enable_slicing=True,
         enable_tiling=True,
         use_fp8_gemms=True,
+        use_parallel_vae=True,
     )
     default_input_values = DefaultInputValues(
         height=720,
@@ -164,6 +171,11 @@ class xFuserHunyuanvideo15Model(xFuserModel):
             torch_dtype=torch.bfloat16,
         )
         return pipe
+
+    def _post_load_and_state_initialization(self, input_args: dict) -> None:
+        super()._post_load_and_state_initialization(input_args)
+        if self.config.use_parallel_vae:
+            self._setup_parallel_vae()
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
         kwargs = {
@@ -275,6 +287,7 @@ class xFuserHunyuanvideo15SparseModel(xFuserHunyuanvideo15Model):
         enable_slicing=True,
         enable_tiling=True,
         supports_sparse_attention_backends=True,
+        use_parallel_vae=True,
     )
 
     def _validate_ssta_attention_kwargs(self, attn_param: dict) -> None:

--- a/xfuser/model_executor/models/runner_models/ideogram4.py
+++ b/xfuser/model_executor/models/runner_models/ideogram4.py
@@ -6,7 +6,6 @@ import os
 import torch
 from diffusers.pipelines.pipeline_utils import DiffusionPipeline
 
-from xfuser.core.distributed.parallel_state import get_vae_parallel_group
 from xfuser.core.utils.runner_utils import log
 from xfuser.model_executor.models.runner_models.base_model import (
     DefaultInputValues,
@@ -162,21 +161,6 @@ def _check_load_result(
             f"Failed to load {component_name}: "
             f"missing keys={missing_keys[:10]}, unexpected keys={unexpected_keys[:10]}"
         )
-
-
-def _setup_parallel_vae(vae) -> None:
-    try:
-        from distvae.modules.adapters.vae.decoder_adapters import DecoderAdapter
-
-        vae.decoder = DecoderAdapter(
-            vae.decoder,
-            vae_group=get_vae_parallel_group().device_group,
-        ).to(vae.device)
-        log("Parallel VAE decoder enabled.")
-    except ImportError:
-        log("DistVAE not available for decoder. Defaulting to single-rank.")
-    except Exception as error:
-        raise ValueError(f"Failed to patch VAE decoder: {error}") from error
 
 
 def _default_guidance_schedule(num_inference_steps: int) -> list[float]:
@@ -389,4 +373,4 @@ class xFuserIdeogram4Model(xFuserModel):
         self.pipe.transformer._init_sp_state()
         self.pipe.unconditional_transformer._init_sp_state()
         if self.config.use_parallel_vae:
-            _setup_parallel_vae(self.pipe.vae)
+            self._setup_parallel_vae()

--- a/xfuser/model_executor/models/runner_models/ideogram4.py
+++ b/xfuser/model_executor/models/runner_models/ideogram4.py
@@ -15,9 +15,6 @@ from xfuser.model_executor.models.runner_models.base_model import (
     register_model,
     xFuserModel,
 )
-from xfuser.model_executor.models.transformers.transformer_ideogram4 import (
-    get_ideogram4_transformer_wrapper_class,
-)
 from xfuser.model_executor.pipelines.pipeline_ideogram4 import (
     get_ideogram4_pipeline_class,
 )
@@ -235,6 +232,10 @@ class xFuserIdeogram4Model(xFuserModel):
         model_id: str,
         subfolder: str,
     ):
+        from xfuser.model_executor.models.transformers.transformer_ideogram4 import (
+            get_ideogram4_transformer_wrapper_class,
+        )
+
         transformer_class = get_ideogram4_transformer_wrapper_class()
         transformer = transformer_class.from_config(
             transformer_class.load_config(model_id, subfolder=subfolder)
@@ -280,6 +281,10 @@ class xFuserIdeogram4Model(xFuserModel):
         return text_encoder
 
     def _load_model(self) -> DiffusionPipeline:
+        from xfuser.model_executor.models.transformers.transformer_ideogram4 import (
+            get_ideogram4_transformer_wrapper_class,
+        )
+
         model_id = self.config.model
         transformer_class = get_ideogram4_transformer_wrapper_class()
 

--- a/xfuser/model_executor/models/runner_models/krea2.py
+++ b/xfuser/model_executor/models/runner_models/krea2.py
@@ -79,7 +79,7 @@ class _Krea2BaseModel(xFuserModel):
         pipefusion_parallel_degree=False,
         data_parallel_degree=True,
         use_cfg_parallel=False,
-        use_parallel_vae=False,
+        use_parallel_vae=True,
         use_fp8_gemms=True,
         use_fp4_gemms=True,
         use_hybrid_attn_schedule=True,
@@ -87,6 +87,11 @@ class _Krea2BaseModel(xFuserModel):
         enable_tiling=True,
         enable_slicing=True,
     )
+
+    def _post_load_and_state_initialization(self, input_args: dict) -> None:
+        super()._post_load_and_state_initialization(input_args)
+        if self.config.use_parallel_vae:
+            self._setup_parallel_vae()
 
     def _validate_config(self, config) -> None:
         super()._validate_config(config)

--- a/xfuser/model_executor/models/runner_models/lingbot_video.py
+++ b/xfuser/model_executor/models/runner_models/lingbot_video.py
@@ -112,6 +112,10 @@ class xFuserLingBotVideoMoEModel(xFuserModel):
         use_hybrid_gemm_schedule=True,
         fully_shard_degree=True,
         use_parallel_vae=True,
+        # The refiner encodes the whole base video at the final output resolution, which is the
+        # largest encode any of these models does. It runs through this VAE, which _run_refiner
+        # takes from the pipeline that has already been sharded.
+        use_parallel_vae_encoder=True,
         enable_tiling=True,
         enable_slicing=True,
     )

--- a/xfuser/model_executor/models/runner_models/lingbot_video.py
+++ b/xfuser/model_executor/models/runner_models/lingbot_video.py
@@ -23,7 +23,6 @@ from xfuser.model_executor.models.runner_models.base_model import (
     DiffusionOutput,
 )
 from xfuser.core.distributed.runtime_state import get_runtime_state
-from xfuser.core.distributed.parallel_state import get_vae_parallel_group
 from xfuser.core.utils.runner_utils import log
 
 
@@ -76,32 +75,6 @@ def _load_json_prompt(prompt: str) -> str:
             return json.dumps(caption, ensure_ascii=False, separators=(",", ":"))
         return str(caption)
     return prompt
-
-
-def _setup_parallel_vae(vae, use_encoder=False):
-    import torch.distributed as dist
-    vae_group = get_vae_parallel_group().device_group
-    log(f"VAE parallel group: world_size={dist.get_world_size(vae_group)}, "
-        f"rank={dist.get_rank(vae_group)}, vae.device={vae.device}")
-    try:
-        from distvae.modules.adapters.vae.decoder_adapters import WanDecoderAdapter
-        vae.decoder = WanDecoderAdapter(vae.decoder, vae_group=vae_group).to(vae.device)
-        log("Parallel VAE decoder enabled.")
-    except ImportError:
-        log("distvae WanDecoderAdapter not available, skipping parallel VAE decoder.")
-        return
-    except Exception as e:
-        log(f"Failed to patch VAE decoder: {e}")
-        return
-    if use_encoder:
-        try:
-            from distvae.modules.adapters.vae.encoder_adapters import WanEncoderAdapter
-            vae.encoder = WanEncoderAdapter(vae.encoder, vae_group=vae_group).to(vae.device)
-            log("Parallel VAE encoder enabled.")
-        except ImportError:
-            log("distvae WanEncoderAdapter not available, skipping parallel VAE encoder.")
-        except Exception as e:
-            log(f"Failed to patch VAE encoder: {e}")
 
 
 @register_model("robbyant/lingbot-video-moe-30b-a3b")
@@ -199,7 +172,7 @@ class xFuserLingBotVideoMoEModel(xFuserModel):
                 if hasattr(block, "_cached_bulk_dtype"):
                     _patch_block_bulk_dtype(block)
         if self.config.use_parallel_vae:
-            _setup_parallel_vae(self.pipe.vae)
+            self._setup_parallel_vae()
 
         # Cache pre-transposed expert weights to eliminate per-call copies
         self.pipe.transformer.cache_expert_weights()

--- a/xfuser/model_executor/models/runner_models/lingbot_video.py
+++ b/xfuser/model_executor/models/runner_models/lingbot_video.py
@@ -7,9 +7,6 @@ from diffusers.pipelines.pipeline_utils import DiffusionPipeline
 from transformers import Qwen3VLForConditionalGeneration, Qwen3VLProcessor
 
 from xfuser import xFuserArgs
-from xfuser.model_executor.models.transformers.transformer_lingbot_video import (
-    xFuserLingBotVideoTransformer3DWrapper,
-)
 from xfuser.model_executor.pipelines.pipeline_lingbot_video import (
     xFuserLingBotVideoPipeline,
     get_lingbot_video_pipeline_class,
@@ -189,6 +186,9 @@ class xFuserLingBotVideoMoEModel(xFuserModel):
 
     def _load_refiner(self, input_args):
         from lingbot_video.scheduling_flow_unipc import FlowUniPCMultistepScheduler
+        from xfuser.model_executor.models.transformers.transformer_lingbot_video import (
+            xFuserLingBotVideoTransformer3DWrapper,
+        )
 
         log("Loading refiner transformer...")
         model_name = self.settings.model_name
@@ -263,6 +263,9 @@ class xFuserLingBotVideoMoEModel(xFuserModel):
 
     def _build_pipe(self, model_name, transformer_subfolder="transformer", use_i2v=False):
         from lingbot_video.scheduling_flow_unipc import FlowUniPCMultistepScheduler
+        from xfuser.model_executor.models.transformers.transformer_lingbot_video import (
+            xFuserLingBotVideoTransformer3DWrapper,
+        )
 
         transformer = xFuserLingBotVideoTransformer3DWrapper.from_pretrained(
             model_name, torch_dtype=torch.bfloat16, subfolder=transformer_subfolder,

--- a/xfuser/model_executor/models/runner_models/ltx.py
+++ b/xfuser/model_executor/models/runner_models/ltx.py
@@ -57,6 +57,7 @@ class xFuserLTX23VideoModel(xFuserModel):
         ring_degree=True,
         enable_tiling=True,
         enable_slicing=True,
+        use_parallel_vae=True,
     )
 
     _STG_SCALE = 1.0
@@ -210,6 +211,9 @@ class xFuserLTX23VideoModel(xFuserModel):
         super()._post_load_and_state_initialization(input_args)
         self.upsample_pipe.to(self.pipe.device)
         self.second_pipe.to(self.pipe.device)
+        # After both pipelines land on their device, since sharding a decoder rebuilds it there.
+        if self.config.use_parallel_vae:
+            self._setup_parallel_vae()
 
 
 @register_model("Lightricks/LTX-2")
@@ -240,6 +244,7 @@ class xFuserLTX2VideoModel(xFuserModel):
         enable_tiling=True,
         enable_slicing=True,
         use_fp8_gemms=True,
+        use_parallel_vae=True,
     )
 
     def _load_model(self) -> DiffusionPipeline:
@@ -345,3 +350,6 @@ class xFuserLTX2VideoModel(xFuserModel):
         super()._post_load_and_state_initialization(input_args)
         self.upsample_pipe.to(self.pipe.device)
         self.second_pipe.to(self.pipe.device)
+        # After both pipelines land on their device, since sharding a decoder rebuilds it there.
+        if self.config.use_parallel_vae:
+            self._setup_parallel_vae()

--- a/xfuser/model_executor/models/runner_models/ltx.py
+++ b/xfuser/model_executor/models/runner_models/ltx.py
@@ -114,11 +114,6 @@ class xFuserLTX23VideoModel(xFuserModel):
 
         return pipe
 
-    def _enable_options(self) -> None:
-        super()._enable_options()
-        if self.config.enable_slicing:
-            self.second_pipe.vae.enable_slicing()
-
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
         from diffusers.pipelines.ltx2.utils import STAGE_2_DISTILLED_SIGMA_VALUES
         generator = torch.Generator(device="cuda").manual_seed(input_args["seed"])
@@ -285,13 +280,6 @@ class xFuserLTX2VideoModel(xFuserModel):
         self.upsample_pipe = upsample_pipe
 
         return pipe
-
-    def _enable_options(self) -> None:
-        super()._enable_options()
-        if self.config.enable_tiling:
-            self.second_pipe.vae.enable_tiling()
-        if self.config.enable_slicing:
-            self.second_pipe.vae.enable_slicing()
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
         from diffusers.pipelines.ltx2.utils import STAGE_2_DISTILLED_SIGMA_VALUES

--- a/xfuser/model_executor/models/runner_models/qwen.py
+++ b/xfuser/model_executor/models/runner_models/qwen.py
@@ -25,6 +25,7 @@ class xFuserQwenImageEditModel(xFuserModel):
         ring_degree=True,
         fully_shard_degree=True,
         use_fp8_gemms=True,
+        use_parallel_vae=True,
         enable_tiling=True,
         enable_slicing=True,
     )
@@ -56,6 +57,11 @@ class xFuserQwenImageEditModel(xFuserModel):
         elif "2509" in config.model:
             self.settings.model_name = "Qwen/Qwen-Image-Edit-2509"
             self.settings.output_name = "qwen_image_edit_2509"
+
+    def _post_load_and_state_initialization(self, input_args: dict) -> None:
+        super()._post_load_and_state_initialization(input_args)
+        if self.config.use_parallel_vae:
+            self._setup_parallel_vae()
 
     def _load_model(self) -> DiffusionPipeline:
         from diffusers import QwenImageEditPipeline
@@ -110,6 +116,7 @@ class xFuserQwenImageModel(xFuserModel):
         ring_degree=True,
         fully_shard_degree=True,
         use_fp8_gemms=True,
+        use_parallel_vae=True,
         enable_tiling=True,
         enable_slicing=True,
     )
@@ -139,6 +146,11 @@ class xFuserQwenImageModel(xFuserModel):
         if "2512" in config.model:
             self.settings.model_name = "Qwen/Qwen-Image-2512"
             self.settings.output_name = "qwen_image_2512"
+
+    def _post_load_and_state_initialization(self, input_args: dict) -> None:
+        super()._post_load_and_state_initialization(input_args)
+        if self.config.use_parallel_vae:
+            self._setup_parallel_vae()
 
     def _load_model(self) -> DiffusionPipeline:
         from diffusers import QwenImagePipeline

--- a/xfuser/model_executor/models/runner_models/qwen.py
+++ b/xfuser/model_executor/models/runner_models/qwen.py
@@ -26,6 +26,8 @@ class xFuserQwenImageEditModel(xFuserModel):
         fully_shard_degree=True,
         use_fp8_gemms=True,
         use_parallel_vae=True,
+        # Editing encodes the image being edited, at the size it will be generated at.
+        use_parallel_vae_encoder=True,
         enable_tiling=True,
         enable_slicing=True,
     )

--- a/xfuser/model_executor/models/runner_models/qwen.py
+++ b/xfuser/model_executor/models/runner_models/qwen.py
@@ -110,6 +110,8 @@ class xFuserQwenImageModel(xFuserModel):
         ring_degree=True,
         fully_shard_degree=True,
         use_fp8_gemms=True,
+        enable_tiling=True,
+        enable_slicing=True,
     )
     default_input_values = DefaultInputValues(
         height=928,

--- a/xfuser/model_executor/models/runner_models/stable_diffusion.py
+++ b/xfuser/model_executor/models/runner_models/stable_diffusion.py
@@ -24,6 +24,7 @@ class xFuserStableDiffusionModel(xFuserModel):
         enable_slicing=True,
         fully_shard_degree=True,
         use_fp8_gemms=True,
+        use_parallel_vae=True,
     )
     default_input_values = DefaultInputValues(
         height=1024,
@@ -54,6 +55,11 @@ class xFuserStableDiffusionModel(xFuserModel):
             torch_dtype=dtype,
         )
         return pipe
+
+    def _post_load_and_state_initialization(self, input_args: dict) -> None:
+        super()._post_load_and_state_initialization(input_args)
+        if self.config.use_parallel_vae:
+            self._setup_parallel_vae()
 
     def _get_compiled_pipe_components(self):
         return ["transformer", "text_encoder", "text_encoder_2", "text_encoder_3"]

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -21,7 +21,6 @@ from xfuser.model_executor.models.runner_models.base_model import (
     DiffusionOutput,
 )
 from xfuser.core.distributed.runtime_state import get_runtime_state
-from xfuser.core.distributed.parallel_state import get_vae_parallel_group
 from xfuser.core.utils.runner_utils import (
     log,
     resize_and_crop_image,
@@ -54,48 +53,6 @@ def _build_attention_kwargs(config: "xFuserArgs") -> dict:
         "spargeattn_reorder_sequence": config.spargeattn_reorder_sequence,
         "use_spargeattn_static_block_mask": config.use_spargeattn_static_block_mask,
     }
-
-
-def _setup_parallel_vae(vae, enable_parallel_encoder: bool = True) -> None:
-    """ Parallelizes VAE en-/decoder using distvae """
-    # Handle encoder
-    if enable_parallel_encoder:
-        try:
-            from distvae.modules.adapters.vae.encoder_adapters import WanEncoderAdapter
-            vae_scale_factor = getattr(vae.config, 'scaling_factor', 8)
-            if hasattr(vae.config, 'vae_scale_factor_spatial'):
-                vae_scale_factor = vae.config.vae_scale_factor_spatial
-            patched_encoder = WanEncoderAdapter(
-                vae.encoder,
-                vae_group=get_vae_parallel_group().device_group,
-                vae_scale_factor=vae_scale_factor,
-            ).to(vae.device)
-            vae.encoder = patched_encoder
-            log(f"Parallel VAE encoder enabled successfully.")
-        except ImportError:
-            log(
-                "DistVAE library is missing or does not support WanEncoderAdapter. "
-                "Try installing latest DistVAE from https://github.com/xdit-project/DistVAE. "
-                "Defaulting to single-rank encoder."
-            )
-        except Exception as e:
-            raise ValueError(f"Failed to patch VAE encoder. {e}")
-    # Handle decoder
-    try:
-        from distvae.modules.adapters.vae.decoder_adapters import WanDecoderAdapter
-        patched_decoder = WanDecoderAdapter(
-            vae.decoder, vae_group=get_vae_parallel_group().device_group
-        ).to(vae.device)
-        vae.decoder = patched_decoder
-        log(f"Parallel VAE decoder enabled successfully.")
-    except ImportError:
-        log(
-            "DistVAE library is missing or does not support WanDecoderAdapter. "
-            "Try installing latest DistVAE from https://github.com/xdit-project/DistVAE. "
-            "Defaulting to single-rank decoder."
-        )
-    except Exception as e:
-        raise ValueError(f"Failed to patch VAE decoder. {e}")
 
 
 def _remap_lightx2v_to_diffusers(k: str) -> str:
@@ -216,7 +173,7 @@ class xFuserWan21I2VModel(xFuserModel):
     def _post_load_and_state_initialization(self, input_args: dict) -> None:
         super()._post_load_and_state_initialization(input_args)
         if self.config.use_parallel_vae:
-            _setup_parallel_vae(self.pipe.vae, self.capabilities.use_parallel_vae_encoder)
+            self._setup_parallel_vae()
         self.pipe.scheduler.config.flow_shift = input_args["flow_shift"]
 
     def _load_model(self) -> DiffusionPipeline:
@@ -498,7 +455,7 @@ class xFuserWan21T2VModel(xFuserModel):
     def _post_load_and_state_initialization(self, input_args: dict) -> None:
         super()._post_load_and_state_initialization(input_args)
         if self.config.use_parallel_vae:
-            _setup_parallel_vae(self.pipe.vae, self.capabilities.use_parallel_vae_encoder)
+            self._setup_parallel_vae()
         self.pipe.scheduler.config.flow_shift = input_args["flow_shift"]
 
     def _load_model(self) -> DiffusionPipeline:

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -355,6 +355,8 @@ class xFuserWan22DistilledI2VModel(xFuserWan22I2VModel):
         use_parallel_vae_encoder=True,
         cross_attention_backend=True,
         supports_sparge_attention_backends=True,
+        enable_tiling=True,
+        enable_slicing=True,
         supports_distilled_weights=True,
     )
     default_input_values = DefaultInputValues(

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -672,6 +672,7 @@ class xFuserWan21VACEModel(xFuserModel):
         enable_tiling=True,
         enable_slicing=True,
         fully_shard_degree=True,
+        use_parallel_vae=True,
     )
 
     default_input_values = DefaultInputValues(
@@ -724,6 +725,11 @@ class xFuserWan21VACEModel(xFuserModel):
         )
         pipe.scheduler.flow_shift = 5.0 # 5.0 for 720p, 3.0 for 480p
         return pipe
+
+    def _post_load_and_state_initialization(self, input_args: dict) -> None:
+        super()._post_load_and_state_initialization(input_args)
+        if self.config.use_parallel_vae:
+            self._setup_parallel_vae()
 
     def _prepare_video_and_mask(self, first_img: Image, last_img: Image, height: int, width: int, num_frames: int) -> tuple[List[Image.Image], List[Image.Image]]:
         """ Prepare video and mask for Wan VACE model """

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -556,6 +556,9 @@ class xFuserWan22TI2VModel(xFuserWan21T2VModel):
         use_hybrid_attn_schedule=True,
         use_hybrid_gemm_schedule=True,
         use_parallel_vae=True,
+        # The i2v task loads the image-to-video pipeline, which encodes the first frame. The t2v
+        # task loads one that encodes nothing, and pays nothing for a sharded encoder.
+        use_parallel_vae_encoder=True,
         cross_attention_backend=True,
         supports_sparge_attention_backends=True,
         enable_tiling=True,
@@ -673,6 +676,9 @@ class xFuserWan21VACEModel(xFuserModel):
         enable_slicing=True,
         fully_shard_degree=True,
         use_parallel_vae=True,
+        # VACE encodes the conditioning video, its inactive and reactive halves, and any reference
+        # image, all of which its pipeline holds to a multiple of the VAE ratio.
+        use_parallel_vae_encoder=True,
     )
 
     default_input_values = DefaultInputValues(

--- a/xfuser/model_executor/models/runner_models/z_image.py
+++ b/xfuser/model_executor/models/runner_models/z_image.py
@@ -59,6 +59,7 @@ class xFuserZImageModel(xFuserModel):
         fully_shard_degree=True,
         use_fp8_gemms=True,
         use_int8_gemms=True,
+        use_parallel_vae=True,
     )
     settings = ModelSettings(
         model_name="Tongyi-MAI/Z-Image",
@@ -113,6 +114,11 @@ class xFuserZImageModel(xFuserModel):
         )
         return pipe
 
+    def _post_load_and_state_initialization(self, input_args: dict) -> None:
+        super()._post_load_and_state_initialization(input_args)
+        if self.config.use_parallel_vae:
+            self._setup_parallel_vae()
+
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
         prompt = _normalize_prompt(input_args["prompt"])
         output = self.pipe(
@@ -138,6 +144,7 @@ class xFuserZImageTurboModel(xFuserModel):
         use_fp8_gemms=True,
         use_int8_gemms=True,
         fully_shard_degree=True,
+        use_parallel_vae=True,
     )
     default_input_values = DefaultInputValues(
         height=1024,
@@ -193,6 +200,11 @@ class xFuserZImageTurboModel(xFuserModel):
             torch_dtype=torch.bfloat16,
         )
         return pipe
+
+    def _post_load_and_state_initialization(self, input_args: dict) -> None:
+        super()._post_load_and_state_initialization(input_args)
+        if self.config.use_parallel_vae:
+            self._setup_parallel_vae()
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
         prompt = _normalize_prompt(input_args["prompt"])

--- a/xfuser/model_executor/models/runner_models/z_image.py
+++ b/xfuser/model_executor/models/runner_models/z_image.py
@@ -133,6 +133,8 @@ class xFuserZImageTurboModel(xFuserModel):
     min_diffusers_version = "0.36.0"
 
     capabilities = ModelCapabilities(
+        enable_tiling=True,
+        enable_slicing=True,
         use_fp8_gemms=True,
         use_int8_gemms=True,
         fully_shard_degree=True,


### PR DESCRIPTION
## What

Adds `--vae_tile_size`, one knob that narrows the VAE's tile window on every runner model, plus a guard that tells a failed VAE decode which flag would fix it.

## Why

A VAE's tile window defaults to something near its training resolution and never shrinks. Decoding above that resolution can therefore run out of memory with `--enable_tiling` already on, because it is the tile itself that no longer fits. The only way to narrow the window was to set diffusers attributes on the VAE by hand, and which attributes exist depends on the VAE class.

Chasing that turned up flags already failing quietly. `--enable_tiling` and `--enable_slicing` were doing nothing on models whose capability tables had lost the flags, and on VAE classes the installed diffusers cannot tile at all, because diffusers hands every autoencoder those methods through a mixin whether or not the class implements them.

## Coverage

`--vae_tile_size` takes one edge in output pixels and rescales whichever tiling attributes the VAE class carries, keeping their proportions. Those attributes come in three shapes across the seven VAE classes the runner models load, which is all of them:

| VAE class | attributes rescaled | reached by |
| --- | --- | --- |
| `AutoencoderKL` | `tile_sample_min_size` with `tile_latent_min_size` | SD3, Z-Image, Flux.1 |
| `AutoencoderKLFlux2` | same pair | Flux.2, Ideogram 4 |
| `AutoencoderKLWan` | `tile_sample_min_*` with `tile_sample_stride_*` | Wan 2.1/2.2, CausalWan, Cosmos3, LingBot-Video |
| `AutoencoderKLQwenImage` | same pair | Qwen-Image, Krea 2 |
| `AutoencoderKLHunyuanVideo` | same pair | HunyuanVideo |
| `AutoencoderKLLTX2Video` | same pair | LTX-2, LTX-2.3 |
| `AutoencoderKLHunyuanVideo15` | `tile_sample_min_*` with `tile_latent_min_*` | HunyuanVideo 1.5 |

Overlap factors are read but never rescaled, being fractions of a window that is itself changing. They do constrain which windows are legal: a window whose overlap lands on a fractional latent size is not offered. Frame tiling is left alone throughout, having nothing to do with a spatial tile edge.

A size the attributes cannot express exactly snaps down to the nearest window that works, rather than rounding into a fractional latent size the decoder would fail on. A size above the VAE's own window is declined, since widening it raises peak memory instead of lowering it. Both cases log what they did.

## Behaviour worth knowing

**It turns tiling on by itself.** LTX-2.3 tiles its stage-2 VAE at load, so requiring `--enable_tiling` alongside would mean tiling every stage just to reach the one that ran out of memory.

**Staged models get both VAEs.** A model that decodes in stages loads a second pipeline with its own VAE, and the later stage decodes at full resolution. All VAE options now reach both, which also removes the two `_enable_options` overrides LTX carried for this.

**Parallel VAE reaches five more models, and the rest are listed below.** Making the capability check real turned `--use_parallel_vae` from silently ignored into refused on models that never implemented it. Five of those decode through a VAE DistVAE already has an adapter for, so they are now wired up properly rather than left refusing: Z-Image, Z-Image-Turbo and SD3.5 through `AutoencoderKL`, CausalWan and Wan2.1-VACE through `AutoencoderKLWan`.

Still outstanding, because their decoders need an adapter written in [DistVAE](https://github.com/xdit-project/DistVAE) rather than a declaration here:

| Models | VAE | Blocks with no adapter |
| --- | --- | --- |
| Qwen-Image, Qwen-Image-Edit, Krea-2-Raw, Krea-2-Turbo | `AutoencoderKLQwenImage` | `QwenImageUpBlock`, and no `conv_norm_out` |
| HunyuanVideo | `AutoencoderKLHunyuanVideo` | `HunyuanVideoUpBlock3D` |
| HunyuanVideo 1.5 and its distilled variants | `AutoencoderKLHunyuanVideo15` | `HunyuanVideo15UpBlock3D` |
| LTX-2, LTX-2.3 | `AutoencoderKLLTX2Video` | `LTX2VideoUpBlock3d` |

Those refuse the flag with a message pointing at `--vae_tile_size`, which addresses the same memory pressure without the latency win. Encoder sharding is thinner still: DistVAE ships one encoder adapter, for Wan, so `--use_parallel_vae_encoder` remains limited to Wan I2V and Cosmos 3.

**Wiring parallel VAE is now one call, not a sixth copy.** Five runner files each carried their own module-level `_setup_parallel_vae`, so enabling a sixth model meant copying one of them and knowing which DistVAE adapter its decoder blocks call for by reading someone else's. The VAE answers that itself, from the blocks its decoder is built out of, so `xFuserModel._setup_parallel_vae` now does the whole job and the five copies are gone.

What looked model-specific in them was a function of the VAE's config. Both remaining differences come from `patch_size`: the encoder adapter shards by the encoder's own downsampling, so a VAE that patches has to divide that factor out, and the decoder adapter's patchify assumes no patching because Wan does none. Deriving both reproduces every value the copies passed, Cosmos 3's 16 over 2 included, and does nothing for a VAE that does not patch. Only a single factor counts as patching here, since `patch_size` is not one thing across VAE classes: Flux 2 declares `(2, 2)` for the pixel unshuffle at its boundary, which is not a factor either adapter takes.

That means a missing DistVAE adapter now raises where four of the five copies logged and carried on sharding nothing, or sharding only the decoder when the encoder was wanted too. Refusing up front also replaces an assertion thrown from inside a half-built replacement decoder with an error that names the flag.

**It composes with `--use_parallel_vae`, and is checked up front.** The two divide the same axis: diffusers hands the decoder one tile, then DistVAE splits that tile's latent rows across the VAE group. Below one row per rank, the split yields fewer patches than there are ranks and the surplus ranks index off the end without reporting anything. A window that thin is now refused, naming the smallest window that gives every rank a row.

**LTX-2 wants a wide window.** It compresses space hard enough that a narrow window leaves very few latent rows per tile, and a tile can arrive thinner than a convolution's own padding, which torch reports from deep inside the decoder without mentioning tiles. Whether it happens depends on the output size, so it cannot be caught when the window is set. That failure is now prefaced with the window that caused it, and a larger window can fail where a smaller one works, so the message says to try another size rather than only to go smaller.

**Version floors.** Tiling and slicing arrived class by class across diffusers releases, Wan's tiling in 0.34, one past the `diffusers>=0.33.0` floor in setup.py. An install that satisfies the floor can still be short of the class a model loads, so both flags now raise instead of silently doing nothing.

## Fixes included

- Wan 2.2 distilled I2V, Qwen-Image and Z-Image-Turbo had lost `enable_tiling` and `enable_slicing` from their capability tables. `ModelCapabilities` is frozen, so re-declaring the block without a flag reads as `False`, and `--enable_tiling` was refused on three models that support it.
- The capability check tested every int-valued config with `value > 1`, written for degrees like `ulysses_degree`. `bool` subclasses `int`, so boolean flags took that branch, `True > 1` is `False`, and no boolean capability was ever refused: `--use_parallel_vae` on a model that cannot do it ran as a silent no-op.
- Making that check real exposed CausalWan declaring `use_fp8_gemms=False` in the same class body that lists `fp8_gemm_module_list=["transformer.blocks"]`. The declaration was the wrong half. The declarations this change makes load-bearing were audited against the code reading them, including both hybrid schedule flags, which are declared exactly where `_calculate_hybrid_attention_step_multiplier` accounts for the model's steps.
- One of the two `--enable_slicing` definitions described tiling.

## Structure

The diffusers VAE knowledge, which attributes each class carries and how they scale, lives in `xfuser/core/utils/vae_tiling.py` and reads no xDiT config. Its counterpart `vae_parallel.py` holds the DistVAE half: which adapter a decoder's blocks call for, and the numbers an adapter has to be told about the VAE. Neither reads xDiT config. The runner keeps the policy: what to do with a size that does not fit, what to say when a decode fails.

## Test plan

`tests/core/test_vae_tiling.py` and `tests/core/test_vae_parallel.py`, 37 tests, no downloads. Each of the seven VAE classes is built tiny, resized through the same planning the flag uses, and decoded on CPU, asserting the output matches an untiled decode's size, so a window that only looks valid still has to survive a real decode. The rest covers the three attribute shapes, snapping, the fractional-latent rejection, latent-row counting for the parallel-VAE check, and the padding-error matcher against verbatim text from `AutoencoderKLLTX2Video`.

The parallel-VAE tests pin which adapter each VAE class needs, so a decoder reworked upstream breaks the mapping loudly instead of at someone's first multi-GPU decode, and check that an unshardable VAE is refused before its decode is touched. They also pin the encoder scale factor the five deleted copies used to derive by hand, patching divided out, since that number is now shared. Because the real adapters need a process group, a stand-in stands in for them, which puts every VAE class through the config reads that wrapping does rather than only the ones picking an adapter does.

Not covered by these tests: multi-GPU behaviour, which was reasoned about rather than run. The five newly enabled models each want a two-rank decode checked against a single-rank one before this merges. So does one model per adapter among the eight already using parallel VAE, since their wiring moved to the shared method: the decoder is wrapped by the same adapter with the same arguments, but only a real two-rank decode shows it.
