### PR TITLE
feat: add AITER CK VSA for Wan

### DIFF
--- a/benchmarks/wan_vsa_accuracy.py
+++ b/benchmarks/wan_vsa_accuracy.py
@@ -1,0 +1,159 @@
+"""Trace Wan diffusion accuracy per timestep.
+
+Run with torchrun. Capture a dense reference first, then compare VSA online:
+
+  torchrun --nproc_per_node=4 benchmarks/wan_vsa_accuracy.py capture ...
+  torchrun --nproc_per_node=4 benchmarks/wan_vsa_accuracy.py compare \
+      --reference dense.pt --attention-backend AITER_VSA ...
+"""
+
+import argparse
+import json
+import os
+
+import torch
+import torch.nn.functional as F
+
+from xfuser import xFuserArgs
+from xfuser.runner import xFuserModelRunner
+
+
+def _metric(reference: torch.Tensor, actual: torch.Tensor) -> dict:
+    reference = reference.to(actual.device, torch.float32)
+    actual = actual.float()
+    delta = actual - reference
+    return {
+        "mae": float(delta.abs().mean()),
+        "rmse": float(delta.square().mean().sqrt()),
+        "relative_l2": float(
+            torch.linalg.vector_norm(delta)
+            / torch.linalg.vector_norm(reference).clamp_min(1e-12)
+        ),
+        "cosine": float(
+            F.cosine_similarity(reference.flatten(), actual.flatten(), dim=0)
+        ),
+    }
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mode", choices=("capture", "compare"))
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--reference")
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--attention-backend", default="AITER")
+    parser.add_argument("--prompt", required=True)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--steps", type=int, default=50)
+    parser.add_argument("--height", type=int, default=480)
+    parser.add_argument("--width", type=int, default=832)
+    parser.add_argument("--frames", type=int, default=81)
+    parser.add_argument("--guidance-scale", type=float, default=6.0)
+    parser.add_argument("--flow-shift", type=float, default=8.0)
+    parser.add_argument("--vsa-drop-rates", type=float, nargs="+")
+    parser.add_argument("--vsa-prob-threshold", type=float, default=0.9)
+    parser.add_argument("--ulysses-degree", type=int, default=4)
+    args = parser.parse_args()
+    if args.mode == "compare" and not args.reference:
+        parser.error("--reference is required in compare mode")
+    return args
+
+
+def main():
+    args = _parse_args()
+    rank = int(os.environ.get("RANK", "0"))
+    config = xFuserArgs(
+        model="Wan2.1-T2V",
+        attention_backend=args.attention_backend,
+        cross_attention_backend="AITER",
+        dit_parallel_size=args.ulysses_degree,
+        ulysses_degree=args.ulysses_degree,
+        ring_degree=1,
+        height=args.height,
+        width=args.width,
+        num_frames=args.frames,
+        num_inference_steps=args.steps,
+        prompt=args.prompt,
+        negative_prompt=None,
+        seed=args.seed,
+        guidance_scale=args.guidance_scale,
+        flow_shift=args.flow_shift,
+        output_directory="/tmp/wan-vsa-accuracy",
+        warmup_steps=0,
+        vsa_drop_rates=args.vsa_drop_rates,
+        vsa_prob_threshold=args.vsa_prob_threshold,
+        input_images=[],
+    )
+    runner = xFuserModelRunner(vars(config))
+    runner.model.settings.model_name = args.model_path
+    input_args = runner.preprocess_args(vars(config))
+    runner.initialize(input_args)
+    runner.model.pipe.transformer.attention_kwargs[
+        "vsa_collect_density"
+    ] = True
+
+    reference = None
+    if rank == 0 and args.mode == "compare":
+        reference = torch.load(args.reference, map_location="cpu")["trace"]
+
+    scheduler = runner.model.pipe.scheduler
+    original_step = scheduler.step
+    trace = []
+    rows = []
+
+    def traced_step(*step_args, **step_kwargs):
+        output = original_step(*step_args, **step_kwargs)
+        model_output = (
+            step_args[0] if step_args else step_kwargs["model_output"]
+        )
+        timestep = (
+            step_args[1] if len(step_args) > 1 else step_kwargs["timestep"]
+        )
+        latent = output[0] if isinstance(output, tuple) else output.prev_sample
+        index = len(trace) if args.mode == "capture" else len(rows)
+        if rank == 0:
+            transformer = runner.model.pipe.transformer
+            schedule = transformer.attention_kwargs
+            metadata = {
+                "step": index,
+                "timestep": float(timestep.reshape(-1)[0]),
+                "vsa_step_index": schedule.get("vsa_step_index"),
+                "vsa_num_steps": schedule.get("vsa_num_steps"),
+                "drop_rate": schedule.get("vsa_effective_drop_rate"),
+                "use_dense": schedule.get("vsa_use_dense"),
+            }
+            density = schedule.get("vsa_last_density")
+            if density is not None:
+                metadata["last_layer_density"] = float(density)
+            if args.mode == "capture":
+                trace.append(
+                    {
+                        **metadata,
+                        "noise": model_output.detach().float().cpu(),
+                        "latent": latent.detach().float().cpu(),
+                    }
+                )
+            else:
+                expected = reference[index]
+                rows.append(
+                    {
+                        **metadata,
+                        "noise": _metric(expected["noise"], model_output),
+                        "latent": _metric(expected["latent"], latent),
+                    }
+                )
+        return output
+
+    scheduler.step = traced_step
+    _, timings = runner.run(input_args)
+    if rank == 0:
+        if args.mode == "capture":
+            torch.save({"trace": trace, "timings": timings}, args.output)
+        else:
+            with open(args.output, "w") as handle:
+                json.dump({"rows": rows, "timings": timings}, handle, indent=2)
+    runner.cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/wan_vsa_accuracy.py
+++ b/benchmarks/wan_vsa_accuracy.py
@@ -82,15 +82,13 @@ def main():
         warmup_steps=0,
         vsa_drop_rates=args.vsa_drop_rates,
         vsa_prob_threshold=args.vsa_prob_threshold,
+        vsa_collect_density=True,
         input_images=[],
     )
     runner = xFuserModelRunner(vars(config))
     runner.model.settings.model_name = args.model_path
     input_args = runner.preprocess_args(vars(config))
     runner.initialize(input_args)
-    runner.model.pipe.transformer.attention_kwargs[
-        "vsa_collect_density"
-    ] = True
 
     reference = None
     if rank == 0 and args.mode == "compare":

--- a/benchmarks/wan_vsa_video_validation.py
+++ b/benchmarks/wan_vsa_video_validation.py
@@ -1,0 +1,163 @@
+"""Run paired Dense/VSA Wan validations without reloading model weights."""
+
+import argparse
+import json
+import math
+import os
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from xfuser import xFuserArgs
+from xfuser.core.distributed.attention_backend import AttentionBackendType
+from xfuser.core.distributed.runtime_state import get_runtime_state
+from xfuser.runner import xFuserModelRunner
+
+
+DEFAULT_PROMPTS = (
+    "Two anthropomorphic cats in boxing gear fight on a spotlighted stage.",
+    "A red sailboat crosses a stormy ocean at sunset, cinematic camera.",
+    "A robot chef chops vegetables in a bright modern kitchen.",
+)
+
+
+def _tensor_video(video) -> torch.Tensor:
+    frames = video[0] if isinstance(video, list) and len(video) == 1 else video
+    array = np.stack([np.asarray(frame) for frame in frames])
+    result = torch.from_numpy(array).float()
+    if result.max() > 1.0:
+        result.div_(255.0)
+    return result.permute(0, 3, 1, 2).contiguous()
+
+
+def _ssim(reference: torch.Tensor, actual: torch.Tensor) -> float:
+    channels = reference.shape[1]
+    coords = torch.arange(11, dtype=torch.float32) - 5
+    gaussian = torch.exp(-(coords * coords) / (2 * 1.5 * 1.5))
+    gaussian /= gaussian.sum()
+    window = torch.outer(gaussian, gaussian)
+    window = window.expand(channels, 1, 11, 11)
+    mu_x = F.conv2d(reference, window, padding=5, groups=channels)
+    mu_y = F.conv2d(actual, window, padding=5, groups=channels)
+    sigma_x = F.conv2d(reference * reference, window, padding=5, groups=channels)
+    sigma_y = F.conv2d(actual * actual, window, padding=5, groups=channels)
+    sigma_xy = F.conv2d(reference * actual, window, padding=5, groups=channels)
+    sigma_x -= mu_x.square()
+    sigma_y -= mu_y.square()
+    sigma_xy -= mu_x * mu_y
+    c1, c2 = 0.01 ** 2, 0.03 ** 2
+    score = ((2 * mu_x * mu_y + c1) * (2 * sigma_xy + c2)) / (
+        (mu_x.square() + mu_y.square() + c1) * (sigma_x + sigma_y + c2)
+    )
+    return float(score.mean())
+
+
+def _metrics(reference, actual, lpips_metric=None) -> dict:
+    reference = _tensor_video(reference)
+    actual = _tensor_video(actual)
+    mse = float((reference - actual).square().mean())
+    result = {
+        "mae": float((reference - actual).abs().mean()),
+        "psnr": -10.0 * math.log10(max(mse, 1e-12)),
+        "ssim": _ssim(reference, actual),
+    }
+    if lpips_metric is not None:
+        lpips_metric.reset()
+        sampled_reference = F.interpolate(
+            reference[::8], size=(224, 224), mode="bilinear",
+            align_corners=False,
+        )
+        sampled_actual = F.interpolate(
+            actual[::8], size=(224, 224), mode="bilinear",
+            align_corners=False,
+        )
+        for start in range(0, len(sampled_reference), 2):
+            lpips_metric.update(
+                sampled_reference[start:start + 2],
+                sampled_actual[start:start + 2],
+            )
+        result["lpips_alex_frame_stride_8"] = float(lpips_metric.compute())
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--prompts", nargs="+", default=DEFAULT_PROMPTS)
+    parser.add_argument("--seeds", type=int, nargs="+", default=(0, 1, 2))
+    parser.add_argument("--steps", type=int, default=50)
+    parser.add_argument("--height", type=int, default=480)
+    parser.add_argument("--width", type=int, default=832)
+    parser.add_argument("--frames", type=int, default=81)
+    parser.add_argument("--iterations", type=int, default=1)
+    args = parser.parse_args()
+    rank = int(os.environ.get("RANK", "0"))
+
+    config = xFuserArgs(
+        model="Wan2.1-T2V", attention_backend="AITER_VSA",
+        cross_attention_backend="AITER", dit_parallel_size=4,
+        ulysses_degree=4, ring_degree=1, height=args.height,
+        width=args.width, num_frames=args.frames,
+        num_inference_steps=args.steps, prompt=args.prompts[0],
+        seed=args.seeds[0], guidance_scale=6.0, flow_shift=8.0,
+        output_directory="/tmp/wan-vsa-validation", warmup_steps=0,
+        num_iterations=args.iterations,
+        vsa_drop_rates=[0.25, 0.40], vsa_prob_threshold=0.9,
+        input_images=[],
+    )
+    runner = xFuserModelRunner(vars(config))
+    runner.model.settings.model_name = args.model_path
+    first_input = runner.preprocess_args(vars(config))
+    runner.initialize(first_input)
+    runtime = get_runtime_state()
+    rows = []
+    lpips_metric = None
+    if rank == 0:
+        try:
+            from torchmetrics.image.lpip import (
+                LearnedPerceptualImagePatchSimilarity,
+            )
+            lpips_metric = LearnedPerceptualImagePatchSimilarity(
+                net_type="alex", normalize=True, sync_on_compute=False
+            )
+        except (ImportError, RuntimeError):
+            pass
+
+    for prompt in args.prompts:
+        for seed in args.seeds:
+            run_args = dict(first_input, prompt=prompt, seed=seed)
+            runtime.attention_backend = AttentionBackendType.AITER
+            dense, dense_time = runner.run(run_args)
+            runtime.attention_backend = AttentionBackendType.AITER_VSA
+            sparse, sparse_time = runner.run(run_args)
+            if rank == 0:
+                rows.append({
+                    "prompt": prompt,
+                    "seed": seed,
+                    "metrics": _metrics(
+                        dense.videos, sparse.videos, lpips_metric
+                    ),
+                    "dense_seconds": dense_time[-1],
+                    "vsa_seconds": sparse_time[-1],
+                    "speedup": dense_time[-1] / sparse_time[-1],
+                })
+
+    if rank == 0:
+        summary = {
+            "mean_psnr": float(np.mean([r["metrics"]["psnr"] for r in rows])),
+            "mean_ssim": float(np.mean([r["metrics"]["ssim"] for r in rows])),
+            "mean_speedup": float(np.mean([r["speedup"] for r in rows])),
+        }
+        if lpips_metric is not None:
+            summary["mean_lpips_alex_frame_stride_8"] = float(np.mean([
+                r["metrics"]["lpips_alex_frame_stride_8"] for r in rows
+            ]))
+        with open(args.output, "w") as handle:
+            json.dump({"summary": summary, "rows": rows}, handle, indent=2)
+    runner.cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/wan_vsa_video_validation.py
+++ b/benchmarks/wan_vsa_video_validation.py
@@ -81,6 +81,11 @@ def _metrics(reference, actual, lpips_metric=None) -> dict:
     return result
 
 
+def _measured_timings(timings: list[float]) -> list[float]:
+    """Discard the first iteration as warmup when repeats are available."""
+    return timings[1:] if len(timings) > 1 else timings
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--output", required=True)
@@ -133,15 +138,21 @@ def main():
             runtime.attention_backend = AttentionBackendType.AITER_VSA
             sparse, sparse_time = runner.run(run_args)
             if rank == 0:
+                dense_measured = _measured_timings(dense_time)
+                sparse_measured = _measured_timings(sparse_time)
+                dense_seconds = float(np.mean(dense_measured))
+                sparse_seconds = float(np.mean(sparse_measured))
                 rows.append({
                     "prompt": prompt,
                     "seed": seed,
                     "metrics": _metrics(
                         dense.videos, sparse.videos, lpips_metric
                     ),
-                    "dense_seconds": dense_time[-1],
-                    "vsa_seconds": sparse_time[-1],
-                    "speedup": dense_time[-1] / sparse_time[-1],
+                    "dense_timings": dense_measured,
+                    "vsa_timings": sparse_measured,
+                    "dense_seconds": dense_seconds,
+                    "vsa_seconds": sparse_seconds,
+                    "speedup": dense_seconds / sparse_seconds,
                 })
 
     if rank == 0:

