### PR TITLE
[Model] Add LingBot-Video support (MoE 30B + Dense 1.3B)

### DIFF
--- a/xfuser/model_executor/models/runner_models/lingbot_video.py
+++ b/xfuser/model_executor/models/runner_models/lingbot_video.py
@@ -125,8 +125,9 @@ class xFuserLingBotVideoMoEModel(xFuserModel):
         config.task = saved_task
 
     def _calculate_hybrid_attention_step_multiplier(self, input_args: dict) -> int:
-        do_cfg = input_args["guidance_scale"] > 1.0
-        return 2 if do_cfg else 1
+        if input_args["guidance_scale"] > 1.0 and not self.config.use_cfg_parallel:
+            return 2
+        return 1
 
     capabilities = ModelCapabilities(
         ulysses_degree=True,

--- a/xfuser/model_executor/models/runner_models/lingbot_video.py
+++ b/xfuser/model_executor/models/runner_models/lingbot_video.py
@@ -1,0 +1,493 @@
+import copy
+import json
+import os
+import torch
+from diffusers import AutoencoderKLWan
+from diffusers.pipelines.pipeline_utils import DiffusionPipeline
+from transformers import Qwen3VLForConditionalGeneration, Qwen3VLProcessor
+
+from xfuser import xFuserArgs
+from xfuser.model_executor.models.transformers.transformer_lingbot_video import (
+    xFuserLingBotVideoTransformer3DWrapper,
+)
+from xfuser.model_executor.pipelines.pipeline_lingbot_video import (
+    xFuserLingBotVideoPipeline,
+    get_lingbot_video_pipeline_class,
+)
+from xfuser.model_executor.models.runner_models.base_model import (
+    ModelSettings,
+    xFuserModel,
+    register_model,
+    ModelCapabilities,
+    DefaultInputValues,
+    DiffusionOutput,
+)
+from xfuser.core.distributed.runtime_state import get_runtime_state
+from xfuser.core.distributed.parallel_state import get_vae_parallel_group
+from xfuser.core.utils.runner_utils import log
+
+
+LINGBOT_FSDP_STRATEGY = {
+    "transformer": {
+        "wrap_attrs": ["blocks"],
+        "dtype": torch.bfloat16,
+    },
+}
+
+# MoE backend config
+os.environ.setdefault("LINGBOT_MOE_EXPERT_BACKEND", "grouped_mm")
+os.environ.setdefault("LINGBOT_MOE_PAD_BACKEND", "vectorized")
+
+# Refiner constants
+REFINER_BASE_HEIGHT = 480
+REFINER_BASE_WIDTH = 832
+REFINER_STEPS = 8        # canonical: refiner runs few steps on partially-noised input
+REFINER_T_THRESH = 0.85  # canonical: noise level threshold for refiner init
+
+DEFAULT_NEGATIVE_PROMPT = (
+    '{"universal_negative": {"visual_quality": ["low quality", "worst quality", '
+    '"blurry", "pixelated", "jpeg artifacts", "low resolution", "unstable color", '
+    '"color flicker", "underexposed", "overexposed", "invisible subject", '
+    '"subject hidden in darkness"], "artistic_style": ["painting", "illustration", '
+    '"drawing", "cartoon", "3d render", "cgi", "sketch", "digital art"], '
+    '"composition_and_content": ["text", "watermark", "signature", "logo", '
+    '"subtitles", "pillarboxed", "side bars", "portrait image in landscape frame"], '
+    '"temporal_and_motion_stability": ["flickering", "jittery", "motion blur", '
+    '"temporal inconsistency", "warping", "morphing", "incoherent motion", '
+    '"unnatural movement", "static object with sudden jump", '
+    '"frame-to-frame inconsistency"], "material_and_structure": ["plastic-like glass", '
+    '"unrealistic texture", "deformed bottle", "liquid freezing improperly", '
+    '"distorted reflections"]}}'
+)
+
+
+def _load_json_prompt(prompt: str) -> str:
+    """If prompt is a path to a .json file, load and serialize the caption.
+
+    LingBot-Video expects structured JSON captions, not plain text.
+    The JSON file should have {"caption": {...}, "duration": N} format.
+    The caption dict is serialized to a compact JSON string.
+    """
+    if isinstance(prompt, str) and prompt.endswith(".json") and os.path.isfile(prompt):
+        with open(prompt, encoding="utf-8") as f:
+            data = json.load(f)
+        caption = data.get("caption", data)
+        if isinstance(caption, (dict, list)):
+            return json.dumps(caption, ensure_ascii=False, separators=(",", ":"))
+        return str(caption)
+    return prompt
+
+
+def _setup_parallel_vae(vae, use_encoder=False):
+    import torch.distributed as dist
+    vae_group = get_vae_parallel_group().device_group
+    log(f"VAE parallel group: world_size={dist.get_world_size(vae_group)}, "
+        f"rank={dist.get_rank(vae_group)}, vae.device={vae.device}")
+    try:
+        from distvae.modules.adapters.vae.decoder_adapters import WanDecoderAdapter
+        vae.decoder = WanDecoderAdapter(vae.decoder, vae_group=vae_group).to(vae.device)
+        log("Parallel VAE decoder enabled.")
+    except ImportError:
+        log("distvae WanDecoderAdapter not available, skipping parallel VAE decoder.")
+        return
+    except Exception as e:
+        log(f"Failed to patch VAE decoder: {e}")
+        return
+    if use_encoder:
+        try:
+            from distvae.modules.adapters.vae.encoder_adapters import WanEncoderAdapter
+            vae.encoder = WanEncoderAdapter(vae.encoder, vae_group=vae_group).to(vae.device)
+            log("Parallel VAE encoder enabled.")
+        except ImportError:
+            log("distvae WanEncoderAdapter not available, skipping parallel VAE encoder.")
+        except Exception as e:
+            log(f"Failed to patch VAE encoder: {e}")
+
+
+@register_model("robbyant/lingbot-video-moe-30b-a3b")
+@register_model("LingBot-Video-MoE")
+class xFuserLingBotVideoMoEModel(xFuserModel):
+
+    def save_output(self, output):
+        # Stock TI2V CFG parallel puts output on rank 0, but xDiT's runner
+        # only saves from the last rank. Skip gracefully when no output.
+        if output.videos or output.images:
+            super().save_output(output)
+        else:
+            log("No output on this rank (CFG parallel secondary), skipping save.")
+
+    def _validate_config(self, config):
+        # Temporarily clear task to skip base class task validation,
+        # then restore — we handle --task refine ourselves.
+        saved_task = config.task
+        config.task = None
+        super()._validate_config(config)
+        config.task = saved_task
+
+    def _calculate_hybrid_attention_step_multiplier(self, input_args: dict) -> int:
+        do_cfg = input_args["guidance_scale"] > 1.0
+        return 2 if do_cfg else 1
+
+    capabilities = ModelCapabilities(
+        ulysses_degree=True,
+        ring_degree=False,
+        use_cfg_parallel=True,
+        use_fp8_gemms=True,
+        use_fp4_gemms=True,
+        use_hybrid_attn_schedule=True,
+        use_hybrid_gemm_schedule=True,
+        fully_shard_degree=True,
+        use_parallel_vae=True,
+        enable_tiling=True,
+        enable_slicing=True,
+    )
+    default_input_values = DefaultInputValues(
+        height=480,
+        width=832,
+        num_inference_steps=40,
+        num_frames=81,
+        negative_prompt=DEFAULT_NEGATIVE_PROMPT,
+        guidance_scale=3.0,
+        flow_shift=3.0,
+    )
+    settings = ModelSettings(
+        model_name="robbyant/lingbot-video-moe-30b-a3b",
+        output_name="lingbot_video_moe",
+        model_output_type="video",
+        fps=24,
+        fp8_gemm_module_list=["transformer.blocks"],
+        fp4_gemm_module_list=["transformer.blocks"],
+        fsdp_strategy=LINGBOT_FSDP_STRATEGY,
+    )
+
+    def _post_load_and_state_initialization(self, input_args: dict) -> None:
+        # Cache bulk_dtype on each block before quantization replaces nn.Linear
+        # modules — LingBotVideoBlock.forward reads self.attn.to_q.weight.dtype
+        # which breaks after FP4/FP8 quantization removes .weight.
+        if self.config.use_fp4_gemms or self.config.use_fp8_gemms:
+            for block in self.pipe.transformer.blocks:
+                if hasattr(block, "attn") and hasattr(block.attn, "to_q"):
+                    w = getattr(block.attn.to_q, "weight", None)
+                    if w is not None:
+                        block._cached_bulk_dtype = w.dtype
+        # Use LingBot's own FSDP approach instead of xDiT's: shard per-block
+        # with ignored_params for minority-dtype (FP32 norms/router).
+        if self.config.fully_shard_degree > 1:
+            from lingbot_video.fsdp_inference import apply_fsdp_inference, init_fsdp_inference_mesh
+            local_rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+            self.pipe.transformer.to(f"cuda:{local_rank}")
+            mesh = init_fsdp_inference_mesh()
+            info = apply_fsdp_inference(self.pipe.transformer, mesh)
+            log(f"FSDP: {info.wrapped_blocks} blocks sharded, "
+                f"{info.ignored_params} FP32 params excluded, "
+                f"VRAM: {torch.cuda.memory_allocated(local_rank)/1e9:.1f}GB")
+            # Move remaining components to GPU
+            self.pipe.vae.to(f"cuda:{local_rank}")
+            self.pipe.text_encoder.to(f"cuda:{local_rank}")
+            # Skip xDiT's own FSDP sharding
+            saved_fsdp = self.config.fully_shard_degree
+            self.config.fully_shard_degree = 1
+            super()._post_load_and_state_initialization(input_args)
+            self.config.fully_shard_degree = saved_fsdp
+        else:
+            super()._post_load_and_state_initialization(input_args)
+        # After quantization, patch blocks that lost .weight.dtype
+        if self.config.use_fp4_gemms or self.config.use_fp8_gemms:
+            from xfuser.model_executor.models.transformers.transformer_lingbot_video import _patch_block_bulk_dtype
+            for block in self.pipe.transformer.blocks:
+                if hasattr(block, "_cached_bulk_dtype"):
+                    _patch_block_bulk_dtype(block)
+        if self.config.use_parallel_vae:
+            _setup_parallel_vae(self.pipe.vae)
+
+        # Cache pre-transposed expert weights to eliminate per-call copies
+        self.pipe.transformer.cache_expert_weights()
+
+        # Load refiner if requested via --task refine
+        self.refiner_pipe = None
+        use_refiner = self.config.task == "refine"
+        if use_refiner:
+            self._load_refiner(input_args)
+
+    def _load_refiner(self, input_args):
+        from lingbot_video.scheduling_flow_unipc import FlowUniPCMultistepScheduler
+
+        log("Loading refiner transformer...")
+        model_name = self.settings.model_name
+        refiner_transformer = xFuserLingBotVideoTransformer3DWrapper.from_pretrained(
+            model_name, torch_dtype=torch.bfloat16, subfolder="refiner",
+        )
+        local_rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+        refiner_transformer = refiner_transformer.to(f"cuda:{local_rank}")
+        refiner_scheduler = FlowUniPCMultistepScheduler.from_pretrained(
+            model_name, subfolder="scheduler",
+        )
+        LingBotVideoPipeline = get_lingbot_video_pipeline_class()
+        refiner_pipe = LingBotVideoPipeline(
+            transformer=refiner_transformer,
+            vae=self.pipe.vae,
+            text_encoder=self.pipe.text_encoder,
+            processor=self.pipe.processor,
+            scheduler=refiner_scheduler,
+        )
+        refiner_pipe.__class__ = type(
+            "xFuserLingBotVideoPipeline",
+            (xFuserLingBotVideoPipeline, LingBotVideoPipeline),
+            {},
+        )
+        # Quantize refiner linears (same path as base transformer)
+        if self.config.use_fp4_gemms or self.config.use_fp8_gemms:
+            from xfuser.model_executor.models.transformers.transformer_lingbot_video import _patch_block_bulk_dtype
+            from xfuser.core.utils.runner_utils import quantize_linear_layers_to_fp4, quantize_linear_layers_to_fp8
+            # Cache bulk dtype before quantization replaces nn.Linear
+            for block in refiner_transformer.blocks:
+                if hasattr(block, "attn") and hasattr(block.attn, "to_q"):
+                    w = getattr(block.attn.to_q, "weight", None)
+                    if w is not None:
+                        block._cached_bulk_dtype = w.dtype
+            device = f"cuda:{local_rank}"
+            if self.config.use_fp4_gemms:
+                log("Quantizing refiner blocks to FP4...")
+                quantize_linear_layers_to_fp4(
+                    refiner_transformer.blocks,
+                    fp8_layers=self.settings.fp8_precision_overrides,
+                    use_hybrid_schedule=self.config.use_hybrid_gemm_schedule,
+                    device=device,
+                )
+            elif self.config.use_fp8_gemms:
+                log("Quantizing refiner blocks to FP8...")
+                quantize_linear_layers_to_fp8(refiner_transformer.blocks, device=device)
+            # Patch blocks that lost .weight.dtype
+            for block in refiner_transformer.blocks:
+                if hasattr(block, "_cached_bulk_dtype"):
+                    _patch_block_bulk_dtype(block)
+        # Enable VAE tiling/slicing for refiner (1080p needs it)
+        if self.config.enable_tiling:
+            refiner_pipe.vae.enable_tiling()
+        if self.config.enable_slicing:
+            refiner_pipe.vae.enable_slicing()
+
+        # FSDP shard the refiner transformer if enabled
+        if self.config.fully_shard_degree > 1:
+            from xfuser.core.distributed.parallel_state import get_fs_group
+            from xfuser.core.distributed.sharding import shard_component
+            device_group = get_fs_group().device_group
+            fs_local_rank = get_fs_group().local_rank
+            log("Sharding refiner transformer with FSDP...")
+            refiner_pipe.transformer = shard_component(
+                refiner_transformer, ["blocks"], device_group, fs_local_rank,
+                torch.bfloat16, sync_module_states=False,
+            )
+
+        self.refiner_pipe = refiner_pipe
+        refiner_pipe.transformer.cache_expert_weights()
+        log("Refiner loaded.")
+
+    def _build_pipe(self, model_name, transformer_subfolder="transformer", use_i2v=False):
+        from lingbot_video.scheduling_flow_unipc import FlowUniPCMultistepScheduler
+
+        transformer = xFuserLingBotVideoTransformer3DWrapper.from_pretrained(
+            model_name, torch_dtype=torch.bfloat16, subfolder=transformer_subfolder,
+        )
+        vae = AutoencoderKLWan.from_pretrained(
+            model_name, torch_dtype=torch.float32, subfolder="vae",
+        )
+        text_encoder = Qwen3VLForConditionalGeneration.from_pretrained(
+            model_name, torch_dtype=torch.bfloat16, subfolder="text_encoder",
+        )
+        processor = Qwen3VLProcessor.from_pretrained(
+            model_name, subfolder="processor",
+        )
+        scheduler = FlowUniPCMultistepScheduler.from_pretrained(
+            model_name, subfolder="scheduler",
+        )
+        if use_i2v:
+            from lingbot_video.pipeline_lingbot_video_i2v import LingBotVideoImageToVideoPipeline
+            BasePipeClass = LingBotVideoImageToVideoPipeline
+        else:
+            BasePipeClass = get_lingbot_video_pipeline_class()
+        pipe = BasePipeClass(
+            transformer=transformer,
+            vae=vae,
+            text_encoder=text_encoder,
+            processor=processor,
+            scheduler=scheduler,
+        )
+        pipe.__class__ = type(
+            "xFuserLingBotVideoPipeline",
+            (xFuserLingBotVideoPipeline, BasePipeClass),
+            {},
+        )
+        return pipe
+
+    def _load_model(self) -> DiffusionPipeline:
+        use_i2v = bool(self.config.img_file_path) or bool(self.config.input_images)
+        if use_i2v:
+            log("TI2V mode: loading image-to-video pipeline")
+        return self._build_pipe(self.settings.model_name, use_i2v=use_i2v)
+
+    def _run_pipe(self, input_args: dict) -> DiffusionOutput:
+        raw_prompt = input_args["prompt"]
+        if isinstance(raw_prompt, list):
+            raw_prompt = raw_prompt[0] if len(raw_prompt) == 1 else " ".join(raw_prompt)
+        prompt = _load_json_prompt(raw_prompt)
+        generator = torch.Generator(device="cuda").manual_seed(input_args["seed"])
+
+        # In refiner mode, --height/--width is the final output resolution;
+        # base pass runs at fixed 480x832, refiner upscales to target.
+        use_refiner = hasattr(self, "refiner_pipe") and self.refiner_pipe is not None
+        if use_refiner:
+            refiner_height = input_args["height"]
+            refiner_width = input_args["width"]
+            base_height = REFINER_BASE_HEIGHT
+            base_width = REFINER_BASE_WIDTH
+        else:
+            base_height = input_args["height"]
+            base_width = input_args["width"]
+
+        pipe_kwargs = dict(
+            prompt=prompt,
+            negative_prompt=input_args["negative_prompt"],
+            height=base_height,
+            width=base_width,
+            num_frames=input_args["num_frames"],
+            num_inference_steps=input_args["num_inference_steps"],
+            guidance_scale=input_args["guidance_scale"],
+            shift=input_args.get("flow_shift", 3.0),
+            generator=generator,
+        )
+
+        # TI2V: pass image to pipeline
+        images = input_args.get("input_images", [])
+        if images:
+            pipe_kwargs["image"] = images[0]
+
+        # Base pass
+        output = self.pipe(**pipe_kwargs)
+
+        # Refiner pass
+        if use_refiner and output.frames:
+            output = self._run_refiner(output, input_args, prompt, generator,
+                                       refiner_height, refiner_width)
+
+        return DiffusionOutput(videos=output.frames or None, pipe_args=input_args)
+
+    def _run_refiner(self, base_output, input_args, prompt, generator,
+                     refiner_height, refiner_width):
+        from lingbot_video.utils import prepare_refiner_latent
+        import numpy as np
+
+        torch.cuda.empty_cache()
+        device = next(self.refiner_pipe.vae.parameters()).device
+        vae = self.refiner_pipe.vae
+
+        base_frames = base_output.frames
+        frames_np = np.array(base_frames[0] if isinstance(base_frames, list) else base_frames)
+        # (T, H, W, 3) -> (T, 3, H, W) on CPU
+        frames_cpu = torch.from_numpy(frames_np).permute(0, 3, 1, 2).float()
+        del frames_np, base_frames
+        num_frames = frames_cpu.shape[0]
+
+        # Resize on CPU (avoids GPU allocation of full 1080p tensor)
+        frames_cpu = torch.nn.functional.interpolate(
+            frames_cpu, size=(refiner_height, refiner_width),
+            mode="bilinear", align_corners=False,
+        ).mul_(2.0).sub_(1.0)
+        # (T, 3, H, W) -> (1, 3, T, H, W), transfer to GPU only for VAE encode
+        video_tensor = frames_cpu.unsqueeze(0).permute(0, 2, 1, 3, 4)
+        del frames_cpu
+
+        refiner_generator = torch.Generator(device="cuda").manual_seed(input_args["seed"])
+        with torch.no_grad():
+            x_up = self.refiner_pipe._vae_latent_to_dit(
+                vae.encode(video_tensor.to(device=device, dtype=vae.dtype)).latent_dist.mode()
+            )
+            del video_tensor
+            torch.cuda.empty_cache()
+            noise = torch.randn(
+                x_up.shape, device=x_up.device, dtype=x_up.dtype,
+                generator=refiner_generator,
+            )
+            initial_latent = prepare_refiner_latent(x_up, noise, REFINER_T_THRESH)
+
+        guidance = input_args.get("guidance_scale_2") or input_args["guidance_scale"]
+        shift = input_args.get("flow_shift", 3.0)
+        log(f"Running refiner: {refiner_height}x{refiner_width}, "
+            f"{REFINER_STEPS} steps, guidance={guidance}, t_thresh={REFINER_T_THRESH}")
+        refiner_output = self.refiner_pipe(
+            prompt=prompt,
+            negative_prompt=input_args["negative_prompt"],
+            height=refiner_height,
+            width=refiner_width,
+            num_frames=num_frames,
+            num_inference_steps=REFINER_STEPS,
+            guidance_scale=guidance,
+            shift=shift,
+            t_thresh=REFINER_T_THRESH,
+            generator=refiner_generator,
+            latents=initial_latent,
+        )
+        return refiner_output
+
+    def _prepare_and_compile_transformer(self, pipe, height, width, num_frames):
+        """Prepare RoPE + MoE patches for compile, then compile and warmup."""
+        pipe.transformer.prepare_for_compile(
+            height=height,
+            width=width,
+            num_frames=num_frames,
+            vae_scale_temporal=getattr(pipe, "vae_scale_factor_temporal", 4),
+            vae_scale_spatial=getattr(pipe, "vae_scale_factor_spatial", 8),
+        )
+        pipe.transformer = torch.compile(pipe.transformer, mode="default")
+
+    def _reset_scheduler(self, pipe):
+        scheduler = pipe.scheduler
+        if hasattr(scheduler, "timestep_list"):
+            scheduler.timestep_list = [None] * len(scheduler.timestep_list)
+
+    def _compile_model(self, input_args):
+        torch._inductor.config.reorder_for_compute_comm_overlap = True
+
+        # In refiner mode, --height/--width is the target; base uses 480x832
+        if self.refiner_pipe is not None:
+            base_h, base_w = REFINER_BASE_HEIGHT, REFINER_BASE_WIDTH
+            refiner_h, refiner_w = input_args["height"], input_args["width"]
+        else:
+            base_h, base_w = input_args["height"], input_args["width"]
+
+        # Compile base transformer
+        self._prepare_and_compile_transformer(
+            self.pipe, base_h, base_w, input_args["num_frames"],
+        )
+
+        # Compile refiner BEFORE warmup so warmup covers both
+        if self.refiner_pipe is not None:
+            log("Compiling refiner transformer...")
+            self._prepare_and_compile_transformer(
+                self.refiner_pipe, refiner_h, refiner_w,
+                input_args["num_frames"],
+            )
+
+        compile_args = copy.deepcopy(input_args)
+        compile_args["num_inference_steps"] = 2
+        self._run_timed_pipe(compile_args)
+        self._reset_scheduler(self.pipe)
+        if self.refiner_pipe is not None:
+            self._reset_scheduler(self.refiner_pipe)
+
+
+@register_model("robbyant/lingbot-video-dense-1.3b")
+@register_model("LingBot-Video-Dense")
+class xFuserLingBotVideoDenseModel(xFuserLingBotVideoMoEModel):
+
+    def __init__(self, config: xFuserArgs) -> None:
+        super().__init__(config)
+        self.settings = ModelSettings(
+            model_name="robbyant/lingbot-video-dense-1.3b",
+            output_name="lingbot_video_dense",
+            model_output_type="video",
+            fps=24,
+            fp8_gemm_module_list=["transformer.blocks"],
+            fp4_gemm_module_list=["transformer.blocks"],
+            fsdp_strategy=LINGBOT_FSDP_STRATEGY,
+        )

--- a/xfuser/model_executor/models/transformers/transformer_lingbot_video.py
+++ b/xfuser/model_executor/models/transformers/transformer_lingbot_video.py
@@ -1,0 +1,330 @@
+import torch
+from typing import Optional, Union, Dict, Any
+
+from diffusers.models.modeling_outputs import Transformer2DModelOutput
+
+from xfuser.model_executor.layers.usp import USP
+from xfuser.core.distributed import (
+    get_sequence_parallel_world_size,
+    get_sequence_parallel_rank,
+    get_sp_group,
+    get_runtime_state,
+)
+
+
+def get_lingbot_video_classes():
+    from lingbot_video.transformer_lingbot_video import (
+        LingBotVideoTransformer3DModel,
+        apply_rotary_emb,
+        make_joint_position_ids,
+        _cat_interleave,
+    )
+    return (
+        LingBotVideoTransformer3DModel,
+        apply_rotary_emb,
+        make_joint_position_ids,
+        _cat_interleave,
+    )
+
+
+def _usp_attention_forward(attn_module, x, rotary_emb, attention_mask=None, packed_indices=None, parallel_config=None):
+    """Replacement forward for LingBotVideoAttention that uses USP for distributed attention.
+
+    For single GPU (sp_world_size=1), USP routes through the configured attention backend
+    (AITER, FlashAttention, etc.) rather than the default SDPA dispatch.
+    """
+    B, S, _ = x.shape
+    q = attn_module.to_q(x).unflatten(2, (attn_module.num_heads, attn_module.head_dim))
+    k = attn_module.to_k(x).unflatten(2, (attn_module.num_heads, attn_module.head_dim))
+    v = attn_module.to_v(x).unflatten(2, (attn_module.num_heads, attn_module.head_dim))
+
+    _, apply_rotary_emb_fn, _, _ = get_lingbot_video_classes()
+    q = apply_rotary_emb_fn(attn_module.norm_q(q), rotary_emb)
+    k = apply_rotary_emb_fn(attn_module.norm_k(k), rotary_emb)
+
+    # USP expects (B, H, S, D), LingBot attention uses (B, S, H, D)
+    q = q.transpose(1, 2)
+    k = k.transpose(1, 2)
+    v = v.transpose(1, 2)
+    out = USP(q, k, v)
+    out = out.transpose(1, 2)  # back to (B, S, H, D)
+    return attn_module.to_out(out.flatten(2, 3).type_as(x))
+
+
+def _patch_block_bulk_dtype(block):
+    """Patch LingBotVideoBlock.forward to use cached dtype instead of .weight.dtype.
+
+    After FP4/FP8 quantization, attn.to_q no longer has .weight, so the stock
+    forward's `self.attn.to_q.weight.dtype` crashes. This patches the block to
+    use the pre-cached dtype instead.
+    """
+    original_forward = block.forward
+
+    def patched_forward(x, temb6, rotary_emb, attention_mask=None, moe_padding_mask=None, packed_indices=None, parallel_config=None):
+        import torch.nn.functional as F
+        from lingbot_video.transformer_lingbot_video import LingBotVideoSparseMoeBlock
+
+        expected_tokens = x.shape[0] * x.shape[1]
+        if temb6.ndim != 2 or temb6.shape[0] != expected_tokens:
+            raise ValueError(
+                f"LingBotVideoBlock expects token-level temb6 with shape "
+                f"(B*S, 6D); got {tuple(temb6.shape)} for hidden states {tuple(x.shape)}."
+            )
+        mod = temb6.view(x.shape[0], x.shape[1], -1) + block.scale_shift_table.unsqueeze(0)
+        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = mod.chunk(6, dim=-1)
+        gate_msa, gate_mlp = gate_msa.tanh(), gate_mlp.tanh()
+        scale_msa, scale_mlp = 1.0 + scale_msa, 1.0 + scale_mlp
+
+        bulk_dtype = getattr(block, "_cached_bulk_dtype", torch.bfloat16)
+        attn_in = (block.norm1(x) * scale_msa + shift_msa).to(bulk_dtype)
+        attn_out = block.attn(
+            attn_in, rotary_emb, attention_mask,
+            packed_indices=packed_indices, parallel_config=parallel_config,
+        )
+        x = x + (gate_msa * block.norm_post_attn(attn_out)).to(x.dtype)
+
+        ffn_in = (block.norm2(x) * scale_mlp + shift_mlp).to(bulk_dtype)
+        if isinstance(block.ffn, LingBotVideoSparseMoeBlock):
+            ffn_out = block.ffn(ffn_in, padding_mask=moe_padding_mask)
+        else:
+            ffn_out = block.ffn(ffn_in)
+        ffn_normed = block.norm_post_ffn(ffn_out)
+        x = x + (gate_mlp * ffn_normed).to(x.dtype)
+        return x
+
+    block.forward = patched_forward
+
+
+def _reorder_tokens_compile_friendly(tokens, top_scores, top_indices, num_experts):
+    """Compile-friendly _reorder_tokens that avoids dynamic-shape torch.where.
+
+    Assumes all top-k slots are active (scores != 0), which holds for standard
+    top-k routing where exactly k experts are selected per token.
+    """
+    num_tokens = tokens.shape[0]
+    top_k = top_indices.shape[1]
+    flat_scores = top_scores.reshape(-1)
+    flat_indices = top_indices.reshape(-1)
+
+    counts = torch.zeros(num_experts, device=tokens.device, dtype=torch.int64)
+    counts.scatter_add_(0, flat_indices.long(), torch.ones_like(flat_indices, dtype=torch.int64))
+
+    sort_order = torch.argsort(flat_indices, stable=True)
+    sorted_positions = sort_order
+    sorted_scores = flat_scores[sort_order]
+    original_token_idx = sort_order // top_k
+    permuted_tokens = tokens[original_token_idx]
+    return permuted_tokens, counts, sorted_positions, sorted_scores, num_tokens, top_k
+
+
+def _rope_forward_no_rebuild(rope_module, position_ids):
+    """RoPE forward that skips the lazy table rebuild check.
+
+    The table must be pre-built via a warmup call before torch.compile.
+    Eliminates the data-dependent `max_vals >= axes_lens` graph break.
+    """
+    if rope_module.freqs_cis is None:
+        return rope_module._original_forward(position_ids)
+    device = position_ids.device
+    if rope_module.freqs_cis[0].device != device:
+        rope_module.freqs_cis = [fc.to(device) for fc in rope_module.freqs_cis]
+    return torch.cat(
+        [rope_module.freqs_cis[i][position_ids[:, i]] for i in range(len(rope_module.axes_dims))],
+        dim=-1,
+    )
+
+
+class xFuserLingBotVideoTransformer3DWrapper:
+    """Wrapper that adds USP (Ulysses Sequence Parallelism) to LingBotVideoTransformer3DModel.
+
+    Uses the same chunk-blocks-gather pattern as the Wan 2.1 wrapper but applied to
+    the joint [video; text] sequence (since LingBot uses self-attention only, no cross-attention).
+    """
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+        LingBotVideoTransformer3DModel = get_lingbot_video_classes()[0]
+        model = LingBotVideoTransformer3DModel.from_pretrained(
+            pretrained_model_name_or_path, **kwargs
+        )
+        model.__class__ = type(
+            "xFuserLingBotVideoTransformer3DWrapper",
+            (xFuserLingBotVideoTransformer3DWrapper, LingBotVideoTransformer3DModel),
+            {},
+        )
+        model._install_usp_attention = cls._install_usp_attention.__get__(model)
+        model.prepare_for_compile = cls.prepare_for_compile.__get__(model)
+        model._install_usp_attention()
+        model._usp_attention_installed = True
+        return model
+
+    def prepare_for_compile(self, height, width, num_frames, vae_scale_temporal=4, vae_scale_spatial=8):
+        """Pre-build RoPE table and patch forward to skip the rebuild check.
+
+        Must be called before torch.compile to eliminate graph breaks from
+        the data-dependent rebuild logic in LingBotVideoRotaryEmbedding.
+        """
+        _, _, make_joint_position_ids_fn, _ = get_lingbot_video_classes()
+        pF, pH, pW = self.config.patch_size
+        gt = ((num_frames - 1) // vae_scale_temporal + 1) // pF
+        gh = (height // vae_scale_spatial) // pH
+        gw = (width // vae_scale_spatial) // pW
+        max_text_len = 512
+        device = next(self.parameters()).device
+        pos_ids = make_joint_position_ids_fn(max_text_len, gt, gh, gw, device)
+        self.rope(pos_ids)
+        self.rope._original_forward = self.rope.forward
+        self.rope.forward = lambda pos_ids, _r=self.rope: _rope_forward_no_rebuild(_r, pos_ids)
+        # Patch MoE _reorder_tokens to avoid dynamic-shape torch.where graph breaks
+        from lingbot_video.transformer_lingbot_video import LingBotVideoSparseMoeBlock
+        for block in self.blocks:
+            if isinstance(block.ffn, LingBotVideoSparseMoeBlock):
+                block.ffn._reorder_tokens = staticmethod(_reorder_tokens_compile_friendly)
+        self._compile_friendly_forward = True
+
+    def cache_expert_weights(self):
+        """Pre-transpose expert weights to eliminate per-call .bfloat16().transpose() copies.
+
+        The stock _run_grouped_experts calls w1.bfloat16().transpose(-2,-1) on every
+        forward — 6 weight copies per block × 48 layers × 48 steps = 5.6TB of memcpy.
+        """
+        from lingbot_video.transformer_lingbot_video import LingBotVideoSparseMoeBlock
+
+        for block in self.blocks:
+            if not isinstance(block.ffn, LingBotVideoSparseMoeBlock):
+                continue
+            experts = block.ffn.experts
+            # Pre-transpose: [E, I, H] -> [E, H, I] (contiguous), replace originals
+            w1T = experts.w1.data.bfloat16().transpose(-2, -1).contiguous()
+            w3T = experts.w3.data.bfloat16().transpose(-2, -1).contiguous()
+            w2T = experts.w2.data.bfloat16().transpose(-2, -1).contiguous()
+            # Replace original weights with transposed versions to free memory
+            experts.w1 = torch.nn.Parameter(w1T, requires_grad=False)
+            experts.w3 = torch.nn.Parameter(w3T, requires_grad=False)
+            experts.w2 = torch.nn.Parameter(w2T, requires_grad=False)
+
+            # Patch _run_grouped_experts to skip .bfloat16().transpose() since weights are pre-transposed
+            def _make_fast(moe_block):
+                e = moe_block.experts
+                def _fast(self_moe, tokens, counts):
+                    import torch.nn.functional as F
+                    input_shape, padded_tokens, permuted_indices, aligned_counts = self_moe._pad_grouped_tokens(tokens, counts)
+                    offsets = torch.cumsum(aligned_counts, dim=0, dtype=torch.int32)
+                    h = F.silu(torch._grouped_mm(padded_tokens.bfloat16(), e.w1, offs=offsets))
+                    h = h * torch._grouped_mm(padded_tokens.bfloat16(), e.w3, offs=offsets)
+                    out = torch._grouped_mm(h, e.w2, offs=offsets).type_as(padded_tokens)
+                    return self_moe._unpad_grouped_tokens(out, input_shape, permuted_indices)
+                return _fast
+            block.ffn._run_grouped_experts = _make_fast(block.ffn).__get__(block.ffn)
+
+    def _install_usp_attention(self):
+        for block in self.blocks:
+            block.attn._original_forward = block.attn.forward
+            block.attn.forward = lambda *args, _attn=block.attn, **kw: _usp_attention_forward(_attn, *args, **kw)
+
+    def _chunk_and_pad_sequence(self, x, sp_world_rank, sp_world_size, pad_amount, dim):
+        if pad_amount > 0:
+            if dim < 0:
+                dim = x.ndim + dim
+            pad_shape = list(x.shape)
+            pad_shape[dim] = pad_amount
+            x = torch.cat([x, torch.zeros(pad_shape, dtype=x.dtype, device=x.device)], dim=dim)
+        x = torch.chunk(x, sp_world_size, dim=dim)[sp_world_rank]
+        return x
+
+    def _gather_and_unpad(self, x, pad_amount, dim):
+        x = get_sp_group().all_gather(x, dim=dim)
+        size = x.size(dim)
+        return x.narrow(dim=dim, start=0, length=size - pad_amount)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        timestep: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        encoder_attention_mask: Optional[torch.Tensor] = None,
+        return_dict: bool = True,
+    ):
+        sp_world_size = get_sequence_parallel_world_size()
+        get_runtime_state().increment_step_counter()
+
+        if sp_world_size <= 1:
+            LingBotVideoTransformer3DModel = get_lingbot_video_classes()[0]
+            return LingBotVideoTransformer3DModel.forward(
+                self, hidden_states, timestep, encoder_hidden_states,
+                encoder_attention_mask, return_dict,
+            )
+
+        _, _, make_joint_position_ids_fn, _ = get_lingbot_video_classes()
+
+        sp_world_rank = get_sequence_parallel_rank()
+
+        B, C, T, H, W = hidden_states.shape
+        pF, pH, pW = self.config.patch_size
+        gt, gh, gw = T // pF, H // pH, W // pW
+        n_video = gt * gh * gw
+        L = encoder_hidden_states.shape[1]
+        device = hidden_states.device
+
+        # For compile-friendliness, use L directly as text_len (pipeline already
+        # strips padding for B=1). Avoids .tolist() / .item() graph breaks.
+        text_lens_list = [L] * B
+
+        # Patchify
+        patch_tokens = hidden_states.reshape(B, C, gt, pF, gh, pH, gw, pW)
+        patch_tokens = patch_tokens.permute(0, 2, 4, 6, 3, 5, 7, 1).reshape(B, n_video, pF * pH * pW * C)
+        x = self.patch_embedder(patch_tokens)
+
+        # Text embedding and concatenation
+        text = self.text_embedder(encoder_hidden_states)
+        joint = torch.cat([x, text], dim=1)  # [video; text]
+        joint_seq_len = joint.shape[1]
+
+        # RoPE
+        pos_ids = make_joint_position_ids_fn(L, gt, gh, gw, device)
+        rotary = self.rope(pos_ids).unsqueeze(0)
+        if B > 1:
+            rotary = rotary.expand(B, -1, -1)
+
+        # SP chunking — chunk BEFORE computing temb6 to avoid full-seq allocations
+        pad_amount = (sp_world_size - (joint_seq_len % sp_world_size)) % sp_world_size
+        joint = self._chunk_and_pad_sequence(joint, sp_world_rank, sp_world_size, pad_amount, dim=1)
+        rotary = self._chunk_and_pad_sequence(rotary, sp_world_rank, sp_world_size, pad_amount, dim=1)
+        local_seq_len = joint.shape[1]
+        del x, text, patch_tokens
+
+        # Timestep embedding — compute t_emb once, expand to local chunk only
+        timestep_for_embed = timestep.float()
+        timestep_proj = self.time_proj(timestep_for_embed)
+        t_emb = self.time_embedder(timestep_proj)
+        temb_input = t_emb.unsqueeze(1).expand(B, local_seq_len, -1)
+        temb6 = self.time_modulation(temb_input.reshape(B * local_seq_len, -1))
+        temb6 = temb6.reshape(B, local_seq_len, -1)
+
+        temb6_flat = temb6.reshape(temb6.shape[0] * temb6.shape[1], -1)
+
+        # Transformer blocks
+        for block in self.blocks:
+            joint = block(joint, temb6_flat, rotary, None, None)
+
+        # Output norm + projection
+        final_mod = self.norm_out_modulation(temb_input.reshape(joint.shape[0] * joint.shape[1], -1))
+        shift, scale = final_mod.reshape(joint.shape[0], joint.shape[1], -1).chunk(2, dim=-1)
+        final_hidden = self.norm_out(joint) * (1.0 + scale) + shift
+        projected = self.proj_out(final_hidden.to(self.proj_out.weight.dtype))
+
+        # Gather across SP ranks
+        if sp_world_size > 1:
+            projected = self._gather_and_unpad(projected, pad_amount, dim=1)
+
+        # Extract video tokens only
+        x_out = projected[:, :n_video]
+
+        # Unpatchify
+        Cout = self.config.out_channels
+        x_out = x_out.reshape(B, gt, gh, gw, pF, pH, pW, Cout)
+        x_out = x_out.permute(0, 7, 1, 4, 2, 5, 3, 6).reshape(B, Cout, T, H, W)
+
+        if not return_dict:
+            return (x_out,)
+        return Transformer2DModelOutput(sample=x_out)

--- a/xfuser/model_executor/pipelines/pipeline_lingbot_video.py
+++ b/xfuser/model_executor/pipelines/pipeline_lingbot_video.py
@@ -1,0 +1,227 @@
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import torch
+
+from xfuser.core.distributed import (
+    get_classifier_free_guidance_rank,
+    get_classifier_free_guidance_world_size,
+    get_cfg_group,
+)
+
+
+def get_lingbot_video_pipeline_class():
+    from lingbot_video.pipeline_lingbot_video import LingBotVideoPipeline
+    return LingBotVideoPipeline
+
+
+class xFuserLingBotVideoPipeline:
+    """Wrapper that adds xDiT's CFG parallelism to LingBotVideoPipeline.
+
+    Uses xDiT's distributed infrastructure (get_cfg_group, etc.) instead of
+    the built-in cfg_parallel_group parameter.
+    """
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+        LingBotVideoPipeline = get_lingbot_video_pipeline_class()
+        kwargs.setdefault("trust_remote_code", True)
+        pipe = LingBotVideoPipeline.from_pretrained(
+            pretrained_model_name_or_path, **kwargs
+        )
+        pipe.__class__ = type(
+            "xFuserLingBotVideoPipeline",
+            (xFuserLingBotVideoPipeline, LingBotVideoPipeline),
+            {},
+        )
+        return pipe
+
+    @torch.no_grad()
+    def __call__(
+        self,
+        prompt: Union[str, List[str]] = "",
+        negative_prompt: Union[str, List[str]] = "",
+        height: int = 480,
+        width: int = 832,
+        num_frames: int = 81,
+        num_inference_steps: int = 40,
+        guidance_scale: float = 3.0,
+        shift: float = 3.0,
+        generator: Optional[Union[torch.Generator, List[torch.Generator]]] = None,
+        latents: Optional[torch.Tensor] = None,
+        prompt_embeds: Optional[torch.Tensor] = None,
+        prompt_mask: Optional[torch.Tensor] = None,
+        negative_prompt_embeds: Optional[torch.Tensor] = None,
+        negative_prompt_mask: Optional[torch.Tensor] = None,
+        output_type: str = "np",
+        return_dict: bool = True,
+        **kwargs,
+    ):
+        cfg_rank = get_classifier_free_guidance_rank()
+        do_cfg_parallel = guidance_scale > 1.0 and get_classifier_free_guidance_world_size() == 2
+
+        if do_cfg_parallel and "image" not in kwargs:
+            # T2V CFG parallel: custom path with xDiT's all_gather
+            return self._call_with_xdit_cfg_parallel(
+                prompt=prompt,
+                negative_prompt=negative_prompt,
+                height=height,
+                width=width,
+                num_frames=num_frames,
+                num_inference_steps=num_inference_steps,
+                guidance_scale=guidance_scale,
+                shift=shift,
+                generator=generator,
+                latents=latents,
+                prompt_embeds=prompt_embeds,
+                prompt_mask=prompt_mask,
+                negative_prompt_embeds=negative_prompt_embeds,
+                negative_prompt_mask=negative_prompt_mask,
+                output_type=output_type,
+                return_dict=return_dict,
+                **kwargs,
+            )
+        else:
+            # Delegate to the stock pipeline (T2V or TI2V).
+            stock_bases = [b for b in type(self).__mro__
+                          if b not in (xFuserLingBotVideoPipeline, type(self))
+                          and hasattr(b, "__call__")
+                          and "__call__" in b.__dict__]
+            parent_cls = stock_bases[0] if stock_bases else get_lingbot_video_pipeline_class()
+            return parent_cls.__call__(
+                self,
+                prompt=prompt,
+                negative_prompt=negative_prompt,
+                height=height,
+                width=width,
+                num_frames=num_frames,
+                num_inference_steps=num_inference_steps,
+                guidance_scale=guidance_scale,
+                shift=shift,
+                generator=generator,
+                latents=latents,
+                prompt_embeds=prompt_embeds,
+                prompt_mask=prompt_mask,
+                negative_prompt_embeds=negative_prompt_embeds,
+                negative_prompt_mask=negative_prompt_mask,
+                output_type=output_type,
+                return_dict=return_dict,
+                **kwargs,
+            )
+
+    def _call_with_xdit_cfg_parallel(
+        self,
+        prompt,
+        negative_prompt,
+        height,
+        width,
+        num_frames,
+        num_inference_steps,
+        guidance_scale,
+        shift,
+        generator,
+        latents,
+        prompt_embeds,
+        prompt_mask,
+        negative_prompt_embeds,
+        negative_prompt_mask,
+        output_type,
+        return_dict,
+        **kwargs,
+    ):
+        from lingbot_video.pipeline_lingbot_video import (
+            LingBotVideoPipelineOutput,
+            _transformer_timestep,
+            _transformer_autocast,
+            _module_dtype,
+        )
+        from lingbot_video.utils import compute_refiner_sigmas
+
+        self.check_inputs(height, width, num_frames)
+        device = self._execution_device
+        cfg_rank = get_classifier_free_guidance_rank()
+
+        # TI2V: preprocess image for VLM text encoder (both ranks need it)
+        encode_kwargs = {}
+        image = kwargs.get("image")
+        if image is not None and hasattr(self, "_vlm_image"):
+            pixel = self.preprocess_image(image, height, width)
+            pixel = pixel.to(device=device, dtype=torch.float32)
+            encode_kwargs["images"] = [self._vlm_image(pixel)]
+
+        # Encode prompts per-rank: rank 0 = conditional, rank 1 = unconditional
+        if cfg_rank == 0:
+            if prompt_embeds is None:
+                prompt_embeds, prompt_mask = self.encode_prompt(
+                    prompt, device=device, **encode_kwargs)
+            local_embeds = prompt_embeds.to(device)
+            local_mask = prompt_mask.to(device)
+        else:
+            if negative_prompt_embeds is None:
+                negative_prompt_embeds, negative_prompt_mask = self.encode_prompt(
+                    negative_prompt, device=device, **encode_kwargs)
+            local_embeds = negative_prompt_embeds.to(device)
+            local_mask = negative_prompt_mask.to(device)
+
+        latents = self.prepare_latents(num_frames, height, width, generator, latents, device)
+
+        # TI2V: encode first frame and inject into latents
+        if image is not None and hasattr(self, "encode_image_latent"):
+            cond_latent = self.encode_image_latent(pixel, generator=generator)
+            cond_latent = cond_latent.to(device=device, dtype=torch.float32)
+            latents = self._apply_inpainting(latents, cond_latent)
+        else:
+            cond_latent = None
+
+        t_thresh = kwargs.get("t_thresh", None)
+        refiner_sigma_tail_steps = kwargs.get("refiner_sigma_tail_steps", None)
+        sigmas = compute_refiner_sigmas(
+            sigma_max=float(self.scheduler.sigma_max),
+            sigma_min=float(self.scheduler.sigma_min),
+            num_inference_steps=num_inference_steps,
+            shift=shift,
+            t_thresh=t_thresh,
+            tail_steps=refiner_sigma_tail_steps,
+        )
+        if sigmas is None:
+            self.scheduler.set_timesteps(num_inference_steps, device=device, shift=shift)
+        else:
+            self.scheduler.set_timesteps(int(sigmas.shape[0]), device=device, sigmas=sigmas, shift=1.0)
+
+        transformer_dtype = _module_dtype(self.transformer)
+
+        for i, timestep in enumerate(self.progress_bar(self.scheduler.timesteps)):
+            timestep_batch = _transformer_timestep(timestep, transformer_dtype).expand(1).to(device)
+            local_model_input = local_embeds.to(transformer_dtype)
+
+            with _transformer_autocast(device, transformer_dtype):
+                noise_pred = self.transformer(
+                    latents,
+                    timestep_batch,
+                    local_model_input,
+                    encoder_attention_mask=local_mask,
+                    return_dict=False,
+                )[0].float()
+
+            # All-gather across CFG ranks: rank 0 = cond, rank 1 = uncond
+            noise_pred_cond, noise_pred_uncond = get_cfg_group().all_gather(
+                noise_pred, separate_tensors=True
+            )
+            noise_pred = noise_pred_uncond + guidance_scale * (noise_pred_cond - noise_pred_uncond)
+
+            latents = self.scheduler.step(
+                noise_pred, timestep, latents, return_dict=False, generator=generator
+            )[0]
+            if cond_latent is not None:
+                latents = self._apply_inpainting(latents, cond_latent)
+
+        if output_type == "latent":
+            frames = latents
+        elif output_type == "np":
+            frames = self._decode_latents(latents)
+        else:
+            raise ValueError(f"Unsupported output_type: {output_type}")
+
+        self.maybe_free_model_hooks()
+        if not return_dict:
+            return (frames,)
+        return LingBotVideoPipelineOutput(frames=frames)

--- a/xfuser/model_executor/pipelines/pipeline_lingbot_video.py
+++ b/xfuser/model_executor/pipelines/pipeline_lingbot_video.py
@@ -59,8 +59,8 @@ class xFuserLingBotVideoPipeline:
         cfg_rank = get_classifier_free_guidance_rank()
         do_cfg_parallel = guidance_scale > 1.0 and get_classifier_free_guidance_world_size() == 2
 
-        if do_cfg_parallel and "image" not in kwargs:
-            # T2V CFG parallel: custom path with xDiT's all_gather
+        if do_cfg_parallel:
+            # CFG parallel: custom path with xDiT's all_gather (T2V and TI2V)
             return self._call_with_xdit_cfg_parallel(
                 prompt=prompt,
                 negative_prompt=negative_prompt,


### PR DESCRIPTION
# Add LingBot-Video Support (MoE 30B + Dense 1.3B)

## Summary

Adds xDiT support for [LingBot-Video](https://github.com/Robbyant/lingbot-video), a Mixture-of-Experts video generation model (30B total / 3B active per token) for embodied intelligence. Supports both the MoE 30B and Dense 1.3B variants with T2V, TI2V, and refiner pipelines.

**Requires:** `pip install lingbot-video` (model not in diffusers, ships as standalone package)

## Features

- **Parallelism:** USP (Ulysses) u=2/4/8, CFG parallel, FSDP, parallel VAE
- **Quantization:** FP8 attention (AITER), FP8/FP4 GEMMs (torchao), hybrid attention schedule
- **torch.compile:** Zero graph breaks on both Dense and MoE models (2.13x over eager)
- **Modes:** T2V (`--prompt`), TI2V (`--input_images`), refiner (`--task refine`)
- **JSON prompts:** `--prompt path/to/prompt.json`; model requires structured JSON captions

## Usage

LingBot-Video requires structured JSON captions, not plain text prompts. The JSON
contains scene descriptions, camera info, and per-element actions with timestamps:

```json
{
  "caption": {
    "comprehensive_description": {
      "scene_content_description": "A young child is outdoors on a sunny day, playing with bubbles...",
      "camera_movement_description": "The camera is stationary, medium close-up, eye level..."
    },
    "camera_info": {
      "color": "Saturated", "frame_size": "Medium Close Up",
      "shot_type_angle": "Low angle", "lens_size": "Long Lens",
      "composition": "Center", "lighting": "Hard light", "lighting_type": "Daylight"
    },
    "prominent_elements": [
      {
        "name": "young child",
        "description": "A child with short brown hair wearing a colorful striped shirt",
        "actions": [
          {"timestamp": "[0.0s - 2.0s]", "action": "holds bubble wand and blows gently"},
          {"timestamp": "[2.0s - 5.0s]", "action": "waves the wand through the air"}
        ]
      }
    ]
  },
  "duration": 5
}
```

Use the [prompt rewriter](https://github.com/Robbyant/lingbot-video/tree/master/rewriter) to convert natural language to this format, or use the example prompts from `assets/cases/`.

```bash
# Dense 1.3B, single GPU
python -m xfuser.cli --model robbyant/lingbot-video-dense-1.3b \
  --prompt prompt.json --height 480 --width 832 --num_frames 81 \
  --guidance_scale 1.0 --use_torch_compile

# MoE 30B, 8 GPU with USP + CFG + FP8 attention + parallel VAE
python -m xfuser.cli --model robbyant/lingbot-video-moe-30b-a3b \
  --prompt prompt.json --height 1088 --width 1920 --num_frames 81 \
  --guidance_scale 3.0 --use_torch_compile --attention_backend AITER_FP8 \
  --ulysses_degree 4 --use_cfg_parallel --use_parallel_vae --nproc_per_node 8

# MoE 30B with refiner (480p base → 1080p output)
python -m xfuser.cli --model robbyant/lingbot-video-moe-30b-a3b \
  --prompt prompt.json --task refine \
  --height 480 --width 832 --num_frames 81 \
  --guidance_scale 1.0 --use_torch_compile --ulysses_degree 8 --nproc_per_node 8

# TI2V (text + image → video)
python -m xfuser.cli --model robbyant/lingbot-video-moe-30b-a3b \
  --prompt prompt.json --input_images first_frame.png \
  --height 480 --width 832 --num_frames 81 --guidance_scale 1.0 --use_torch_compile

# Refiner at 2K (--height/--width is the output resolution)
python -m xfuser.cli ... --task refine --height 1440 --width 2560
```



https://github.com/user-attachments/assets/24b8b688-8b1d-4fd2-9403-e498b035247d

https://github.com/user-attachments/assets/eeabdff4-16b2-40a6-a5b5-216fedf13419



## Performance (MoE 30B, torch.compile, MI355X, 81 frames / 3.4s at 24fps)

### 480p Base (832×480, guidance_scale=1.0, 40 steps)

| Config | GPUs | Time | Speedup |
|--------|:----:|:----:|:-------:|
| BF16 | 1 | 44.0s | 1.00x |
| FP8 attn | 1 | 34.9s | 1.26x |
| FP8 attn + FP4 GEMMs | 1 | 34.2s | 1.29x |
| BF16 + u=4 | 4 | 29.8s | 1.48x |
| FP8 attn + FP4 + u=4 + pvae | 4 | 18.5s | 2.38x |
| BF16 + u=8 + pvae | 8 | **18.1s** | **2.43x** |

### 1080p Native (1920×1088, guidance_scale=3.0, 40 steps, 8 GPU)

| Config | Time | Speedup |
|--------|:----:|:-------:|
| BF16 + u=8 | 181.4s | 1.00x |
| BF16 + u=4+cfg=2 | 171.6s | 1.06x |
| FP8 attn + u=8 | 118.3s | 1.53x |
| FP8 attn + u=4+cfg=2 | **109.7s** | **1.65x** |

### T2V 1080p Refiner (480p→1080p, 40+8 steps, compiled)

| Config | GPUs | Time | Speedup |
|--------|:----:|:----:|:-------:|
| BF16 | 1 | 358.5s | 1.00x |
| BF16 + u=8 | 8 | 88.0s | 4.07x |
| BF16 + u=8 + pvae | 8 | 67.4s | 5.32x |
| FP8 attn + u=8 + pvae | 8 | 53.1s | 6.75x |
| FP8 attn + u=4+cfg=2 + pvae | 8 | **50.0s** | **7.17x** |

### TI2V 1080p Refiner (480p→1080p, 40+8 steps, compiled)

| Config | GPUs | Time | Speedup |
|--------|:----:|:----:|:-------:|
| BF16 | 1 | 359.7s | 1.00x |
| BF16 + u=8 | 8 | 87.0s | 4.13x |
| FP8 attn + u=8 + pvae | 8 | 53.0s | 6.79x |
| FP8 attn + u=4+cfg=2 + pvae | 8 | **49.9s** | **7.21x** |

## Architecture Notes

LingBot-Video differs from Wan 2.1:
- **Standalone model** — `LingBotVideoTransformer3DModel` is not a subclass of `WanTransformer3DModel`
- **Self-attention only** — text embeddings concatenated with video tokens before layer loop, no cross-attention
- **MoE FFN** — 128 experts, top-8 routing, `torch._grouped_mm` backend
- **Custom scheduler** — vendored `FlowUniPCMultistepScheduler` (not in diffusers)
- **Refiner** — separate 48-layer MoE transformer for upscaling (480p base → 1080p/2K target)

### Implementation approach
- Transformer wrapper with USP attention installed at load time. 
- Custom forward that chunks sequence before temb6 computation to avoid full-sequence memory allocations at high resolution
- Pipeline wrapper with MRO-based parent class dispatch for T2V/TI2V compatibility
- Manual component loading (bypasses diffusers `model_index.json` custom class resolution)
- FSDP via LingBot's native `apply_fsdp_inference` with `ignored_params` for mixed FP32/BF16
- Parallel VAE via distvae `WanDecoderAdapter`
- Pre-transposed expert weights to eliminate per-call `.bfloat16().transpose()` copies

### torch.compile fixes (zero graph breaks)
1. **RoPE lazy rebuild:** patched `forward()` to skip data-dependent `max_vals >= axes_lens` check
2. **`bool(tensor)` padding check:** compile-friendly forward avoids `has_padding` branch
3. **MoE `_reorder_tokens`:** replaced `torch.where(flat_scores != 0)` (dynamic shape) with static `argsort`
4. **Pre-transposed expert weights:** replace `w1/w3/w2` in-place with transposed copies, bound method patch on `_run_grouped_experts`


## Known Limitations

- FP8/FP4 GEMMs (torchao) only quantize attention linears, not MoE expert weights. `torch._grouped_mm` does not support FP8 dtype