--- a/tests/core/test_vsa_attention.py
+++ b/tests/core/test_vsa_attention.py
@@ -6,6 +6,8 @@ import torch
 
 from xfuser.config.args import xFuserArgs
 from xfuser.config.config import RuntimeConfig
+from xfuser.core.distributed.attention_backend import AttentionBackendType
+from xfuser.core.distributed.runtime_state import DiTRuntimeState
 from xfuser.core.vsa_attention import (
     _first_frame_block_count,
     aiter_vsa_attention,
@@ -137,6 +139,26 @@ def test_vsa_probability_defaults_match_benchmark():
     )
 
 
+def test_vsa_rejects_hybrid_attention_schedule():
+    state = DiTRuntimeState.__new__(DiTRuntimeState)
+    state.runtime_config = RuntimeConfig(use_hybrid_attn_schedule=True)
+
+    with pytest.raises(RuntimeError, match="hybrid attention schedule"):
+        state._check_if_backend_compatible_with_current_configuration(
+            AttentionBackendType.AITER_VSA
+        )
+
+
+def test_runtime_state_tracks_vsa_schedule_per_timestep():
+    state = DiTRuntimeState.__new__(DiTRuntimeState)
+    state.reset_vsa_schedule_state(2)
+
+    assert state.advance_vsa_schedule(1000.0) == (0, 2)
+    assert state.advance_vsa_schedule(1000.0) == (0, 2)
+    assert state.advance_vsa_schedule(500.0) == (1, 2)
+    assert state.advance_vsa_schedule(0.0) == (0, 2)
+
+
 def test_first_frame_blocks_ignore_cross_frame_partial_block():
     # Wan 480x832 has a 21x30x52 post-patch grid. Twelve 128-token
     # blocks fit wholly in the first frame; the remaining 24 tokens share
@@ -161,6 +183,26 @@ def test_padded_static_mask_cache_uses_layout_identity():
     first = setup_sparge(query, query, query, **kwargs)[-1]
     second = setup_sparge(query.clone(), query, query, **kwargs)[-1]
     assert first is second
+
+
+@pytest.mark.parametrize("reorder_sequence", [False, True])
+def test_existing_sparge_paths_keep_padded_mask_allocation(reorder_sequence):
+    query = torch.randn(1, 1, 24, 4)
+    kwargs = {
+        "thw": (2, 3, 4),
+        "sp_size": 1,
+        "reorder_sequence": reorder_sequence,
+        "use_static_block_mask": True,
+        "block_m": 16,
+        "block_n": 16,
+        "pad_block_divisible": True,
+        "use_sliced_gilbert": False,
+    }
+    first = setup_sparge(query, query, query, **kwargs)[-1]
+    second = setup_sparge(query.clone(), query, query, **kwargs)[-1]
+
+    assert first is not second
+    torch.testing.assert_close(first, second)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires AITER GPU")

--- a/tests/core/test_vsa_attention.py
+++ b/tests/core/test_vsa_attention.py
@@ -1,14 +1,22 @@
+import inspect
 import math
 
-import torch
 import pytest
+import torch
 
+from xfuser.config.args import xFuserArgs
+from xfuser.config.config import RuntimeConfig
 from xfuser.core.vsa_attention import (
+    _first_frame_block_count,
+    aiter_vsa_attention,
     block_mask_to_delta_lut,
     build_jenga_block_mask,
     jenga_scheduled_drop_rate,
 )
-from xfuser.core.sparge_attention.sparge import get_sliced_gilbert_perm
+from xfuser.core.sparge_attention.sparge import (
+    get_sliced_gilbert_perm,
+    setup_sparge,
+)
 
 
 def _reference_jenga_mask(query, key, block_size, top_k, threshold):
@@ -102,8 +110,83 @@ def test_jenga_scheduled_drop_rate_matches_reference():
     )
     assert jenga_scheduled_drop_rate(25, 50, rates) == 0.75
     assert jenga_scheduled_drop_rate(26, 50, rates) == 0.85
-    assert jenga_scheduled_drop_rate(19, 20, rates) == 0.75
-    assert jenga_scheduled_drop_rate(26, 30, rates) == 0.85
+    assert jenga_scheduled_drop_rate(10, 20, rates) == 0.75
+    assert jenga_scheduled_drop_rate(11, 20, rates) == 0.85
+    assert jenga_scheduled_drop_rate(15, 30, rates) == 0.75
+    assert jenga_scheduled_drop_rate(16, 30, rates) == 0.85
+
+
+def test_vsa_probability_defaults_match_benchmark():
+    assert (
+        xFuserArgs.__dataclass_fields__["vsa_prob_threshold"].default
+        == 0.9
+    )
+    assert (
+        RuntimeConfig.__dataclass_fields__["vsa_prob_threshold"].default
+        == 0.9
+    )
+    assert (
+        RuntimeConfig.__dataclass_fields__["vsa_collect_density"].default
+        is False
+    )
+    assert (
+        inspect.signature(build_jenga_block_mask)
+        .parameters["prob_threshold"]
+        .default
+        == 0.9
+    )
+
+
+def test_first_frame_blocks_ignore_cross_frame_partial_block():
+    # Wan 480x832 has a 21x30x52 post-patch grid. Twelve 128-token
+    # blocks fit wholly in the first frame; the remaining 24 tokens share
+    # a boundary block with the next frame.
+    assert _first_frame_block_count((21, 30, 52), 128) == 12
+    with pytest.raises(ValueError, match="positive"):
+        _first_frame_block_count((0, 30, 52), 128)
+
+
+def test_padded_static_mask_cache_uses_layout_identity():
+    query = torch.randn(1, 1, 24, 4)
+    kwargs = {
+        "thw": (2, 3, 4),
+        "sp_size": 1,
+        "reorder_sequence": True,
+        "use_static_block_mask": True,
+        "block_m": 16,
+        "block_n": 16,
+        "pad_block_divisible": True,
+        "use_sliced_gilbert": True,
+    }
+    first = setup_sparge(query, query, query, **kwargs)[-1]
+    second = setup_sparge(query.clone(), query, query, **kwargs)[-1]
+    assert first is second
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires AITER GPU")
+def test_vsa_density_collection_is_opt_in():
+    query = torch.randn(
+        1, 4, 256, 128, device="cuda", dtype=torch.bfloat16
+    )
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+    kwargs = {
+        "thw": (1, 16, 16),
+        "sp_size": 1,
+        "drop_rate": 0.5,
+        "reorder_sequence": False,
+        "use_static_block_mask": False,
+        "use_first_frame_mask": False,
+    }
+    _, disabled_density = aiter_vsa_attention(
+        query, key, value, collect_density=False, **kwargs
+    )
+    _, enabled_density = aiter_vsa_attention(
+        query, key, value, collect_density=True, **kwargs
+    )
+    assert disabled_density is None
+    assert enabled_density is not None
+    assert 0.0 < float(enabled_density) <= 1.0
 
 
 def test_sliced_gilbert_permutation_matches_jenga_reference():

--- a/tests/core/test_vsa_attention.py
+++ b/tests/core/test_vsa_attention.py
@@ -1,0 +1,162 @@
+import math
+
+import torch
+import pytest
+
+from xfuser.core.vsa_attention import (
+    block_mask_to_delta_lut,
+    build_jenga_block_mask,
+    jenga_scheduled_drop_rate,
+)
+from xfuser.core.sparge_attention.sparge import get_sliced_gilbert_perm
+
+
+def _reference_jenga_mask(query, key, block_size, top_k, threshold):
+    batch, heads, sequence, head_dim = query.shape
+    blocks = sequence // block_size
+    query_pool = query.reshape(
+        batch, heads, blocks, block_size, head_dim
+    ).mean(dim=-2)
+    key_pool = key.reshape(
+        batch, heads, blocks, block_size, head_dim
+    ).mean(dim=-2)
+    scores = torch.matmul(query_pool, key_pool.transpose(-1, -2))
+    probabilities = torch.softmax(scores * head_dim**-0.5, dim=-1)
+    sorted_probabilities, indices = probabilities.sort(
+        dim=-1, descending=True
+    )
+    needed = (sorted_probabilities.cumsum(-1) <= threshold).sum(-1) + 1
+    needed = needed.clamp(min=top_k, max=blocks)
+    result = torch.zeros(
+        batch, heads, blocks, blocks, dtype=torch.bool
+    )
+    for b in range(batch):
+        for h in range(heads):
+            for q in range(blocks):
+                result[b, h, q, indices[b, h, q, : needed[b, h, q]]] = True
+    return result
+
+
+def test_build_jenga_block_mask_matches_reference():
+    generator = torch.Generator().manual_seed(17)
+    query = torch.randn(2, 3, 32, 8, generator=generator)
+    key = torch.randn(2, 3, 32, 8, generator=generator)
+
+    actual = build_jenga_block_mask(
+        query,
+        key,
+        block_size=8,
+        top_k=2,
+        prob_threshold=0.7,
+    )
+    expected = _reference_jenga_mask(query, key, 8, 2, 0.7)
+    torch.testing.assert_close(actual, expected)
+
+
+def test_jenga_mask_unions_static_and_first_frame_relations():
+    query = torch.zeros(1, 1, 32, 4)
+    key = torch.zeros_like(query)
+    static = torch.eye(4, dtype=torch.bool)
+
+    mask = build_jenga_block_mask(
+        query,
+        key,
+        block_size=8,
+        top_k=1,
+        prob_threshold=0.0,
+        static_block_mask=static,
+        first_frame_blocks=2,
+    )
+
+    assert mask[0, 0, 0, :2].all()
+    assert mask[0, 0, 1, :2].all()
+    assert mask[0, 0, 2, 2]
+    assert mask[0, 0, 3, 3]
+
+
+def test_block_mask_to_delta_lut():
+    mask = torch.tensor(
+        [[[[True, False, True, False, False, True], [False, True, False, True, False, False]]]]
+    )
+    lut, counts = block_mask_to_delta_lut(mask)
+
+    assert lut.dtype == torch.int32
+    assert counts.dtype == torch.int32
+    torch.testing.assert_close(counts, torch.tensor([[[3, 2]]], dtype=torch.int32))
+    torch.testing.assert_close(
+        lut[0, 0, 0, :3], torch.tensor([0, 2, 3], dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        lut[0, 0, 1, :2], torch.tensor([1, 2], dtype=torch.int32)
+    )
+
+
+def test_jenga_scheduled_drop_rate_matches_reference():
+    rates = [0.75, 0.85]
+    assert jenga_scheduled_drop_rate(0, 50, rates) == 0.0
+    assert math.isclose(
+        jenga_scheduled_drop_rate(1, 50, rates), 0.75 * 10 / 49
+    )
+    assert math.isclose(
+        jenga_scheduled_drop_rate(2, 50, rates), 0.75 * 20 / 49
+    )
+    assert jenga_scheduled_drop_rate(25, 50, rates) == 0.75
+    assert jenga_scheduled_drop_rate(26, 50, rates) == 0.85
+    assert jenga_scheduled_drop_rate(19, 20, rates) == 0.75
+    assert jenga_scheduled_drop_rate(26, 30, rates) == 0.85
+
+
+def test_sliced_gilbert_permutation_matches_jenga_reference():
+    forward, inverse = get_sliced_gilbert_perm(
+        (2, 3, 4), torch.device("cpu")
+    )
+    assert inverse.tolist() == [
+        0, 1, 10, 11, 3, 2, 9, 8, 4, 5, 6, 7,
+        23, 22, 13, 12, 20, 21, 14, 15, 19, 18, 17, 16,
+    ]
+    assert forward.tolist() == [
+        0, 1, 5, 4, 8, 9, 10, 11, 7, 6, 2, 3,
+        15, 14, 18, 19, 23, 22, 21, 20, 16, 17, 13, 12,
+    ]
+    torch.testing.assert_close(inverse[forward], torch.arange(24))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires AITER GPU")
+def test_ck_vsa_matches_masked_dense():
+    try:
+        from aiter.ops.jenga_sparse_attention import vsa_sparse_attention
+    except ImportError:
+        pytest.skip("AITER VSA kernel is unavailable")
+
+    torch.manual_seed(7)
+    query = torch.randn(
+        1, 4, 256, 128, device="cuda", dtype=torch.bfloat16
+    )
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+    block_mask = torch.tensor(
+        [[[[True, False], [True, True]]]], device="cuda"
+    ).expand(1, 4, 2, 2).contiguous()
+    lut, counts = block_mask_to_delta_lut(block_mask)
+    seqstart = torch.tensor([0, 256], device="cuda", dtype=torch.int32)
+    output = torch.empty_like(query)
+    output = vsa_sparse_attention(
+        query, key, value, lut, counts, output, None, None,
+        seqstart, seqstart, 0, 1, 4, 4, 256, 256, 128, 128,
+    )
+
+    token_mask = block_mask.repeat_interleave(
+        128, dim=-2
+    ).repeat_interleave(128, dim=-1)
+    scores = torch.matmul(query.float(), key.float().transpose(-1, -2))
+    scores.mul_(128 ** -0.5).masked_fill_(~token_mask, -torch.inf)
+    reference = torch.matmul(torch.softmax(scores, dim=-1), value.float())
+    relative_l2 = (
+        torch.linalg.vector_norm(output.float() - reference)
+        / torch.linalg.vector_norm(reference)
+    )
+    cosine = torch.nn.functional.cosine_similarity(
+        output.float().flatten(), reference.flatten(), dim=0
+    )
+    assert float(relative_l2) <= 1e-2
+    assert float(cosine) >= 0.999

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -130,6 +130,8 @@ class xFuserArgs:
     coco_path: Optional[str] = None
     use_cache: bool = False
     use_teacache: bool = False
+    wan_teacache_thresh: float = 0.2
+    wan_teacache_use_ret_steps: bool = False
     use_fbcache: bool = False
     # Other arguments
     use_fp8_t5_encoder: bool = False
@@ -176,6 +178,16 @@ class xFuserArgs:
     spargeattn_simthreshold: float = 0.3
     spargeattn_cdfthreshold: float = 0.92
     use_spargeattn_head_balance: bool = False
+    # AITER CK-Tile VSA attention
+    vsa_block_size: int = 128
+    vsa_top_k: int = 1
+    vsa_top_k_ratio: float = 0.0
+    vsa_drop_rates: Optional[List[float]] = None
+    vsa_calls_per_step: int = 2
+    vsa_prob_threshold: float = 0.9
+    vsa_reorder_sequence: bool = True
+    use_vsa_static_block_mask: bool = True
+    use_vsa_first_frame_mask: bool = True
     # Distilled model weight paths
     distilled_transformer_path: Optional[str] = None
     distilled_transformer_2_path: Optional[str] = None
@@ -225,7 +237,18 @@ class xFuserArgs:
         runtime_group.add_argument(
             "--use_teacache",
             action="store_true",
-            help="Enable teacache to accelerate inference in a single card",
+            help="Enable TeaCache. Wan supports sequence parallel TeaCache.",
+        )
+        runtime_group.add_argument(
+            "--wan_teacache_thresh",
+            type=float,
+            default=0.2,
+            help="Wan TeaCache accumulated relative-L1 threshold.",
+        )
+        runtime_group.add_argument(
+            "--wan_teacache_use_ret_steps",
+            action="store_true",
+            help="Use Wan TeaCache retention-step coefficients and warmup.",
         )
         runtime_group.add_argument(
             "--use_fbcache",
@@ -800,6 +823,64 @@ class xFuserArgs:
                  "effect with ulysses_degree>1 and a Sparge attention backend.",
         )
         parser.add_argument(
+            "--vsa_block_size",
+            type=int,
+            default=128,
+            help="Query/KV block size for the AITER CK-Tile VSA backend.",
+        )
+        parser.add_argument(
+            "--vsa_top_k",
+            type=int,
+            default=1,
+            help="Minimum KV blocks selected per query block by AITER VSA.",
+        )
+        parser.add_argument(
+            "--vsa_top_k_ratio",
+            type=float,
+            default=0.0,
+            help="Minimum selected KV-block fraction for AITER VSA. "
+                 "For Jenga drop rate r, set this to 1-r.",
+        )
+        parser.add_argument(
+            "--vsa_drop_rates",
+            type=float,
+            nargs="+",
+            default=None,
+            help="Enable Jenga's per-step sparse schedule. One value applies "
+                 "to all steps; two values switch after the midpoint. "
+                 "Drop rates <=0.25 use dense AITER attention.",
+        )
+        parser.add_argument(
+            "--vsa_calls_per_step",
+            type=int,
+            default=2,
+            help="Legacy override; Wan infers calls per step from CFG mode.",
+        )
+        parser.add_argument(
+            "--vsa_prob_threshold",
+            type=float,
+            default=0.9,
+            help="Jenga cumulative probability threshold for AITER VSA.",
+        )
+        parser.add_argument(
+            "--vsa_reorder_sequence",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            help="Reorder Wan video tokens with the sliced Gilbert curve before VSA.",
+        )
+        parser.add_argument(
+            "--use_vsa_static_block_mask",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            help="Union Gilbert physical-neighbor blocks into the dynamic VSA mask.",
+        )
+        parser.add_argument(
+            "--use_vsa_first_frame_mask",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            help="Preserve first-frame block relations in the VSA mask.",
+        )
+        parser.add_argument(
             "--distilled_transformer_path",
             type=nullable_str,
             default=None,
@@ -893,6 +974,10 @@ class xFuserArgs:
             use_parallel_vae=self.use_parallel_vae,
             use_torch_compile=self.use_torch_compile,
             use_onediff=self.use_onediff,
+            use_teacache=self.use_teacache,
+            wan_teacache_thresh=self.wan_teacache_thresh,
+            wan_teacache_use_ret_steps=self.wan_teacache_use_ret_steps,
+            use_fbcache=self.use_fbcache,
             # use_profiler=self.use_profiler,
             use_fp8_t5_encoder=self.use_fp8_t5_encoder,
             attention_backend=self.attention_backend,
@@ -902,6 +987,15 @@ class xFuserArgs:
             spargeattn_simthreshold=self.spargeattn_simthreshold,
             spargeattn_cdfthreshold=self.spargeattn_cdfthreshold,
             use_spargeattn_head_balance=self.use_spargeattn_head_balance,
+            vsa_block_size=self.vsa_block_size,
+            vsa_top_k=self.vsa_top_k,
+            vsa_top_k_ratio=self.vsa_top_k_ratio,
+            vsa_drop_rates=self.vsa_drop_rates,
+            vsa_calls_per_step=self.vsa_calls_per_step,
+            vsa_prob_threshold=self.vsa_prob_threshold,
+            vsa_reorder_sequence=self.vsa_reorder_sequence,
+            use_vsa_static_block_mask=self.use_vsa_static_block_mask,
+            use_vsa_first_frame_mask=self.use_vsa_first_frame_mask,
         )
 
         parallel_config = ParallelConfig(

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -957,6 +957,7 @@ class xFuserArgs:
         runtime_config = RuntimeConfig(
             warmup_steps=self.warmup_steps,
             # use_cuda_graph=self.use_cuda_graph,
+            use_hybrid_attn_schedule=self.use_hybrid_attn_schedule,
             use_parallel_vae=self.use_parallel_vae,
             use_torch_compile=self.use_torch_compile,
             use_onediff=self.use_onediff,

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -130,8 +130,6 @@ class xFuserArgs:
     coco_path: Optional[str] = None
     use_cache: bool = False
     use_teacache: bool = False
-    wan_teacache_thresh: float = 0.2
-    wan_teacache_use_ret_steps: bool = False
     use_fbcache: bool = False
     # Other arguments
     use_fp8_t5_encoder: bool = False
@@ -183,11 +181,11 @@ class xFuserArgs:
     vsa_top_k: int = 1
     vsa_top_k_ratio: float = 0.0
     vsa_drop_rates: Optional[List[float]] = None
-    vsa_calls_per_step: int = 2
     vsa_prob_threshold: float = 0.9
     vsa_reorder_sequence: bool = True
     use_vsa_static_block_mask: bool = True
     use_vsa_first_frame_mask: bool = True
+    vsa_collect_density: bool = False
     # Distilled model weight paths
     distilled_transformer_path: Optional[str] = None
     distilled_transformer_2_path: Optional[str] = None
@@ -237,18 +235,7 @@ class xFuserArgs:
         runtime_group.add_argument(
             "--use_teacache",
             action="store_true",
-            help="Enable TeaCache. Wan supports sequence parallel TeaCache.",
-        )
-        runtime_group.add_argument(
-            "--wan_teacache_thresh",
-            type=float,
-            default=0.2,
-            help="Wan TeaCache accumulated relative-L1 threshold.",
-        )
-        runtime_group.add_argument(
-            "--wan_teacache_use_ret_steps",
-            action="store_true",
-            help="Use Wan TeaCache retention-step coefficients and warmup.",
+            help="Enable teacache to accelerate inference in a single card",
         )
         runtime_group.add_argument(
             "--use_fbcache",
@@ -851,12 +838,6 @@ class xFuserArgs:
                  "Drop rates <=0.25 use dense AITER attention.",
         )
         parser.add_argument(
-            "--vsa_calls_per_step",
-            type=int,
-            default=2,
-            help="Legacy override; Wan infers calls per step from CFG mode.",
-        )
-        parser.add_argument(
             "--vsa_prob_threshold",
             type=float,
             default=0.9,
@@ -879,6 +860,11 @@ class xFuserArgs:
             action=argparse.BooleanOptionalAction,
             default=True,
             help="Preserve first-frame block relations in the VSA mask.",
+        )
+        parser.add_argument(
+            "--vsa_collect_density",
+            action="store_true",
+            help="Record the selected VSA block density for profiling.",
         )
         parser.add_argument(
             "--distilled_transformer_path",
@@ -974,10 +960,6 @@ class xFuserArgs:
             use_parallel_vae=self.use_parallel_vae,
             use_torch_compile=self.use_torch_compile,
             use_onediff=self.use_onediff,
-            use_teacache=self.use_teacache,
-            wan_teacache_thresh=self.wan_teacache_thresh,
-            wan_teacache_use_ret_steps=self.wan_teacache_use_ret_steps,
-            use_fbcache=self.use_fbcache,
             # use_profiler=self.use_profiler,
             use_fp8_t5_encoder=self.use_fp8_t5_encoder,
             attention_backend=self.attention_backend,
@@ -991,11 +973,11 @@ class xFuserArgs:
             vsa_top_k=self.vsa_top_k,
             vsa_top_k_ratio=self.vsa_top_k_ratio,
             vsa_drop_rates=self.vsa_drop_rates,
-            vsa_calls_per_step=self.vsa_calls_per_step,
             vsa_prob_threshold=self.vsa_prob_threshold,
             vsa_reorder_sequence=self.vsa_reorder_sequence,
             use_vsa_static_block_mask=self.use_vsa_static_block_mask,
             use_vsa_first_frame_mask=self.use_vsa_first_frame_mask,
+            vsa_collect_density=self.vsa_collect_density,
         )
 
         parallel_config = ParallelConfig(

--- a/xfuser/config/config.py
+++ b/xfuser/config/config.py
@@ -55,6 +55,7 @@ class RuntimeConfig:
     warmup_steps: int = 1
     dtype: torch.dtype = torch.float16
     use_cuda_graph: bool = False
+    use_hybrid_attn_schedule: bool = False
     use_parallel_vae: bool = False
     use_profiler: bool = False
     use_torch_compile: bool = False

--- a/xfuser/config/config.py
+++ b/xfuser/config/config.py
@@ -61,6 +61,8 @@ class RuntimeConfig:
     use_onediff: bool = False
     use_fp8_t5_encoder: bool = False
     use_teacache: bool = False
+    wan_teacache_thresh: float = 0.2
+    wan_teacache_use_ret_steps: bool = False
     use_fbcache: bool = False
     attention_backend: Optional[str] = None
     cross_attention_backend: Optional[str] = None
@@ -69,6 +71,15 @@ class RuntimeConfig:
     spargeattn_simthreshold: float = 0.3
     spargeattn_cdfthreshold: float = 0.92
     use_spargeattn_head_balance: bool = False
+    vsa_block_size: int = 128
+    vsa_top_k: int = 1
+    vsa_top_k_ratio: float = 0.0
+    vsa_drop_rates: Optional[List[float]] = None
+    vsa_calls_per_step: int = 2
+    vsa_prob_threshold: float = 0.9
+    vsa_reorder_sequence: bool = True
+    use_vsa_static_block_mask: bool = True
+    use_vsa_first_frame_mask: bool = True
 
     def __post_init__(self):
         check_packages()

--- a/xfuser/config/config.py
+++ b/xfuser/config/config.py
@@ -61,8 +61,6 @@ class RuntimeConfig:
     use_onediff: bool = False
     use_fp8_t5_encoder: bool = False
     use_teacache: bool = False
-    wan_teacache_thresh: float = 0.2
-    wan_teacache_use_ret_steps: bool = False
     use_fbcache: bool = False
     attention_backend: Optional[str] = None
     cross_attention_backend: Optional[str] = None
@@ -75,11 +73,11 @@ class RuntimeConfig:
     vsa_top_k: int = 1
     vsa_top_k_ratio: float = 0.0
     vsa_drop_rates: Optional[List[float]] = None
-    vsa_calls_per_step: int = 2
     vsa_prob_threshold: float = 0.9
     vsa_reorder_sequence: bool = True
     use_vsa_static_block_mask: bool = True
     use_vsa_first_frame_mask: bool = True
+    vsa_collect_density: bool = False
 
     def __post_init__(self):
         check_packages()

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -449,6 +449,7 @@ class AttentionBackendType(Enum):
     AITER_SPARSE_SAGE_V2 = "AITER Sparse Sage V2"
     AITER_SPARGE = "AITER Sparge"
     AITER_SPARGE_V2 = "AITER Sparge V2"
+    AITER_VSA = "AITER VSA CK"
     FLEX_BLOCK_SPARGE = "Flex Block Sparge"
     AITER_FLYDSL = "AITER FlyDSL"
     NPU = "NPU"
@@ -821,6 +822,104 @@ def _aiter_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs=N
         output = torch.permute(output, [0, 2, 1, 3])
 
     return output, softmax_lse
+
+
+@register_attention_function(AttentionBackendType.AITER_VSA)
+@torch.compiler.disable
+def _aiter_vsa_attn_call(
+    query,
+    key,
+    value,
+    dropout_p,
+    is_causal,
+    attention_kwargs=None,
+):
+    """Jenga mask selection backed by AITER's CK-Tile VSA kernel.
+
+    VSA is a non-causal self-attention backend. Calls without Wan's ``thw``
+    metadata, including text/image cross-attention, use dense AITER attention.
+    """
+    attention_kwargs = attention_kwargs or {}
+    thw = attention_kwargs.get("thw")
+    is_self_attention = query.shape == key.shape == value.shape
+    if thw is None or not is_self_attention:
+        return _aiter_attn_call(
+            query,
+            key,
+            value,
+            dropout_p,
+            is_causal,
+            attention_kwargs,
+        )
+    if is_causal:
+        raise ValueError("AITER VSA CK does not support causal attention")
+    if dropout_p not in (None, 0.0):
+        raise ValueError("AITER VSA CK does not support attention dropout")
+
+    from xfuser.core.vsa_attention import (
+        aiter_vsa_attention,
+        jenga_scheduled_drop_rate,
+    )
+
+    drop_rate = None
+    drop_rates = attention_kwargs.get("vsa_drop_rates")
+    if drop_rates:
+        drop_rate = attention_kwargs.get("vsa_effective_drop_rate")
+        if drop_rate is None:
+            drop_rate = jenga_scheduled_drop_rate(
+                int(attention_kwargs.get("vsa_step_index", 0)),
+                int(attention_kwargs.get("vsa_num_steps", 1)),
+                drop_rates,
+            )
+        use_dense = bool(
+            attention_kwargs.get("vsa_use_dense", drop_rate <= 0.25)
+        )
+        attention_kwargs["vsa_effective_drop_rate"] = drop_rate
+        attention_kwargs["vsa_use_dense"] = use_dense
+        if use_dense:
+            return _aiter_attn_call(
+                query,
+                key,
+                value,
+                dropout_p,
+                is_causal,
+                attention_kwargs,
+            )
+
+    density_sink = attention_kwargs.get("vsa_density_sink")
+    collect_density = bool(
+        density_sink is not None
+        or attention_kwargs.get("vsa_collect_density", False)
+    )
+    output, density = aiter_vsa_attention(
+        query,
+        key,
+        value,
+        thw=tuple(thw),
+        sp_size=get_ulysses_parallel_world_size(),
+        block_size=int(attention_kwargs.get("vsa_block_size", 128)),
+        top_k=int(attention_kwargs.get("vsa_top_k", 1)),
+        top_k_ratio=float(attention_kwargs.get("vsa_top_k_ratio", 0.0)),
+        drop_rate=drop_rate,
+        prob_threshold=float(
+            attention_kwargs.get("vsa_prob_threshold", 0.8)
+        ),
+        reorder_sequence=bool(
+            attention_kwargs.get("vsa_reorder_sequence", True)
+        ),
+        use_static_block_mask=bool(
+            attention_kwargs.get("use_vsa_static_block_mask", True)
+        ),
+        use_first_frame_mask=bool(
+            attention_kwargs.get("use_vsa_first_frame_mask", True)
+        ),
+        collect_density=collect_density,
+    )
+    if density_sink is not None and density is not None:
+        density_sink.copy_(density)
+    if density is not None:
+        attention_kwargs["vsa_last_density"] = density.detach()
+    return output, None
 
 @register_attention_function(AttentionBackendType.AITER_MLA)
 def _aiter_mla_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs=None):

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -886,11 +886,7 @@ def _aiter_vsa_attn_call(
                 attention_kwargs,
             )
 
-    density_sink = attention_kwargs.get("vsa_density_sink")
-    collect_density = bool(
-        density_sink is not None
-        or attention_kwargs.get("vsa_collect_density", False)
-    )
+    collect_density = bool(attention_kwargs.get("vsa_collect_density", False))
     output, density = aiter_vsa_attention(
         query,
         key,
@@ -902,7 +898,7 @@ def _aiter_vsa_attn_call(
         top_k_ratio=float(attention_kwargs.get("vsa_top_k_ratio", 0.0)),
         drop_rate=drop_rate,
         prob_threshold=float(
-            attention_kwargs.get("vsa_prob_threshold", 0.8)
+            attention_kwargs.get("vsa_prob_threshold", 0.9)
         ),
         reorder_sequence=bool(
             attention_kwargs.get("vsa_reorder_sequence", True)
@@ -915,8 +911,6 @@ def _aiter_vsa_attn_call(
         ),
         collect_density=collect_density,
     )
-    if density_sink is not None and density is not None:
-        density_sink.copy_(density)
     if density is not None:
         attention_kwargs["vsa_last_density"] = density.detach()
     return output, None

--- a/xfuser/core/distributed/runtime_state.py
+++ b/xfuser/core/distributed/runtime_state.py
@@ -2,7 +2,7 @@ from abc import ABCMeta
 import importlib
 import inspect
 import random
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import numpy as np
 import torch
@@ -206,6 +206,15 @@ class RuntimeState(metaclass=ABCMeta):
         """
         Check if the selected attention backend is compatible with the current configuration.
         """
+        if (
+            attention_backend == AttentionBackendType.AITER_VSA
+            and self.runtime_config.use_hybrid_attn_schedule
+        ):
+            raise RuntimeError(
+                "AITER_VSA manages its own denoising-step schedule and cannot "
+                "be used with a hybrid attention schedule."
+            )
+
         if attention_backend in [AttentionBackendType.SDPA,
                                  AttentionBackendType.SDPA_MATH,
                                  AttentionBackendType.FLASH_4,
@@ -368,6 +377,9 @@ class DiTRuntimeState(RuntimeState):
         self.gemm_schedule_total_steps: Optional[int] = None
         self.use_high_precision_gemm: bool = True
         self.step_counter: Optional[int] = None
+        self._vsa_denoising_step = -1
+        self._vsa_last_timestep: Optional[float] = None
+        self._vsa_num_steps: Optional[int] = None
         super().__init__(config)
         self.patch_mode = False
         self.pipeline_patch_idx = 0
@@ -426,6 +438,26 @@ class DiTRuntimeState(RuntimeState):
     def has_gemm_schedule(self) -> bool:
         """True if a per-step GEMM precision schedule is active (e.g. for warmup/compile logic)."""
         return self.gemm_schedule is not None
+
+    def reset_vsa_schedule_state(self, num_inference_steps: int) -> None:
+        """Reset AITER VSA's denoising schedule at a pipeline-run boundary."""
+        if num_inference_steps <= 0:
+            raise ValueError("VSA num_inference_steps must be positive.")
+        self._vsa_denoising_step = -1
+        self._vsa_last_timestep = None
+        self._vsa_num_steps = int(num_inference_steps)
+
+    def advance_vsa_schedule(self, timestep: float) -> Tuple[int, int]:
+        """Advance AITER VSA once for each distinct denoising timestep."""
+        num_steps = self._vsa_num_steps
+        if num_steps is None:
+            num_steps = int(self.input_config.num_inference_steps)
+        if self._vsa_last_timestep is None or timestep != self._vsa_last_timestep:
+            self._vsa_denoising_step = (
+                self._vsa_denoising_step + 1
+            ) % max(num_steps, 1)
+            self._vsa_last_timestep = timestep
+        return self._vsa_denoising_step, num_steps
 
     def _get_active_total_steps(self) -> Optional[int]:
         attn_steps = self.schedule_total_steps

--- a/xfuser/core/distributed/runtime_state.py
+++ b/xfuser/core/distributed/runtime_state.py
@@ -218,6 +218,7 @@ class RuntimeState(metaclass=ABCMeta):
                                  AttentionBackendType.AITER_SAGE_V2,
                                  AttentionBackendType.AITER_SPARSE_SAGE_V2,
                                  AttentionBackendType.AITER_SPARGE_V2,
+                                 AttentionBackendType.AITER_VSA,
                                  AttentionBackendType.AITER_FLYDSL,
                                  AttentionBackendType.FLEX_BLOCK_ATTN,
                                  AttentionBackendType.FLEX_BLOCK_SPARGE]:
@@ -312,6 +313,14 @@ class RuntimeState(metaclass=ABCMeta):
                     raise RuntimeError(msg) from None
             except ImportError:
                 raise RuntimeError(msg) from None
+        elif attention_backend == AttentionBackendType.AITER_VSA:
+            try:
+                from aiter.ops.jenga_sparse_attention import vsa_sparse_attention
+            except ImportError:
+                raise RuntimeError(
+                    "AITER VSA CK attention is not available; install the "
+                    "AITER build containing jenga_sparse_attention"
+                ) from None
         elif attention_backend == AttentionBackendType.AITER_FLYDSL:
             try:
                 from aiter.ops.flydsl import flydsl_flash_attn_func

--- a/xfuser/core/sparge_attention/sparge.py
+++ b/xfuser/core/sparge_attention/sparge.py
@@ -274,21 +274,35 @@ def setup_sparge(
         if static_mask is not None:
             n_iq = (image_len + img_pad) // block_m
             n_ik = (image_len + img_pad) // block_n
-            if static_mask_cache_key is None:
-                raise RuntimeError("Static block mask cache metadata is missing")
-            padded_key = (*static_mask_cache_key, n_iq, n_ik)
-            cached_padded = _PADDED_STATIC_BLOCK_MASK_CACHE.get(padded_key)
-            if cached_padded is None:
-                cached_padded = torch.zeros(
+            if use_sliced_gilbert:
+                if static_mask_cache_key is None:
+                    raise RuntimeError(
+                        "Static block mask cache metadata is missing"
+                    )
+                padded_key = (*static_mask_cache_key, n_iq, n_ik)
+                padded_static = _PADDED_STATIC_BLOCK_MASK_CACHE.get(padded_key)
+                if padded_static is None:
+                    padded_static = torch.zeros(
+                        (n_iq, n_ik),
+                        dtype=static_mask.dtype,
+                        device=static_mask.device,
+                    )
+                    padded_static[
+                        : static_mask.shape[0], : static_mask.shape[1]
+                    ] = static_mask
+                    _PADDED_STATIC_BLOCK_MASK_CACHE[padded_key] = padded_static
+            else:
+                # Preserve the existing Sparge backends' allocation behavior;
+                # only VSA's sliced-Gilbert path caches this padded mask.
+                padded_static = torch.zeros(
                     (n_iq, n_ik),
                     dtype=static_mask.dtype,
                     device=static_mask.device,
                 )
-                cached_padded[
+                padded_static[
                     : static_mask.shape[0], : static_mask.shape[1]
                 ] = static_mask
-                _PADDED_STATIC_BLOCK_MASK_CACHE[padded_key] = cached_padded
-            static_mask = cached_padded
+            static_mask = padded_static
 
     # Re-concatenate text tail.
     if text_q is not None:

--- a/xfuser/core/sparge_attention/sparge.py
+++ b/xfuser/core/sparge_attention/sparge.py
@@ -171,6 +171,7 @@ def setup_sparge(
     fwd_perm: Optional[torch.Tensor] = None
     inv_perm: Optional[torch.Tensor] = None
     static_mask: Optional[torch.Tensor] = None
+    static_mask_cache_key: Optional[tuple] = None
     sp_pad_len = 0
 
     # Both reorder and the static mask operate on the spatial (thw) layout,
@@ -204,14 +205,22 @@ def setup_sparge(
         )
         fwd_perm, inv_perm = perm_builder(thw, query.device)
         if use_static_block_mask:
+            mapping_kind = (
+                "sliced_gilbert"
+                if use_sliced_gilbert
+                else "gilbert"
+            )
             static_mask = get_static_block_neighbor_mask(
                 thw, block_m, block_n, query.device,
                 gilbert_mapping=(inv_perm, fwd_perm),
-                mapping_kind=(
-                    "sliced_gilbert"
-                    if use_sliced_gilbert
-                    else "gilbert"
-                ),
+                mapping_kind=mapping_kind,
+            )
+            static_mask_cache_key = (
+                tuple(thw),
+                int(block_m),
+                int(block_n),
+                _device_key(query.device),
+                mapping_kind,
             )
     elif use_static_block_mask:
         # Linear (row-major) order: feed the neighbour builder an identity
@@ -219,6 +228,13 @@ def setup_sparge(
         static_mask = get_static_block_neighbor_mask(
             thw, block_m, block_n, query.device,
             mapping_kind="linear",
+        )
+        static_mask_cache_key = (
+            tuple(thw),
+            int(block_m),
+            int(block_n),
+            _device_key(query.device),
+            "linear",
         )
 
     # Split off image part (without SP padding) and text part.
@@ -258,12 +274,9 @@ def setup_sparge(
         if static_mask is not None:
             n_iq = (image_len + img_pad) // block_m
             n_ik = (image_len + img_pad) // block_n
-            padded_key = (
-                static_mask.data_ptr(),
-                n_iq,
-                n_ik,
-                _device_key(static_mask.device),
-            )
+            if static_mask_cache_key is None:
+                raise RuntimeError("Static block mask cache metadata is missing")
+            padded_key = (*static_mask_cache_key, n_iq, n_ik)
             cached_padded = _PADDED_STATIC_BLOCK_MASK_CACHE.get(padded_key)
             if cached_padded is None:
                 cached_padded = torch.zeros(

--- a/xfuser/core/sparge_attention/sparge.py
+++ b/xfuser/core/sparge_attention/sparge.py
@@ -7,6 +7,8 @@ import torch.nn.functional as F
 from xfuser.core.sparge_attention.block_mask import get_block_map_meansim
 from xfuser.core.sparge_attention.gilbert import (
     curve as gilbert_curve,
+    sliced_curve,
+    sliced_gilbert_mapping,
     sliced_gilbert_block_neighbor_mapping,
 )
 
@@ -19,6 +21,7 @@ _GILBERT_PERM_CACHE: dict[tuple, Tuple[torch.Tensor, torch.Tensor]] = {}
 # Block-neighbor static mask keyed on ((t, h, w), block_m, block_n,
 # (device.type, idx)). Bool tensor of shape (n_image_q, n_image_k) on device.
 _STATIC_BLOCK_MASK_CACHE: dict[tuple, torch.Tensor] = {}
+_PADDED_STATIC_BLOCK_MASK_CACHE: dict[tuple, torch.Tensor] = {}
 
 
 def _device_key(device: torch.device) -> tuple:
@@ -51,12 +54,28 @@ class SpargeState:
 
 def get_gilbert_perm(thw: Tuple[int, int, int], device: torch.device
                      ) -> Tuple[torch.Tensor, torch.Tensor]:
-    key = (tuple(thw), _device_key(device))
+    key = ("3d", tuple(thw), _device_key(device))
     cached = _GILBERT_PERM_CACHE.get(key)
     if cached is not None:
         return cached
     t, h, w = thw
     inv_perm, fwd_perm = gilbert_curve(t, h, w, device)
+    _GILBERT_PERM_CACHE[key] = (fwd_perm, inv_perm)
+    return fwd_perm, inv_perm
+
+
+def get_sliced_gilbert_perm(
+    thw: Tuple[int, int, int], device: torch.device
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    key = ("sliced", tuple(thw), _device_key(device))
+    cached = _GILBERT_PERM_CACHE.get(key)
+    if cached is not None:
+        return cached
+    t, h, w = thw
+    linear_to_gilbert, gilbert_to_linear = sliced_gilbert_mapping(t, h, w)
+    inv_perm, fwd_perm = sliced_curve(
+        linear_to_gilbert, gilbert_to_linear, device
+    )
     _GILBERT_PERM_CACHE[key] = (fwd_perm, inv_perm)
     return fwd_perm, inv_perm
 
@@ -134,6 +153,7 @@ def setup_sparge(
     block_m: int = 128,
     block_n: int = 128,
     pad_block_divisible: bool = False,
+    use_sliced_gilbert: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor,
            SpargeState, Optional[torch.Tensor]]:
 
@@ -177,12 +197,21 @@ def setup_sparge(
             )
 
     if reorder_sequence:
-        fwd_perm, inv_perm = get_gilbert_perm(thw, query.device)
+        perm_builder = (
+            get_sliced_gilbert_perm
+            if use_sliced_gilbert
+            else get_gilbert_perm
+        )
+        fwd_perm, inv_perm = perm_builder(thw, query.device)
         if use_static_block_mask:
             static_mask = get_static_block_neighbor_mask(
                 thw, block_m, block_n, query.device,
                 gilbert_mapping=(inv_perm, fwd_perm),
-                mapping_kind="gilbert",
+                mapping_kind=(
+                    "sliced_gilbert"
+                    if use_sliced_gilbert
+                    else "gilbert"
+                ),
             )
     elif use_static_block_mask:
         # Linear (row-major) order: feed the neighbour builder an identity
@@ -229,11 +258,24 @@ def setup_sparge(
         if static_mask is not None:
             n_iq = (image_len + img_pad) // block_m
             n_ik = (image_len + img_pad) // block_n
-            padded_static = torch.zeros(
-                (n_iq, n_ik), dtype=static_mask.dtype, device=static_mask.device
+            padded_key = (
+                static_mask.data_ptr(),
+                n_iq,
+                n_ik,
+                _device_key(static_mask.device),
             )
-            padded_static[: static_mask.shape[0], : static_mask.shape[1]] = static_mask
-            static_mask = padded_static
+            cached_padded = _PADDED_STATIC_BLOCK_MASK_CACHE.get(padded_key)
+            if cached_padded is None:
+                cached_padded = torch.zeros(
+                    (n_iq, n_ik),
+                    dtype=static_mask.dtype,
+                    device=static_mask.device,
+                )
+                cached_padded[
+                    : static_mask.shape[0], : static_mask.shape[1]
+                ] = static_mask
+                _PADDED_STATIC_BLOCK_MASK_CACHE[padded_key] = cached_padded
+            static_mask = cached_padded
 
     # Re-concatenate text tail.
     if text_q is not None:

--- a/xfuser/core/vsa_attention.py
+++ b/xfuser/core/vsa_attention.py
@@ -154,7 +154,10 @@ def jenga_scheduled_drop_rate(
         raise ValueError(f"drop rates must be in [0,1], got {drop_rates}")
 
     step_index = min(max(int(step_index), 0), total_steps - 1)
-    if len(drop_rates) == 1 or step_index <= 25:
+    # Jenga switches after step 25 in its 50-step reference schedule. Express
+    # that boundary relative to the requested run length so short runs also
+    # exercise both configured rates while preserving the 50-step behavior.
+    if len(drop_rates) == 1 or step_index <= total_steps // 2:
         base_drop_rate = float(drop_rates[0])
     else:
         base_drop_rate = float(drop_rates[1])
@@ -168,13 +171,25 @@ def jenga_scheduled_drop_rate(
     return min(base_drop_rate, progress_x10 * base_drop_rate)
 
 
+def _first_frame_block_count(
+    thw: tuple[int, int, int], block_size: int
+) -> int:
+    """Count blocks fully contained in the first temporal slice."""
+    if block_size <= 0:
+        raise ValueError(f"VSA block size must be positive, got {block_size}")
+    time, height, width = map(int, thw)
+    if time <= 0 or height <= 0 or width <= 0:
+        raise ValueError(f"VSA thw dimensions must be positive, got {thw}")
+    return (height * width) // block_size
+
+
 def build_jenga_block_mask(
     query: torch.Tensor,
     key: torch.Tensor,
     *,
     block_size: int = 128,
     top_k: int = 1,
-    prob_threshold: float = 0.8,
+    prob_threshold: float = 0.9,
     static_block_mask: Optional[torch.Tensor] = None,
     first_frame_blocks: int = 0,
 ) -> torch.Tensor:
@@ -259,7 +274,7 @@ def aiter_vsa_attention(
     top_k: int = 1,
     top_k_ratio: float = 0.0,
     drop_rate: Optional[float] = None,
-    prob_threshold: float = 0.8,
+    prob_threshold: float = 0.9,
     reorder_sequence: bool = True,
     use_static_block_mask: bool = True,
     use_first_frame_mask: bool = True,
@@ -311,11 +326,14 @@ def aiter_vsa_attention(
 
     first_frame_blocks = 0
     if use_first_frame_mask:
-        # Match Jenga's decoupled first-frame rule: divide the padded block
-        # count evenly across temporal slices and keep the first slice local.
-        num_blocks = query.shape[2] // block_size
-        first_frame_blocks = num_blocks // int(thw[0])
+        # Sliced Gilbert order keeps each temporal slice contiguous. Protect
+        # only blocks fully contained in the first frame; a partial boundary
+        # block remains dynamic because it also contains the next frame.
+        first_frame_blocks = _first_frame_block_count(thw, block_size)
 
+    # The probability mask depends on the current Q/K tensors and therefore
+    # cannot be cached. Layout permutations and static-neighbor masks are
+    # cached separately by setup_sparge().
     block_mask = build_jenga_block_mask(
         query,
         key,

--- a/xfuser/core/vsa_attention.py
+++ b/xfuser/core/vsa_attention.py
@@ -1,0 +1,367 @@
+"""Jenga-style block selection for the AITER CK-Tile VSA kernel.
+
+The mask policy and kernel encoding are intentionally separate:
+
+* ``build_jenga_block_mask`` implements Jenga's pooled Q/K CDF selection.
+* ``block_mask_to_delta_lut`` converts a canonical boolean block mask to the
+  delta-encoded LUT consumed by AITER's ``vsa_sparse_attention`` CK op.
+* ``aiter_vsa_attention`` handles xDiT's Gilbert/static-mask setup and restores
+  the original token order after the CK call.
+"""
+
+import math
+from typing import Optional
+
+import torch
+
+from xfuser.core.sparge_attention.sparge import (
+    mask_padded_kv_blocks,
+    restore_sparge_output,
+    setup_sparge,
+)
+
+_SEQSTART_CACHE: dict[tuple, torch.Tensor] = {}
+_DELTA_LUT_WORKSPACE_CACHE: dict[
+    tuple, tuple[torch.Tensor, torch.Tensor]
+] = {}
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:  # CPU-only tests and installations without Triton.
+    triton = None
+    tl = None
+
+
+if triton is not None:
+
+    @triton.jit
+    def _block_mask_to_delta_lut_kernel(
+        mask_ptr,
+        lut_ptr,
+        count_ptr,
+        num_k_blocks: tl.constexpr,
+    ):
+        b = tl.program_id(0)
+        h = tl.program_id(1)
+        q = tl.program_id(2)
+        num_heads = tl.num_programs(1)
+        num_q_blocks = tl.num_programs(2)
+        row = (b * num_heads * num_q_blocks + h * num_q_blocks + q)
+        mask_ptr += row * num_k_blocks
+        lut_ptr += row * num_k_blocks
+        count_ptr += row
+
+        valid = 0
+        previous = 0
+        for k_block in range(num_k_blocks):
+            selected = tl.load(mask_ptr + k_block)
+            if selected != 0:
+                tl.store(lut_ptr + valid, k_block - previous)
+                valid += 1
+                previous = k_block
+        tl.store(count_ptr, valid)
+
+
+def _block_mask_to_delta_lut_torch(
+    block_mask: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Portable reference encoder used by CPU tests and Triton-free installs."""
+    num_k_blocks = block_mask.shape[-1]
+    absolute = torch.arange(
+        num_k_blocks, dtype=torch.int32, device=block_mask.device
+    ).view(1, 1, 1, -1)
+    sentinel = torch.full_like(absolute, num_k_blocks)
+    selected = torch.where(block_mask, absolute, sentinel)
+    selected = selected.sort(dim=-1).values
+    counts = block_mask.sum(dim=-1, dtype=torch.int32)
+
+    valid = (
+        torch.arange(num_k_blocks, device=block_mask.device)
+        .view(1, 1, 1, -1)
+        < counts.unsqueeze(-1)
+    )
+    selected = torch.where(valid, selected, torch.zeros_like(selected))
+    deltas = selected.clone()
+    if num_k_blocks > 1:
+        deltas[..., 1:] = selected[..., 1:] - selected[..., :-1]
+    return deltas.contiguous(), counts.contiguous()
+
+
+def block_mask_to_delta_lut(
+    block_mask: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Encode ``[B,H,Qb,Kb]`` boolean mask for AITER VSA.
+
+    The first valid entry is an absolute KV-block index; following entries are
+    deltas from the previous selected block. ``counts`` gives the valid prefix
+    length for every ``(batch, head, query-block)`` row.
+    """
+    if block_mask.ndim != 4:
+        raise ValueError(
+            f"VSA block mask must have shape [B,H,Qb,Kb], got {block_mask.shape}"
+        )
+    block_mask = block_mask.to(torch.bool).contiguous()
+    b, h, q_blocks, k_blocks = block_mask.shape
+    if k_blocks == 0:
+        raise ValueError("VSA block mask must contain at least one KV block")
+
+    if triton is None or block_mask.device.type != "cuda":
+        return _block_mask_to_delta_lut_torch(block_mask)
+
+    stream_id = torch.cuda.current_stream(block_mask.device).cuda_stream
+    workspace_key = (
+        block_mask.device.index,
+        stream_id,
+        b,
+        h,
+        q_blocks,
+        k_blocks,
+    )
+    workspace = _DELTA_LUT_WORKSPACE_CACHE.get(workspace_key)
+    if workspace is None:
+        workspace = (
+            torch.empty(
+                (b, h, q_blocks, k_blocks),
+                dtype=torch.int32,
+                device=block_mask.device,
+            ),
+            torch.empty(
+                (b, h, q_blocks),
+                dtype=torch.int32,
+                device=block_mask.device,
+            ),
+        )
+        _DELTA_LUT_WORKSPACE_CACHE[workspace_key] = workspace
+    lut, counts = workspace
+    _block_mask_to_delta_lut_kernel[(b, h, q_blocks)](
+        block_mask, lut, counts, k_blocks
+    )
+    return lut, counts
+
+
+def jenga_scheduled_drop_rate(
+    step_index: int,
+    total_steps: int,
+    drop_rates: list[float] | tuple[float, ...],
+) -> float:
+    """Reproduce Jenga's timestep-dependent self-attention drop rate."""
+    if total_steps <= 0:
+        raise ValueError(f"total_steps must be positive, got {total_steps}")
+    if not drop_rates:
+        raise ValueError("drop_rates must contain at least one value")
+    if any(rate < 0.0 or rate > 1.0 for rate in drop_rates):
+        raise ValueError(f"drop rates must be in [0,1], got {drop_rates}")
+
+    step_index = min(max(int(step_index), 0), total_steps - 1)
+    if len(drop_rates) == 1 or step_index <= 25:
+        base_drop_rate = float(drop_rates[0])
+    else:
+        base_drop_rate = float(drop_rates[1])
+
+    # Jenga linearly warms the configured rate over the first 10% of steps.
+    progress_x10 = (
+        step_index / (total_steps - 1) * 10.0
+        if total_steps > 1
+        else 10.0
+    )
+    return min(base_drop_rate, progress_x10 * base_drop_rate)
+
+
+def build_jenga_block_mask(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    *,
+    block_size: int = 128,
+    top_k: int = 1,
+    prob_threshold: float = 0.8,
+    static_block_mask: Optional[torch.Tensor] = None,
+    first_frame_blocks: int = 0,
+) -> torch.Tensor:
+    """Build Jenga's pooled-Q/K importance mask.
+
+    For every query block, select the smallest probability-sorted KV-block
+    prefix whose cumulative softmax mass exceeds ``prob_threshold`` while
+    keeping at least ``top_k`` blocks. Static neighbors and the first-frame
+    relation are unioned into that dynamic mask.
+    """
+    if query.ndim != 4 or key.ndim != 4:
+        raise ValueError("VSA expects query/key in [B,H,S,D] layout")
+    if query.shape != key.shape:
+        raise ValueError(
+            f"VSA self-attention requires matching query/key shapes, got "
+            f"{query.shape} and {key.shape}"
+        )
+    if block_size <= 0:
+        raise ValueError(f"VSA block size must be positive, got {block_size}")
+    if not 0.0 <= prob_threshold <= 1.0:
+        raise ValueError(
+            f"VSA probability threshold must be in [0,1], got {prob_threshold}"
+        )
+
+    batch, heads, sequence, head_dim = query.shape
+    if sequence % block_size != 0:
+        raise ValueError(
+            f"VSA sequence length {sequence} is not divisible by {block_size}"
+        )
+    num_blocks = sequence // block_size
+    top_k = min(max(int(top_k), 1), num_blocks)
+
+    query_pool = query.reshape(
+        batch, heads, num_blocks, block_size, head_dim
+    ).mean(dim=-2)
+    key_pool = key.reshape(
+        batch, heads, num_blocks, block_size, head_dim
+    ).mean(dim=-2)
+    scores = torch.matmul(query_pool, key_pool.transpose(-1, -2))
+    scores = scores * (head_dim ** -0.5)
+    probabilities = torch.softmax(scores, dim=-1)
+    sorted_probabilities, indices = probabilities.sort(
+        dim=-1, descending=True
+    )
+    cumulative = sorted_probabilities.cumsum(dim=-1)
+    needed = (cumulative <= prob_threshold).sum(dim=-1) + 1
+    needed = needed.clamp(min=top_k, max=num_blocks)
+
+    ranks = torch.arange(num_blocks, device=query.device).view(1, 1, 1, -1)
+    selected_by_rank = ranks < needed.unsqueeze(-1)
+    block_mask = torch.zeros(
+        (batch, heads, num_blocks, num_blocks),
+        dtype=torch.bool,
+        device=query.device,
+    )
+    block_mask.scatter_(-1, indices, selected_by_rank)
+
+    if static_block_mask is not None:
+        static_block_mask = static_block_mask.to(
+            device=query.device, dtype=torch.bool
+        )
+        q_blocks = min(num_blocks, static_block_mask.shape[0])
+        k_blocks = min(num_blocks, static_block_mask.shape[1])
+        block_mask[:, :, :q_blocks, :k_blocks] |= static_block_mask[
+            None, None, :q_blocks, :k_blocks
+        ]
+
+    first_frame_blocks = min(max(int(first_frame_blocks), 0), num_blocks)
+    if first_frame_blocks:
+        block_mask[:, :, :first_frame_blocks, :first_frame_blocks] = True
+    return block_mask
+
+
+def aiter_vsa_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    *,
+    thw: tuple[int, int, int],
+    sp_size: int,
+    block_size: int = 128,
+    top_k: int = 1,
+    top_k_ratio: float = 0.0,
+    drop_rate: Optional[float] = None,
+    prob_threshold: float = 0.8,
+    reorder_sequence: bool = True,
+    use_static_block_mask: bool = True,
+    use_first_frame_mask: bool = True,
+    collect_density: bool = False,
+) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Run Jenga-mask sparse attention through AITER's CK-Tile VSA op."""
+    if block_size != 128:
+        raise ValueError(
+            "The current AITER CK-Tile VSA build requires block_size=128"
+        )
+    if query.dtype not in (torch.bfloat16, torch.float16):
+        raise TypeError(f"AITER VSA requires BF16/FP16 QKV, got {query.dtype}")
+    if not (query.shape == key.shape == value.shape):
+        raise ValueError("AITER VSA currently supports self-attention only")
+
+    query, key, value, state, static_mask = setup_sparge(
+        query,
+        key,
+        value,
+        thw=thw,
+        sp_size=sp_size,
+        reorder_sequence=reorder_sequence,
+        use_static_block_mask=use_static_block_mask,
+        block_m=block_size,
+        block_n=block_size,
+        pad_block_divisible=True,
+        use_sliced_gilbert=True,
+    )
+    query = query.contiguous()
+    key = key.contiguous()
+    value = value.contiguous()
+    if not 0.0 <= top_k_ratio <= 1.0:
+        raise ValueError(
+            f"VSA top-k ratio must be in [0,1], got {top_k_ratio}"
+        )
+    if top_k_ratio:
+        top_k = max(
+            int(top_k),
+            math.ceil((query.shape[2] // block_size) * top_k_ratio),
+        )
+    if drop_rate is not None:
+        if not 0.0 <= drop_rate <= 1.0:
+            raise ValueError(f"VSA drop rate must be in [0,1], got {drop_rate}")
+        # Match Jenga's ``int(num_blocks * (1 - sa_drop_rate))`` floor.
+        top_k = max(
+            int(top_k),
+            int((query.shape[2] // block_size) * (1.0 - drop_rate)),
+        )
+
+    first_frame_blocks = 0
+    if use_first_frame_mask:
+        # Match Jenga's decoupled first-frame rule: divide the padded block
+        # count evenly across temporal slices and keep the first slice local.
+        num_blocks = query.shape[2] // block_size
+        first_frame_blocks = num_blocks // int(thw[0])
+
+    block_mask = build_jenga_block_mask(
+        query,
+        key,
+        block_size=block_size,
+        top_k=top_k,
+        prob_threshold=prob_threshold,
+        static_block_mask=static_mask,
+        first_frame_blocks=first_frame_blocks,
+    )
+    block_mask = mask_padded_kv_blocks(block_mask, state, block_size)
+    lut, valid_blocks = block_mask_to_delta_lut(block_mask)
+
+    from aiter.ops.jenga_sparse_attention import vsa_sparse_attention
+
+    batch, heads, sequence, head_dim = query.shape
+    device_index = (
+        query.device.index if query.device.index is not None else -1
+    )
+    seqstart_key = (query.device.type, device_index, sequence)
+    seqstart = _SEQSTART_CACHE.get(seqstart_key)
+    if seqstart is None:
+        seqstart = torch.tensor(
+            [0, sequence], dtype=torch.int32, device=query.device
+        ).contiguous()
+        _SEQSTART_CACHE[seqstart_key] = seqstart
+    output = torch.empty_like(query).contiguous()
+    output = vsa_sparse_attention(
+        query,
+        key,
+        value,
+        lut,
+        valid_blocks,
+        output,
+        None,
+        None,
+        seqstart,
+        seqstart,
+        0,
+        batch,
+        heads,
+        heads,
+        sequence,
+        sequence,
+        head_dim,
+        head_dim,
+    )
+    output = restore_sparge_output(output, state)
+    density = block_mask.float().mean() if collect_density else None
+    return output, density

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -629,9 +629,13 @@ class xFuserModel(abc.ABC):
         profile.export_chrome_trace(profile_file)
         log(f"Profile trace saved to {profile_file}", log_from_all_processes=True)
 
+    def _prepare_inference_run(self, input_args: dict) -> None:
+        """Prepare model-specific state before a pipeline invocation."""
+
     def _run_timed_pipe(self, input_args: dict) -> Tuple[DiffusionOutput, float]:
         """ Run a a full pipeline with timing information """
 
+        self._prepare_inference_run(input_args)
         start = torch.cuda.Event(enable_timing=True)
         end = torch.cuda.Event(enable_timing=True)
         torch.cuda.synchronize()

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -69,6 +69,7 @@ _SPARSE_ATTENTION_BACKENDS = frozenset({
 _SPARGE_ATTENTION_BACKENDS = frozenset({
     AttentionBackendType.AITER_SPARGE,
     AttentionBackendType.AITER_SPARGE_V2,
+    AttentionBackendType.AITER_VSA,
     AttentionBackendType.FLEX_BLOCK_SPARGE,
 })
 

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -66,19 +66,16 @@ def _build_attention_kwargs(config: "xFuserArgs") -> dict:
         "vsa_top_k": config.vsa_top_k,
         "vsa_top_k_ratio": config.vsa_top_k_ratio,
         "vsa_drop_rates": drop_rates,
-        "vsa_calls_per_step": config.vsa_calls_per_step,
         "vsa_prob_threshold": config.vsa_prob_threshold,
         "vsa_reorder_sequence": config.vsa_reorder_sequence,
         "use_vsa_static_block_mask": config.use_vsa_static_block_mask,
         "use_vsa_first_frame_mask": config.use_vsa_first_frame_mask,
-        "use_wan_teacache": config.use_teacache,
-        "wan_teacache_thresh": config.wan_teacache_thresh,
-        "wan_teacache_use_ret_steps": config.wan_teacache_use_ret_steps,
+        "vsa_collect_density": config.vsa_collect_density,
     }
 
 
-def _prepare_wan_inference_run(pipe, config, input_args: dict) -> None:
-    """Publish actual run dimensions and reset per-run sparse/cache state."""
+def _prepare_wan_inference_run(pipe, input_args: dict) -> None:
+    """Publish actual run dimensions and reset per-run VSA state."""
     num_steps = int(input_args["num_inference_steps"])
     get_runtime_state().set_video_input_parameters(
         height=int(input_args["height"]),
@@ -88,17 +85,23 @@ def _prepare_wan_inference_run(pipe, config, input_args: dict) -> None:
         num_inference_steps=num_steps,
         seed=int(input_args["seed"]),
     )
-    calls_per_step = (
-        1
-        if config.use_cfg_parallel
-        or float(input_args.get("guidance_scale", 1.0)) <= 1.0
-        else 2
-    )
     for name in ("transformer", "transformer_2"):
         transformer = getattr(pipe, name, None)
         reset = getattr(transformer, "reset_wan_inference_state", None)
         if reset is not None:
-            reset(num_steps, calls_per_step)
+            reset(num_steps)
+
+
+class xFuserWanModel(xFuserModel):
+    """Common lifecycle hooks for Wan runners."""
+
+    def _prepare_inference_run(self, input_args: dict) -> None:
+        _prepare_wan_inference_run(self.pipe, input_args)
+
+    def _setup_hybrid_attn_schedule(self, input_args: dict) -> None:
+        if self.config.attention_backend == "AITER_VSA":
+            return
+        super()._setup_hybrid_attn_schedule(input_args)
 
 
 def _setup_parallel_vae(vae, enable_parallel_encoder: bool = True) -> None:
@@ -207,15 +210,7 @@ class _DistilledWanScheduler(FlowMatchEulerDiscreteScheduler):
 
 @register_model("Wan-AI/Wan2.1-I2V-14B-720P-Diffusers")
 @register_model("Wan2.1-I2V")
-class xFuserWan21I2VModel(xFuserModel):
-
-    def preprocess_args(self, input_args: dict) -> dict:
-        args = super().preprocess_args(input_args)
-        if self.config.attention_backend == "AITER_VSA":
-            # The Jenga schedule performs its own early dense warmup.
-            args["num_hybrid_attn_high_precision_steps"] = 0
-            self.config.num_hybrid_attn_high_precision_steps = 0
-        return args
+class xFuserWan21I2VModel(xFuserWanModel):
 
     def _calculate_hybrid_attention_step_multiplier(self, input_args: dict) -> int:
         do_cfg = input_args["guidance_scale"] > 1.0
@@ -285,7 +280,6 @@ class xFuserWan21I2VModel(xFuserModel):
         return pipe
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
-        _prepare_wan_inference_run(self.pipe, self.config, input_args)
         output = self.pipe(
             image=input_args["image"],
             height=input_args["height"],
@@ -471,7 +465,6 @@ class xFuserWan22DistilledI2VModel(xFuserWan22I2VModel):
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
         # Guidance is baked into the distilled weights. guidance_scale=1.0 keeps
         # do_classifier_free_guidance=False, so negative_prompt has no effect.
-        _prepare_wan_inference_run(self.pipe, self.config, input_args)
         output = self.pipe(
             image=input_args["image"],
             height=input_args["height"],
@@ -488,15 +481,7 @@ class xFuserWan22DistilledI2VModel(xFuserWan22I2VModel):
 
 @register_model("Wan-AI/Wan2.1-T2V-14B-Diffusers")
 @register_model("Wan2.1-T2V")
-class xFuserWan21T2VModel(xFuserModel):
-
-    def preprocess_args(self, input_args: dict) -> dict:
-        args = super().preprocess_args(input_args)
-        if self.config.attention_backend == "AITER_VSA":
-            # Avoid stacking xDiT's five-step warmup on Jenga's dynamic one.
-            args["num_hybrid_attn_high_precision_steps"] = 0
-            self.config.num_hybrid_attn_high_precision_steps = 0
-        return args
+class xFuserWan21T2VModel(xFuserWanModel):
 
     def _calculate_hybrid_attention_step_multiplier(self, input_args: dict) -> int:
         do_cfg = input_args["guidance_scale"] > 1.0
@@ -564,7 +549,6 @@ class xFuserWan21T2VModel(xFuserModel):
         return pipe
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
-        _prepare_wan_inference_run(self.pipe, self.config, input_args)
         output = self.pipe(
             height=input_args["height"],
             width=input_args["width"],
@@ -688,7 +672,6 @@ class xFuserWan22TI2VModel(xFuserWan21T2VModel):
         return pipe
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
-        _prepare_wan_inference_run(self.pipe, self.config, input_args)
         kwargs = {
             "height": input_args["height"],
             "width": input_args["width"],
@@ -741,7 +724,7 @@ class xFuserWan22TI2VModel(xFuserWan21T2VModel):
 @register_model("Wan-AI/Wan2.1-VACE-1.3B-diffusers")
 @register_model("Wan2.1-VACE-14B")
 @register_model("Wan2.1-VACE-1.3B")
-class xFuserWan21VACEModel(xFuserModel):
+class xFuserWan21VACEModel(xFuserWanModel):
 
     capabilities = ModelCapabilities(
         ulysses_degree=True,
@@ -826,7 +809,6 @@ class xFuserWan21VACEModel(xFuserModel):
         return input_args
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
-        _prepare_wan_inference_run(self.pipe, self.config, input_args)
         output = self.pipe(
             height=input_args["height"],
             width=input_args["width"],

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -47,16 +47,58 @@ COMMON_FSDP_STRATEGY = {
     }
 }
 
+WAN_VSA_ACCURACY_FIRST_DROP_RATES = (0.25, 0.40)
+WAN_VSA_JENGA_REFERENCE_DROP_RATES = (0.75, 0.85)
+
 
 def _build_attention_kwargs(config: "xFuserArgs") -> dict:
-    """Build the per-model attention_kwargs dict used by the AITER Sparge backends. """
+    """Build shared layout and sparse-attention options for Wan."""
+    drop_rates = config.vsa_drop_rates
+    if config.attention_backend == "AITER_VSA" and not drop_rates:
+        drop_rates = list(WAN_VSA_ACCURACY_FIRST_DROP_RATES)
     return {
         "thw": None,
         "spargeattn_simthreshold": config.spargeattn_simthreshold,
         "spargeattn_cdfthreshold": config.spargeattn_cdfthreshold,
         "spargeattn_reorder_sequence": config.spargeattn_reorder_sequence,
         "use_spargeattn_static_block_mask": config.use_spargeattn_static_block_mask,
+        "vsa_block_size": config.vsa_block_size,
+        "vsa_top_k": config.vsa_top_k,
+        "vsa_top_k_ratio": config.vsa_top_k_ratio,
+        "vsa_drop_rates": drop_rates,
+        "vsa_calls_per_step": config.vsa_calls_per_step,
+        "vsa_prob_threshold": config.vsa_prob_threshold,
+        "vsa_reorder_sequence": config.vsa_reorder_sequence,
+        "use_vsa_static_block_mask": config.use_vsa_static_block_mask,
+        "use_vsa_first_frame_mask": config.use_vsa_first_frame_mask,
+        "use_wan_teacache": config.use_teacache,
+        "wan_teacache_thresh": config.wan_teacache_thresh,
+        "wan_teacache_use_ret_steps": config.wan_teacache_use_ret_steps,
     }
+
+
+def _prepare_wan_inference_run(pipe, config, input_args: dict) -> None:
+    """Publish actual run dimensions and reset per-run sparse/cache state."""
+    num_steps = int(input_args["num_inference_steps"])
+    get_runtime_state().set_video_input_parameters(
+        height=int(input_args["height"]),
+        width=int(input_args["width"]),
+        num_frames=int(input_args["num_frames"]),
+        batch_size=1,
+        num_inference_steps=num_steps,
+        seed=int(input_args["seed"]),
+    )
+    calls_per_step = (
+        1
+        if config.use_cfg_parallel
+        or float(input_args.get("guidance_scale", 1.0)) <= 1.0
+        else 2
+    )
+    for name in ("transformer", "transformer_2"):
+        transformer = getattr(pipe, name, None)
+        reset = getattr(transformer, "reset_wan_inference_state", None)
+        if reset is not None:
+            reset(num_steps, calls_per_step)
 
 
 def _setup_parallel_vae(vae, enable_parallel_encoder: bool = True) -> None:
@@ -167,6 +209,14 @@ class _DistilledWanScheduler(FlowMatchEulerDiscreteScheduler):
 @register_model("Wan2.1-I2V")
 class xFuserWan21I2VModel(xFuserModel):
 
+    def preprocess_args(self, input_args: dict) -> dict:
+        args = super().preprocess_args(input_args)
+        if self.config.attention_backend == "AITER_VSA":
+            # The Jenga schedule performs its own early dense warmup.
+            args["num_hybrid_attn_high_precision_steps"] = 0
+            self.config.num_hybrid_attn_high_precision_steps = 0
+        return args
+
     def _calculate_hybrid_attention_step_multiplier(self, input_args: dict) -> int:
         do_cfg = input_args["guidance_scale"] > 1.0
         if do_cfg:
@@ -235,6 +285,7 @@ class xFuserWan21I2VModel(xFuserModel):
         return pipe
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
+        _prepare_wan_inference_run(self.pipe, self.config, input_args)
         output = self.pipe(
             image=input_args["image"],
             height=input_args["height"],
@@ -420,6 +471,7 @@ class xFuserWan22DistilledI2VModel(xFuserWan22I2VModel):
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
         # Guidance is baked into the distilled weights. guidance_scale=1.0 keeps
         # do_classifier_free_guidance=False, so negative_prompt has no effect.
+        _prepare_wan_inference_run(self.pipe, self.config, input_args)
         output = self.pipe(
             image=input_args["image"],
             height=input_args["height"],
@@ -437,6 +489,14 @@ class xFuserWan22DistilledI2VModel(xFuserWan22I2VModel):
 @register_model("Wan-AI/Wan2.1-T2V-14B-Diffusers")
 @register_model("Wan2.1-T2V")
 class xFuserWan21T2VModel(xFuserModel):
+
+    def preprocess_args(self, input_args: dict) -> dict:
+        args = super().preprocess_args(input_args)
+        if self.config.attention_backend == "AITER_VSA":
+            # Avoid stacking xDiT's five-step warmup on Jenga's dynamic one.
+            args["num_hybrid_attn_high_precision_steps"] = 0
+            self.config.num_hybrid_attn_high_precision_steps = 0
+        return args
 
     def _calculate_hybrid_attention_step_multiplier(self, input_args: dict) -> int:
         do_cfg = input_args["guidance_scale"] > 1.0
@@ -504,6 +564,7 @@ class xFuserWan21T2VModel(xFuserModel):
         return pipe
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
+        _prepare_wan_inference_run(self.pipe, self.config, input_args)
         output = self.pipe(
             height=input_args["height"],
             width=input_args["width"],
@@ -627,6 +688,7 @@ class xFuserWan22TI2VModel(xFuserWan21T2VModel):
         return pipe
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
+        _prepare_wan_inference_run(self.pipe, self.config, input_args)
         kwargs = {
             "height": input_args["height"],
             "width": input_args["width"],
@@ -764,6 +826,7 @@ class xFuserWan21VACEModel(xFuserModel):
         return input_args
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
+        _prepare_wan_inference_run(self.pipe, self.config, input_args)
         output = self.pipe(
             height=input_args["height"],
             width=input_args["width"],

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -24,6 +24,7 @@ from xfuser.model_executor.models.runner_models.base_model import (
     DiffusionOutput,
 )
 from xfuser.core.distributed.runtime_state import get_runtime_state
+from xfuser.core.distributed.attention_backend import AttentionBackendType
 from xfuser.core.distributed.parallel_state import get_vae_parallel_group
 from xfuser.core.utils.runner_utils import (
     log,
@@ -48,13 +49,15 @@ COMMON_FSDP_STRATEGY = {
 }
 
 WAN_VSA_ACCURACY_FIRST_DROP_RATES = (0.25, 0.40)
-WAN_VSA_JENGA_REFERENCE_DROP_RATES = (0.75, 0.85)
 
 
 def _build_attention_kwargs(config: "xFuserArgs") -> dict:
     """Build shared layout and sparse-attention options for Wan."""
     drop_rates = config.vsa_drop_rates
-    if config.attention_backend == "AITER_VSA" and not drop_rates:
+    backend = config.attention_backend
+    if isinstance(backend, str):
+        backend = AttentionBackendType[backend.upper()]
+    if backend == AttentionBackendType.AITER_VSA and not drop_rates:
         drop_rates = list(WAN_VSA_ACCURACY_FIRST_DROP_RATES)
     return {
         "thw": None,
@@ -74,34 +77,13 @@ def _build_attention_kwargs(config: "xFuserArgs") -> dict:
     }
 
 
-def _prepare_wan_inference_run(pipe, input_args: dict) -> None:
-    """Publish actual run dimensions and reset per-run VSA state."""
-    num_steps = int(input_args["num_inference_steps"])
-    get_runtime_state().set_video_input_parameters(
-        height=int(input_args["height"]),
-        width=int(input_args["width"]),
-        num_frames=int(input_args["num_frames"]),
-        batch_size=1,
-        num_inference_steps=num_steps,
-        seed=int(input_args["seed"]),
-    )
-    for name in ("transformer", "transformer_2"):
-        transformer = getattr(pipe, name, None)
-        reset = getattr(transformer, "reset_wan_inference_state", None)
-        if reset is not None:
-            reset(num_steps)
-
-
 class xFuserWanModel(xFuserModel):
     """Common lifecycle hooks for Wan runners."""
 
     def _prepare_inference_run(self, input_args: dict) -> None:
-        _prepare_wan_inference_run(self.pipe, input_args)
-
-    def _setup_hybrid_attn_schedule(self, input_args: dict) -> None:
-        if self.config.attention_backend == "AITER_VSA":
-            return
-        super()._setup_hybrid_attn_schedule(input_args)
+        get_runtime_state().reset_vsa_schedule_state(
+            int(input_args["num_inference_steps"])
+        )
 
 
 def _setup_parallel_vae(vae, enable_parallel_encoder: bool = True) -> None:

--- a/xfuser/model_executor/models/transformers/transformer_wan.py
+++ b/xfuser/model_executor/models/transformers/transformer_wan.py
@@ -203,12 +203,9 @@ class xFuserWanTransformer3DWrapper(WanTransformer3DModel):
            pos_embed_seq_len,
         )
         self.attention_kwargs = attention_kwargs
-        self._vsa_call_index = 0
         self._vsa_denoising_step = -1
         self._vsa_last_timestep = None
         self._vsa_num_steps = None
-        self._vsa_calls_per_step = 1
-        self._wan_teacache_states = {}
         for block in self.blocks:
             block.attn1.processor = xFuserWanAttnProcessor(attention_kwargs=self.attention_kwargs)
             block.attn2.processor = xFuserWanAttnProcessor(use_ulysses_parallel_attention=False, is_cross_attention=True)
@@ -223,16 +220,11 @@ class xFuserWanTransformer3DWrapper(WanTransformer3DModel):
             )
 
 
-    def reset_wan_inference_state(
-        self, num_inference_steps: int, calls_per_step: int
-    ) -> None:
-        """Reset VSA/TeaCache state at a pipeline-run boundary."""
-        self._vsa_call_index = 0
+    def reset_wan_inference_state(self, num_inference_steps: int) -> None:
+        """Reset VSA schedule state at a pipeline-run boundary."""
         self._vsa_denoising_step = -1
         self._vsa_last_timestep = None
         self._vsa_num_steps = int(num_inference_steps)
-        self._vsa_calls_per_step = max(int(calls_per_step), 1)
-        self._wan_teacache_states.clear()
 
 
     def _chunk_and_pad_sequence(self, x: torch.Tensor, sp_world_rank: int, sp_world_size: int, pad_amount: int, dim: int) -> torch.Tensor:
@@ -276,49 +268,38 @@ class xFuserWanTransformer3DWrapper(WanTransformer3DModel):
 
 
         runtime_state = get_runtime_state()
-        call_index = 0
-        calls_per_step = self._vsa_calls_per_step
         num_steps = (
             self._vsa_num_steps
             if self._vsa_num_steps is not None
             else int(runtime_state.input_config.num_inference_steps)
         )
-        track_wan_calls = (
+        track_vsa_steps = (
             self.attention_kwargs is not None
-            and (
-                self.attention_kwargs.get("vsa_drop_rates")
-                or self.attention_kwargs.get("use_wan_teacache")
-            )
+            and self.attention_kwargs.get("vsa_drop_rates")
         )
-        if track_wan_calls:
-            total_calls = max(num_steps * calls_per_step, 1)
-            call_index = self._vsa_call_index % total_calls
-            if self.attention_kwargs.get("vsa_drop_rates"):
-                current_timestep = float(timestep.reshape(-1)[0].item())
-                if (
-                    self._vsa_last_timestep is None
-                    or current_timestep != self._vsa_last_timestep
-                ):
-                    self._vsa_denoising_step = (
-                        self._vsa_denoising_step + 1
-                    ) % max(num_steps, 1)
-                    self._vsa_last_timestep = current_timestep
-                self.attention_kwargs["vsa_step_index"] = (
-                    self._vsa_denoising_step
-                )
-                self.attention_kwargs["vsa_num_steps"] = num_steps
-                effective_drop_rate = jenga_scheduled_drop_rate(
-                    self._vsa_denoising_step,
-                    num_steps,
-                    self.attention_kwargs["vsa_drop_rates"],
-                )
-                self.attention_kwargs["vsa_effective_drop_rate"] = (
-                    effective_drop_rate
-                )
-                self.attention_kwargs["vsa_use_dense"] = (
-                    effective_drop_rate <= 0.25
-                )
-            self._vsa_call_index = (call_index + 1) % total_calls
+        if track_vsa_steps:
+            current_timestep = float(timestep.reshape(-1)[0].item())
+            if (
+                self._vsa_last_timestep is None
+                or current_timestep != self._vsa_last_timestep
+            ):
+                self._vsa_denoising_step = (
+                    self._vsa_denoising_step + 1
+                ) % max(num_steps, 1)
+                self._vsa_last_timestep = current_timestep
+            self.attention_kwargs["vsa_step_index"] = self._vsa_denoising_step
+            self.attention_kwargs["vsa_num_steps"] = num_steps
+            effective_drop_rate = jenga_scheduled_drop_rate(
+                self._vsa_denoising_step,
+                num_steps,
+                self.attention_kwargs["vsa_drop_rates"],
+            )
+            self.attention_kwargs["vsa_effective_drop_rate"] = (
+                effective_drop_rate
+            )
+            self.attention_kwargs["vsa_use_dense"] = (
+                effective_drop_rate <= 0.25
+            )
 
         runtime_state.increment_step_counter()
 
@@ -384,87 +365,7 @@ class xFuserWanTransformer3DWrapper(WanTransformer3DModel):
 
 
         # 4. Transformer blocks
-        use_wan_teacache = (
-            self.attention_kwargs is not None
-            and self.attention_kwargs.get("use_wan_teacache", False)
-            and not torch.is_grad_enabled()
-        )
-        if use_wan_teacache:
-            if getattr(self.config, "in_channels", 16) != 16:
-                raise NotImplementedError(
-                    "xDiT Wan TeaCache currently supports Wan2.1 T2V only"
-                )
-            use_ret_steps = bool(
-                self.attention_kwargs.get(
-                    "wan_teacache_use_ret_steps", False
-                )
-            )
-            is_1_3b = len(self.blocks) <= 30
-            if use_ret_steps:
-                coefficients = (
-                    [-5.21862437e4, 9.23041404e3, -5.28275948e2,
-                     1.36987616e1, -4.99875664e-2]
-                    if is_1_3b
-                    else [-3.03318725e5, 4.90537029e4, -2.65530556e3,
-                          5.87365115e1, -3.15583525e-1]
-                )
-            else:
-                coefficients = (
-                    [2.39676752e3, -1.31110545e3, 2.01331979e2,
-                     -8.29855975, 1.37887774e-1]
-                    if is_1_3b
-                    else [-5784.54975374, 5449.50911966, -1811.16591783,
-                          256.27178429, -13.02252404]
-                )
-
-            lane = call_index % calls_per_step
-            state = self._wan_teacache_states.setdefault(
-                lane, {"previous": None, "residual": None, "accumulated": 0.0}
-            )
-            modulated = timestep_proj if use_ret_steps else temb
-            total_calls = max(num_steps * calls_per_step, 1)
-            retention_calls = (5 if use_ret_steps else 1) * calls_per_step
-            cutoff_calls = (
-                total_calls
-                if use_ret_steps
-                else max(total_calls - calls_per_step, 0)
-            )
-            should_calculate = (
-                call_index < retention_calls
-                or call_index >= cutoff_calls
-                or state["previous"] is None
-                or state["residual"] is None
-            )
-            if not should_calculate:
-                relative_l1 = (
-                    (modulated - state["previous"]).abs().mean()
-                    / state["previous"].abs().mean().clamp_min(1e-12)
-                ).float().item()
-                rescaled = 0.0
-                for coefficient in coefficients:
-                    rescaled = rescaled * relative_l1 + coefficient
-                state["accumulated"] += rescaled
-                should_calculate = state["accumulated"] >= float(
-                    self.attention_kwargs.get("wan_teacache_thresh", 0.2)
-                )
-            state["previous"] = modulated.detach().clone()
-
-            if should_calculate:
-                original_hidden_states = hidden_states.clone()
-                for block in self.blocks:
-                    hidden_states = block(
-                        hidden_states,
-                        encoder_hidden_states,
-                        timestep_proj,
-                        rotary_emb,
-                    )
-                state["residual"] = (
-                    hidden_states - original_hidden_states
-                ).detach()
-                state["accumulated"] = 0.0
-            else:
-                hidden_states = hidden_states + state["residual"]
-        elif torch.is_grad_enabled() and self.gradient_checkpointing:
+        if torch.is_grad_enabled() and self.gradient_checkpointing:
             for block in self.blocks:
                 hidden_states = self._gradient_checkpointing_func(
                     block, hidden_states, encoder_hidden_states, timestep_proj, rotary_emb

--- a/xfuser/model_executor/models/transformers/transformer_wan.py
+++ b/xfuser/model_executor/models/transformers/transformer_wan.py
@@ -203,9 +203,6 @@ class xFuserWanTransformer3DWrapper(WanTransformer3DModel):
            pos_embed_seq_len,
         )
         self.attention_kwargs = attention_kwargs
-        self._vsa_denoising_step = -1
-        self._vsa_last_timestep = None
-        self._vsa_num_steps = None
         for block in self.blocks:
             block.attn1.processor = xFuserWanAttnProcessor(attention_kwargs=self.attention_kwargs)
             block.attn2.processor = xFuserWanAttnProcessor(use_ulysses_parallel_attention=False, is_cross_attention=True)
@@ -220,11 +217,29 @@ class xFuserWanTransformer3DWrapper(WanTransformer3DModel):
             )
 
 
-    def reset_wan_inference_state(self, num_inference_steps: int) -> None:
-        """Reset VSA schedule state at a pipeline-run boundary."""
-        self._vsa_denoising_step = -1
-        self._vsa_last_timestep = None
-        self._vsa_num_steps = int(num_inference_steps)
+    def _update_vsa_attention_kwargs(
+        self, timestep: torch.LongTensor
+    ) -> None:
+        """Publish the current AITER VSA schedule values to its backend."""
+        if (
+            self.attention_kwargs is None
+            or not self.attention_kwargs.get("vsa_drop_rates")
+        ):
+            return
+
+        runtime_state = get_runtime_state()
+        step_index, num_steps = runtime_state.advance_vsa_schedule(
+            float(timestep.reshape(-1)[0].item())
+        )
+        self.attention_kwargs["vsa_step_index"] = step_index
+        self.attention_kwargs["vsa_num_steps"] = num_steps
+        effective_drop_rate = jenga_scheduled_drop_rate(
+            step_index,
+            num_steps,
+            self.attention_kwargs["vsa_drop_rates"],
+        )
+        self.attention_kwargs["vsa_effective_drop_rate"] = effective_drop_rate
+        self.attention_kwargs["vsa_use_dense"] = effective_drop_rate <= 0.25
 
 
     def _chunk_and_pad_sequence(self, x: torch.Tensor, sp_world_rank: int, sp_world_size: int, pad_amount: int, dim: int) -> torch.Tensor:
@@ -267,41 +282,8 @@ class xFuserWanTransformer3DWrapper(WanTransformer3DModel):
             lora_scale = 1.0
 
 
-        runtime_state = get_runtime_state()
-        num_steps = (
-            self._vsa_num_steps
-            if self._vsa_num_steps is not None
-            else int(runtime_state.input_config.num_inference_steps)
-        )
-        track_vsa_steps = (
-            self.attention_kwargs is not None
-            and self.attention_kwargs.get("vsa_drop_rates")
-        )
-        if track_vsa_steps:
-            current_timestep = float(timestep.reshape(-1)[0].item())
-            if (
-                self._vsa_last_timestep is None
-                or current_timestep != self._vsa_last_timestep
-            ):
-                self._vsa_denoising_step = (
-                    self._vsa_denoising_step + 1
-                ) % max(num_steps, 1)
-                self._vsa_last_timestep = current_timestep
-            self.attention_kwargs["vsa_step_index"] = self._vsa_denoising_step
-            self.attention_kwargs["vsa_num_steps"] = num_steps
-            effective_drop_rate = jenga_scheduled_drop_rate(
-                self._vsa_denoising_step,
-                num_steps,
-                self.attention_kwargs["vsa_drop_rates"],
-            )
-            self.attention_kwargs["vsa_effective_drop_rate"] = (
-                effective_drop_rate
-            )
-            self.attention_kwargs["vsa_use_dense"] = (
-                effective_drop_rate <= 0.25
-            )
-
-        runtime_state.increment_step_counter()
+        self._update_vsa_attention_kwargs(timestep)
+        get_runtime_state().increment_step_counter()
 
         sp_world_rank = get_sequence_parallel_rank()
         sp_world_size = get_sequence_parallel_world_size()

--- a/xfuser/model_executor/models/transformers/transformer_wan.py
+++ b/xfuser/model_executor/models/transformers/transformer_wan.py
@@ -21,6 +21,7 @@ from xfuser.model_executor.layers.attention_processor import (
     xFuserAttentionProcessorRegister
 )
 from xfuser.envs import PACKAGES_CHECKER
+from xfuser.core.vsa_attention import jenga_scheduled_drop_rate
 
 env_info = PACKAGES_CHECKER.get_packages_info()
 HAS_LONG_CTX_ATTN = env_info["has_long_ctx_attn"]
@@ -202,6 +203,12 @@ class xFuserWanTransformer3DWrapper(WanTransformer3DModel):
            pos_embed_seq_len,
         )
         self.attention_kwargs = attention_kwargs
+        self._vsa_call_index = 0
+        self._vsa_denoising_step = -1
+        self._vsa_last_timestep = None
+        self._vsa_num_steps = None
+        self._vsa_calls_per_step = 1
+        self._wan_teacache_states = {}
         for block in self.blocks:
             block.attn1.processor = xFuserWanAttnProcessor(attention_kwargs=self.attention_kwargs)
             block.attn2.processor = xFuserWanAttnProcessor(use_ulysses_parallel_attention=False, is_cross_attention=True)
@@ -214,6 +221,18 @@ class xFuserWanTransformer3DWrapper(WanTransformer3DModel):
                 torch.arange(num_attention_heads, dtype=torch.long),
                 persistent=False,
             )
+
+
+    def reset_wan_inference_state(
+        self, num_inference_steps: int, calls_per_step: int
+    ) -> None:
+        """Reset VSA/TeaCache state at a pipeline-run boundary."""
+        self._vsa_call_index = 0
+        self._vsa_denoising_step = -1
+        self._vsa_last_timestep = None
+        self._vsa_num_steps = int(num_inference_steps)
+        self._vsa_calls_per_step = max(int(calls_per_step), 1)
+        self._wan_teacache_states.clear()
 
 
     def _chunk_and_pad_sequence(self, x: torch.Tensor, sp_world_rank: int, sp_world_size: int, pad_amount: int, dim: int) -> torch.Tensor:
@@ -256,7 +275,52 @@ class xFuserWanTransformer3DWrapper(WanTransformer3DModel):
             lora_scale = 1.0
 
 
-        get_runtime_state().increment_step_counter()
+        runtime_state = get_runtime_state()
+        call_index = 0
+        calls_per_step = self._vsa_calls_per_step
+        num_steps = (
+            self._vsa_num_steps
+            if self._vsa_num_steps is not None
+            else int(runtime_state.input_config.num_inference_steps)
+        )
+        track_wan_calls = (
+            self.attention_kwargs is not None
+            and (
+                self.attention_kwargs.get("vsa_drop_rates")
+                or self.attention_kwargs.get("use_wan_teacache")
+            )
+        )
+        if track_wan_calls:
+            total_calls = max(num_steps * calls_per_step, 1)
+            call_index = self._vsa_call_index % total_calls
+            if self.attention_kwargs.get("vsa_drop_rates"):
+                current_timestep = float(timestep.reshape(-1)[0].item())
+                if (
+                    self._vsa_last_timestep is None
+                    or current_timestep != self._vsa_last_timestep
+                ):
+                    self._vsa_denoising_step = (
+                        self._vsa_denoising_step + 1
+                    ) % max(num_steps, 1)
+                    self._vsa_last_timestep = current_timestep
+                self.attention_kwargs["vsa_step_index"] = (
+                    self._vsa_denoising_step
+                )
+                self.attention_kwargs["vsa_num_steps"] = num_steps
+                effective_drop_rate = jenga_scheduled_drop_rate(
+                    self._vsa_denoising_step,
+                    num_steps,
+                    self.attention_kwargs["vsa_drop_rates"],
+                )
+                self.attention_kwargs["vsa_effective_drop_rate"] = (
+                    effective_drop_rate
+                )
+                self.attention_kwargs["vsa_use_dense"] = (
+                    effective_drop_rate <= 0.25
+                )
+            self._vsa_call_index = (call_index + 1) % total_calls
+
+        runtime_state.increment_step_counter()
 
         sp_world_rank = get_sequence_parallel_rank()
         sp_world_size = get_sequence_parallel_world_size()
@@ -320,7 +384,87 @@ class xFuserWanTransformer3DWrapper(WanTransformer3DModel):
 
 
         # 4. Transformer blocks
-        if torch.is_grad_enabled() and self.gradient_checkpointing:
+        use_wan_teacache = (
+            self.attention_kwargs is not None
+            and self.attention_kwargs.get("use_wan_teacache", False)
+            and not torch.is_grad_enabled()
+        )
+        if use_wan_teacache:
+            if getattr(self.config, "in_channels", 16) != 16:
+                raise NotImplementedError(
+                    "xDiT Wan TeaCache currently supports Wan2.1 T2V only"
+                )
+            use_ret_steps = bool(
+                self.attention_kwargs.get(
+                    "wan_teacache_use_ret_steps", False
+                )
+            )
+            is_1_3b = len(self.blocks) <= 30
+            if use_ret_steps:
+                coefficients = (
+                    [-5.21862437e4, 9.23041404e3, -5.28275948e2,
+                     1.36987616e1, -4.99875664e-2]
+                    if is_1_3b
+                    else [-3.03318725e5, 4.90537029e4, -2.65530556e3,
+                          5.87365115e1, -3.15583525e-1]
+                )
+            else:
+                coefficients = (
+                    [2.39676752e3, -1.31110545e3, 2.01331979e2,
+                     -8.29855975, 1.37887774e-1]
+                    if is_1_3b
+                    else [-5784.54975374, 5449.50911966, -1811.16591783,
+                          256.27178429, -13.02252404]
+                )
+
+            lane = call_index % calls_per_step
+            state = self._wan_teacache_states.setdefault(
+                lane, {"previous": None, "residual": None, "accumulated": 0.0}
+            )
+            modulated = timestep_proj if use_ret_steps else temb
+            total_calls = max(num_steps * calls_per_step, 1)
+            retention_calls = (5 if use_ret_steps else 1) * calls_per_step
+            cutoff_calls = (
+                total_calls
+                if use_ret_steps
+                else max(total_calls - calls_per_step, 0)
+            )
+            should_calculate = (
+                call_index < retention_calls
+                or call_index >= cutoff_calls
+                or state["previous"] is None
+                or state["residual"] is None
+            )
+            if not should_calculate:
+                relative_l1 = (
+                    (modulated - state["previous"]).abs().mean()
+                    / state["previous"].abs().mean().clamp_min(1e-12)
+                ).float().item()
+                rescaled = 0.0
+                for coefficient in coefficients:
+                    rescaled = rescaled * relative_l1 + coefficient
+                state["accumulated"] += rescaled
+                should_calculate = state["accumulated"] >= float(
+                    self.attention_kwargs.get("wan_teacache_thresh", 0.2)
+                )
+            state["previous"] = modulated.detach().clone()
+
+            if should_calculate:
+                original_hidden_states = hidden_states.clone()
+                for block in self.blocks:
+                    hidden_states = block(
+                        hidden_states,
+                        encoder_hidden_states,
+                        timestep_proj,
+                        rotary_emb,
+                    )
+                state["residual"] = (
+                    hidden_states - original_hidden_states
+                ).detach()
+                state["accumulated"] = 0.0
+            else:
+                hidden_states = hidden_states + state["residual"]
+        elif torch.is_grad_enabled() and self.gradient_checkpointing:
             for block in self.blocks:
                 hidden_states = self._gradient_checkpointing_func(
                     block, hidden_states, encoder_hidden_states, timestep_proj, rotary_emb


### PR DESCRIPTION
## Add AITER CK-Tile VSA Support for Wan

### Summary

This PR adds a Jenga-compatible block-sparse self-attention path for Wan2.1 using AITER's CK-Tile VSA kernel. It supports 4-way Ulysses sequence parallelism, keeps cross-attention and accuracy-sensitive denoising steps on dense AITER, and exposes mask, scheduling, and TeaCache controls through the xDiT runtime configuration.

### Principle

The Wan VSA path preserves the model's logical token order around distributed attention while presenting spatially local blocks to the sparse kernel:

1. Wan publishes the patch-grid shape `(T, H, W)` and the current denoising-step schedule through `attention_kwargs`.
2. USP performs the normal Ulysses Q/K/V all-to-all. The VSA setup then removes SP padding, de-interleaves the sequence, and applies a sliced-Gilbert permutation to video tokens.
3. Q/K are mean-pooled in 128-token blocks. A Jenga-style probability mask retains the smallest sorted block set whose cumulative probability reaches the configured threshold, subject to the drop-rate-derived `top_k` floor.
4. The dynamic mask is unioned with static Gilbert-neighbor relations and first-frame relations; padded KV blocks are removed.
5. The boolean block mask is converted to AITER's int32 delta-LUT plus valid-block counts and executed by `vsa_sparse_attention`.
6. The output is inverse-permuted, re-interleaved, and returned through USP's output all-to-all.

Step 0 and effective drop rates `<= 0.25` use dense AITER. Cross-attention, calls without Wan grid metadata, and unsupported sparse cases also fall back to dense AITER. This avoids combining xDiT's generic five-step high-precision warmup with Jenga's own dynamic schedule.

### Changes

**AITER VSA backend**
- Added `AttentionBackendType.AITER_VSA` and runtime availability checks for `aiter.ops.jenga_sparse_attention.vsa_sparse_attention`.
- Added Jenga block-mask selection, delta-LUT encoding, CK kernel dispatch, dense fallback, and device/workspace caches.

**Wan and Ulysses integration**
- Added sliced-Gilbert permutation and static-neighbor mask support to the shared Sparge sequence setup/restore path.
- Added per-denoising-step VSA scheduling, Wan patch-grid metadata propagation, inference-state reset, and Ulysses-compatible dispatch.
- Added configurable block size, drop rates, probability threshold, sequence reorder, static-neighbor mask, and first-frame mask.

**Wan TeaCache**
- Added sequence-parallel Wan TeaCache state management, threshold controls, and optional retention-step coefficients.

**Validation tools**
- Added mask/LUT/schedule/Gilbert and CK-vs-masked-dense unit tests.
- Added per-timestep accuracy tracing and paired Dense/VSA video validation benchmarks.

### Tests

```bash
PYTHONPATH=. pytest tests/core/test_vsa_attention.py -v
```

Result: `6 passed`, including the AITER CK VSA kernel comparison against masked dense attention on GPU.

```bash
python3 -m py_compile   xfuser/config/args.py xfuser/config/config.py   xfuser/core/distributed/attention_backend.py   xfuser/core/distributed/runtime_state.py   xfuser/core/sparge_attention/sparge.py   xfuser/core/vsa_attention.py   xfuser/model_executor/models/runner_models/base_model.py   xfuser/model_executor/models/runner_models/wan.py   xfuser/model_executor/models/transformers/transformer_wan.py   benchmarks/wan_vsa_accuracy.py   benchmarks/wan_vsa_video_validation.py   tests/core/test_vsa_attention.py
```

### Benchmark

4× AMD MI308X, Wan2.1-T2V-1.3B, Ulysses=4, 3 prompts × 3 seeds, 50 denoising steps, 480×832, 81 frames, guidance scale 6.0, flow shift 8.0, TeaCache disabled. Dense and VSA each used an independent warmup; the first timing was discarded and two measured iterations were retained per case.

```bash
torchrun --nproc_per_node=4 benchmarks/wan_vsa_video_validation.py   --model-path <WAN_MODEL_PATH>   --output wan-vsa-validation.json   --seeds 0 1 2   --steps 50 --height 480 --width 832 --frames 81   --iterations 3
```

**xDiT end-to-end results**
- Dense: mean `65.367 s`, median `65.368 s`, stddev `0.019 s`
- AITER VSA: mean `63.153 s`, median `63.260 s`, stddev `0.265 s`
- Dense / VSA: mean `1.0351×`, median `1.0331×`, speedup stddev `0.0043`
- Dense-vs-VSA quality: PSNR `30.039`, SSIM `0.9469`, LPIPS-Alex `0.02113`

A native Wan implementation using the same weights, kernels, generation settings, and warmup protocol measured `1.0318×`. The relative speedup difference is `0.318%`, within the 2% engineering-consistency target. The remaining approximately 6.38-second absolute framework gap is nearly identical for Dense and VSA and therefore does not account for the sparse-attention speedup.

### Limitations

- Requires an AITER build containing the CK-Tile `jenga_sparse_attention` operator.
- VSA currently supports non-causal Wan self-attention with block size 128; cross-attention remains dense.
- Ring parallelism greater than one is not supported by this backend.

