### PR TITLE
[model] Add Ideogram 4 support through Diffusers

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ The following open-sourced DiT Models are released with xDiT in day 1.
 | [🟢 Qwen Image-Edit](https://huggingface.co/Qwen/Qwen-Image-Edit-2511) | ❎ | ✔️ | ❎ | ❎ | ✔️ | NA |
 | [🟢 Krea2-Raw](https://huggingface.co/krea/Krea-2-Raw) | ❎ | ✔️ | ❎ | ❎ | ✔️ | NA |
 | [🟢 Krea2-Turbo](https://huggingface.co/krea/Krea-2-Turbo) | ❎ | ✔️ | ❎ | ❎ | ✔️ | NA |
+| [🟢 Ideogram 4](https://huggingface.co/ideogram-ai/ideogram-4-fp8) | ✔️ | ✔️ | ❎ | ❎ | ✔️ | NA |
 | [🔴 PixArt-Sigma](https://huggingface.co/PixArt-alpha/PixArt-Sigma-XL-2-1024-MS) | ✔️ | ✔️ | ✔️ | ❎ | ❎ | [Report](./docs/performance/pixart_alpha_legacy.md) |
 | [🟢 PixArt-alpha](https://huggingface.co/PixArt-alpha/PixArt-alpha) | ✔️ | ✔️ | ✔️ | ❎ | ❎ | [Report](./docs/performance/pixart_alpha_legacy.md) |
 | [🟠 Stable Diffusion 3](https://huggingface.co/stabilityai/stable-diffusion-3-medium-diffusers) | ✔️ | ✔️ | ✔️ | ❎ | ✔️ | [Report](./docs/performance/sd3.md) |
@@ -313,6 +314,7 @@ Below is a list of validated diffusers version requirements. If the model is not
 | [HunyuanVideo-1.5](https://github.com/Tencent-Hunyuan/HunyuanVideo-1.5) | >= 0.36.0 |
 | [Z-Image Turbo](https://huggingface.co/Tongyi-MAI/Z-Image-Turbo) | >= 0.36.0 |
 | [Flux 2](https://huggingface.co/black-forest-labs/FLUX.2-dev) | >= 0.36.0 |
+| [Ideogram 4](https://huggingface.co/ideogram-ai/ideogram-4-fp8) | >= 0.39.0 |
 | [Flux](https://huggingface.co/black-forest-labs/FLUX.1-dev) | >= 0.35.2 |
 | [Flux Kontext](https://huggingface.co/black-forest-labs/FLUX.1-Kontext-dev) | >= 0.35.2 |
 | [HunyuanVideo](https://github.com/Tencent/HunyuanVideo) | >= 0.35.2 |

--- a/docs/runner/runner.md
+++ b/docs/runner/runner.md
@@ -102,6 +102,7 @@ Individual model classes that inherit from `xFuserModel`:
 | Qwen-Image-Edit | `Qwen-Image-Edit`, `Qwen/Qwen-Image-Edit`, `Qwen-Image-Edit-2509`, `Qwen/Qwen-Image-Edit-2509`, `Qwen-Image-Edit-2511`, `Qwen/Qwen-Image-Edit-2511` |
 | Krea2-Raw | `krea/krea-2-raw`, `krea/Krea-2-Raw`, `Krea-2-Raw` |
 | Krea2-Turbo | `krea/krea-2-turbo`, `krea/Krea-2-Turbo`, `Krea-2-Turbo` |
+| Ideogram 4 | `Ideogram-4`, `ideogram-ai/ideogram-v4`, `ideogram-ai/ideogram-4-nf4`, `ideogram-ai/ideogram-4-fp8` |
 
 
 

--- a/tests/test_ideogram4_fp8_attention.py
+++ b/tests/test_ideogram4_fp8_attention.py
@@ -1,0 +1,116 @@
+import inspect
+from pathlib import Path
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+
+def _require_gfx950_aiter():
+    if not torch.cuda.is_available() or torch.version.hip is None:
+        pytest.skip("AITER FP8 attention requires a ROCm GPU.")
+
+    arch_name = getattr(torch.cuda.get_device_properties(0), "gcnArchName", "")
+    if "gfx950" not in arch_name:
+        pytest.skip(
+            f"Ideogram 4 HD256 FP8 validation requires gfx950, got {arch_name}."
+        )
+
+    try:
+        import aiter
+    except ImportError:
+        pytest.skip("AITER is not installed.")
+
+    fp8_attention = getattr(aiter, "flash_attn_fp8_pertensor_func", None)
+    if fp8_attention is None:
+        pytest.skip("AITER does not expose flash_attn_fp8_pertensor_func.")
+
+    parameters = inspect.signature(fp8_attention).parameters
+    required_descales = {"q_descale", "k_descale", "v_descale"}
+    if not required_descales.issubset(parameters):
+        pytest.skip("AITER FP8 attention does not expose the per-tensor descale ABI.")
+
+    aiter_root = Path(aiter.__file__).resolve().parent.parent
+    hd256_kernel = (
+        aiter_root
+        / "hsa"
+        / "gfx950"
+        / "fmha_v3_fwd"
+        / "fwd_hd256_fp8.co"
+    )
+    if not hd256_kernel.exists():
+        pytest.skip(
+            "AITER does not include the gfx950 HD256 FP8 FMHA kernel from PR 3732."
+        )
+
+
+@pytest.mark.parametrize("sequence_length", [256, 1024])
+def test_ideogram4_aiter_fp8_attention_hd256(sequence_length):
+    _require_gfx950_aiter()
+
+    from xfuser.core.distributed.attention_backend import _aiter_fp8_attn_call
+
+    torch.manual_seed(1234)
+    device = torch.device("cuda")
+    shape = (1, 18, sequence_length, 256)
+    query = torch.randn(shape, device=device, dtype=torch.bfloat16)
+    key = torch.randn(shape, device=device, dtype=torch.bfloat16)
+    value = torch.randn(shape, device=device, dtype=torch.bfloat16)
+
+    with torch.no_grad():
+        reference = F.scaled_dot_product_attention(query, key, value)
+        output, _ = _aiter_fp8_attn_call(
+            query,
+            key,
+            value,
+            dropout_p=0.0,
+            is_causal=False,
+        )
+
+    output_float = output.float()
+    reference_float = reference.float()
+    relative_l2 = (
+        torch.linalg.vector_norm(output_float - reference_float)
+        / torch.linalg.vector_norm(reference_float)
+    ).item()
+    cosine_similarity = F.cosine_similarity(
+        output_float.flatten(),
+        reference_float.flatten(),
+        dim=0,
+    ).item()
+    print(
+        f"sequence_length={sequence_length} "
+        f"relative_l2={relative_l2:.6f} "
+        f"cosine_similarity={cosine_similarity:.6f}"
+    )
+
+    assert output.shape == reference.shape
+    assert torch.isfinite(output).all()
+    assert relative_l2 < 0.08
+    assert cosine_similarity > 0.995
+
+
+def test_ideogram4_aiter_fp8_attention_hd256_compiles_fullgraph():
+    _require_gfx950_aiter()
+
+    from xfuser.core.distributed.attention_backend import _aiter_fp8_attn_call
+
+    torch.manual_seed(1234)
+    shape = (1, 18, 256, 256)
+    query = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
+    key = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
+    value = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
+
+    def attention(query, key, value):
+        return _aiter_fp8_attn_call(
+            query,
+            key,
+            value,
+            dropout_p=0.0,
+            is_causal=False,
+        )[0]
+
+    compiled_attention = torch.compile(attention, fullgraph=True)
+    output = compiled_attention(query, key, value)
+    assert output.shape == query.shape
+    assert torch.isfinite(output).all()

--- a/tests/test_ideogram4_pipeline.py
+++ b/tests/test_ideogram4_pipeline.py
@@ -1,0 +1,25 @@
+from types import SimpleNamespace
+
+import torch
+
+from xfuser.model_executor.pipelines.pipeline_ideogram4 import (
+    _broadcast_object_in_group,
+)
+
+
+def test_ideogram4_broadcast_object_uses_cpu_subgroup(monkeypatch):
+    cpu_group = object()
+    coordinator = SimpleNamespace(first_rank=3, cpu_group=cpu_group)
+
+    def fake_broadcast(payload, src, group):
+        assert src == 3
+        assert group is cpu_group
+        payload[0] = ["broadcast caption"]
+
+    monkeypatch.setattr(
+        torch.distributed,
+        "broadcast_object_list",
+        fake_broadcast,
+    )
+
+    assert _broadcast_object_in_group(None, coordinator) == ["broadcast caption"]

--- a/xfuser/model_executor/models/runner_models/ideogram4.py
+++ b/xfuser/model_executor/models/runner_models/ideogram4.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+import json
+import os
+
+import torch
+from diffusers.pipelines.pipeline_utils import DiffusionPipeline
+
+from xfuser.core.distributed.parallel_state import get_vae_parallel_group
+from xfuser.core.utils.runner_utils import log
+from xfuser.model_executor.models.runner_models.base_model import (
+    DefaultInputValues,
+    DiffusionOutput,
+    ModelCapabilities,
+    ModelSettings,
+    register_model,
+    xFuserModel,
+)
+from xfuser.model_executor.models.transformers.transformer_ideogram4 import (
+    get_ideogram4_transformer_wrapper_class,
+)
+from xfuser.model_executor.pipelines.pipeline_ideogram4 import (
+    get_ideogram4_pipeline_class,
+)
+
+
+FP8_WEIGHT_DTYPE = torch.float8_e4m3fn
+FP8_SCALE_SUFFIX = ".weight_scale"
+
+
+def _resolve_pretrained_file(model_id: str, filename: str) -> str:
+    if os.path.isdir(model_id):
+        path = os.path.join(model_id, filename)
+        if not os.path.exists(path):
+            raise FileNotFoundError(path)
+        return path
+
+    from huggingface_hub import hf_hub_download
+
+    return hf_hub_download(repo_id=model_id, filename=filename)
+
+
+def _load_sharded_safetensors(
+    model_id: str,
+    subfolder: str,
+    basename: str = "diffusion_pytorch_model",
+) -> dict[str, torch.Tensor]:
+    from huggingface_hub.errors import EntryNotFoundError
+    from safetensors.torch import load_file
+
+    index_filename = f"{subfolder}/{basename}.safetensors.index.json"
+    try:
+        index_path = _resolve_pretrained_file(model_id, index_filename)
+    except (EntryNotFoundError, FileNotFoundError):
+        model_path = _resolve_pretrained_file(
+            model_id,
+            f"{subfolder}/{basename}.safetensors",
+        )
+        return load_file(model_path, device="cpu")
+
+    with open(index_path) as index_file:
+        weight_map = json.load(index_file)["weight_map"]
+
+    state_dict = {}
+    for shard_filename in sorted(set(weight_map.values())):
+        shard_path = _resolve_pretrained_file(
+            model_id,
+            f"{subfolder}/{shard_filename}",
+        )
+        state_dict.update(load_file(shard_path, device="cpu"))
+    return state_dict
+
+
+def _is_fp8_checkpoint(model_id: str) -> bool:
+    try:
+        config_path = _resolve_pretrained_file(
+            model_id,
+            "text_encoder/config.json",
+        )
+        with open(config_path) as config_file:
+            config = json.load(config_file)
+        if config.get("ideogram_fp8_weight_only", False):
+            return True
+    except Exception:
+        pass
+
+    try:
+        index_path = _resolve_pretrained_file(
+            model_id,
+            "transformer/diffusion_pytorch_model.safetensors.index.json",
+        )
+        with open(index_path) as index_file:
+            keys = json.load(index_file)["weight_map"]
+        return any(key.endswith(FP8_SCALE_SUFFIX) for key in keys)
+    except Exception:
+        return False
+
+
+def _convert_ideogram_fp8_transformer_keys(
+    state_dict: dict[str, torch.Tensor],
+) -> dict[str, torch.Tensor]:
+    converted = {}
+    for key, tensor in state_dict.items():
+        if key.endswith(".attention.qkv.weight_scale"):
+            base = key.removesuffix(".attention.qkv.weight_scale")
+            query, key_scale, value = tensor.chunk(3, dim=0)
+            converted[f"{base}.attention.to_q{FP8_SCALE_SUFFIX}"] = query
+            converted[f"{base}.attention.to_k{FP8_SCALE_SUFFIX}"] = key_scale
+            converted[f"{base}.attention.to_v{FP8_SCALE_SUFFIX}"] = value
+        elif key.endswith(".attention.qkv.weight"):
+            base = key.removesuffix(".attention.qkv.weight")
+            query, key_weight, value = tensor.chunk(3, dim=0)
+            converted[f"{base}.attention.to_q.weight"] = query
+            converted[f"{base}.attention.to_k.weight"] = key_weight
+            converted[f"{base}.attention.to_v.weight"] = value
+        elif key.endswith(".attention.o.weight_scale"):
+            converted[
+                key.replace(
+                    ".attention.o.weight_scale",
+                    ".attention.to_out.0.weight_scale",
+                )
+            ] = tensor
+        elif key.endswith(".attention.o.weight"):
+            converted[
+                key.replace(
+                    ".attention.o.weight",
+                    ".attention.to_out.0.weight",
+                )
+            ] = tensor
+        else:
+            converted[key] = tensor
+    return converted
+
+
+def _dequantize_fp8_state_dict(
+    state_dict: dict[str, torch.Tensor],
+    dtype: torch.dtype = torch.bfloat16,
+) -> dict[str, torch.Tensor]:
+    result = {}
+    for key, tensor in state_dict.items():
+        if key.endswith(FP8_SCALE_SUFFIX):
+            continue
+
+        scale_key = f"{key}_scale"
+        if tensor.dtype == FP8_WEIGHT_DTYPE and scale_key in state_dict:
+            scale = state_dict[scale_key].to(torch.float32)
+            result[key] = (tensor.to(torch.float32) * scale.unsqueeze(-1)).to(dtype)
+        elif tensor.is_floating_point():
+            result[key] = tensor.to(dtype)
+        else:
+            result[key] = tensor
+    return result
+
+
+def _check_load_result(
+    component_name: str,
+    missing_keys: list[str],
+    unexpected_keys: list[str],
+) -> None:
+    if missing_keys or unexpected_keys:
+        raise RuntimeError(
+            f"Failed to load {component_name}: "
+            f"missing keys={missing_keys[:10]}, unexpected keys={unexpected_keys[:10]}"
+        )
+
+
+def _setup_parallel_vae(vae) -> None:
+    try:
+        from distvae.modules.adapters.vae.decoder_adapters import DecoderAdapter
+
+        vae.decoder = DecoderAdapter(
+            vae.decoder,
+            vae_group=get_vae_parallel_group().device_group,
+        ).to(vae.device)
+        log("Parallel VAE decoder enabled.")
+    except ImportError:
+        log("DistVAE not available for decoder. Defaulting to single-rank.")
+    except Exception as error:
+        raise ValueError(f"Failed to patch VAE decoder: {error}") from error
+
+
+def _default_guidance_schedule(num_inference_steps: int) -> list[float]:
+    polish_steps = min(3, num_inference_steps)
+    return [7.0] * (num_inference_steps - polish_steps) + [3.0] * polish_steps
+
+
+@register_model("ideogram-ai/ideogram-v4")
+@register_model("ideogram-ai/ideogram-4-nf4")
+@register_model("ideogram-ai/ideogram-4-nf4-diffusers")
+@register_model("ideogram-ai/ideogram-4-fp8")
+@register_model("CalamitousFelicitousness/Ideogram-4-bf16-Diffusers")
+@register_model("Ideogram-4")
+class xFuserIdeogram4Model(xFuserModel):
+    min_diffusers_version = "0.39.0"
+
+    capabilities = ModelCapabilities(
+        ulysses_degree=True,
+        ring_degree=True,
+        use_cfg_parallel=True,
+        use_fp8_gemms=True,
+        use_fp4_gemms=True,
+        fully_shard_degree=True,
+        use_parallel_vae=True,
+        enable_tiling=True,
+        enable_slicing=True,
+    )
+    default_input_values = DefaultInputValues(
+        height=2048,
+        width=2048,
+        num_inference_steps=48,
+        max_sequence_length=2048,
+    )
+    settings = ModelSettings(
+        model_name="ideogram-ai/ideogram-4-fp8",
+        output_name="ideogram4",
+        model_output_type="image",
+        mod_value=16,
+        resolution_divisor=16,
+        fp8_gemm_module_list=[
+            "transformer.layers",
+            "unconditional_transformer.layers",
+        ],
+        fp4_gemm_module_list=[
+            "transformer.layers",
+            "unconditional_transformer.layers",
+        ],
+        fsdp_strategy={
+            "transformer": {"wrap_attrs": ["layers"]},
+            "unconditional_transformer": {"wrap_attrs": ["layers"]},
+        },
+    )
+
+    def _validate_config(self, config) -> None:
+        super()._validate_config(config)
+        if 18 % config.ulysses_degree != 0:
+            raise ValueError(
+                "Ideogram 4 has 18 attention heads, so --ulysses_degree must divide 18."
+            )
+
+    def _validate_args(self, input_args: dict) -> None:
+        super()._validate_args(input_args)
+        height = input_args["height"]
+        width = input_args["width"]
+        if height < 256 or width < 256:
+            raise ValueError(
+                f"Ideogram 4 requires height and width of at least 256, got {height}x{width}."
+            )
+
+    def _load_fp8_transformer(
+        self,
+        model_id: str,
+        subfolder: str,
+    ):
+        transformer_class = get_ideogram4_transformer_wrapper_class()
+        transformer = transformer_class.from_config(
+            transformer_class.load_config(model_id, subfolder=subfolder)
+        )
+        transformer._install_xfuser_processors()
+
+        state_dict = _load_sharded_safetensors(model_id, subfolder)
+        state_dict = _convert_ideogram_fp8_transformer_keys(state_dict)
+        state_dict = _dequantize_fp8_state_dict(state_dict)
+        missing_keys, unexpected_keys = transformer.load_state_dict(
+            state_dict,
+            strict=False,
+            assign=True,
+        )
+        _check_load_result(subfolder, missing_keys, unexpected_keys)
+        transformer.eval()
+        log(f"Loaded {model_id}/{subfolder} through the Ideogram FP8 converter.")
+        return transformer
+
+    def _load_fp8_text_encoder(self, model_id: str):
+        from transformers import AutoConfig, AutoModel
+
+        config = AutoConfig.from_pretrained(
+            model_id,
+            subfolder="text_encoder",
+            trust_remote_code=True,
+        )
+        text_encoder = AutoModel.from_config(config, trust_remote_code=True)
+        state_dict = _load_sharded_safetensors(
+            model_id,
+            "text_encoder",
+            basename="model",
+        )
+        state_dict = _dequantize_fp8_state_dict(state_dict)
+        missing_keys, unexpected_keys = text_encoder.load_state_dict(
+            state_dict,
+            strict=False,
+            assign=True,
+        )
+        _check_load_result("text_encoder", missing_keys, unexpected_keys)
+        text_encoder.eval()
+        log(f"Loaded {model_id}/text_encoder through the Ideogram FP8 converter.")
+        return text_encoder
+
+    def _load_model(self) -> DiffusionPipeline:
+        model_id = self.config.model
+        transformer_class = get_ideogram4_transformer_wrapper_class()
+
+        if _is_fp8_checkpoint(model_id):
+            transformer = self._load_fp8_transformer(model_id, "transformer")
+            unconditional_transformer = self._load_fp8_transformer(
+                model_id,
+                "unconditional_transformer",
+            )
+            text_encoder = self._load_fp8_text_encoder(model_id)
+        else:
+            transformer = transformer_class.from_pretrained(
+                model_id,
+                subfolder="transformer",
+                torch_dtype=torch.bfloat16,
+            )
+            unconditional_transformer = transformer_class.from_pretrained(
+                model_id,
+                subfolder="unconditional_transformer",
+                torch_dtype=torch.bfloat16,
+            )
+            text_encoder = None
+
+        pipeline_kwargs = {
+            "transformer": transformer,
+            "unconditional_transformer": unconditional_transformer,
+            "torch_dtype": torch.bfloat16,
+        }
+        if text_encoder is not None:
+            pipeline_kwargs["text_encoder"] = text_encoder
+
+        try:
+            from diffusers import Ideogram4PromptEnhancerHead
+
+            pipeline_kwargs["prompt_enhancer_head"] = (
+                Ideogram4PromptEnhancerHead.from_pretrained(
+                    "diffusers/qwen3-vl-8b-instruct-lm-head",
+                    torch_dtype=torch.bfloat16,
+                )
+            )
+            log("Loaded the Ideogram 4 prompt enhancer head.")
+        except Exception as error:
+            log(
+                "Prompt enhancer head is unavailable; plain text prompts will not "
+                f"be upsampled automatically ({error})."
+            )
+
+        pipeline_class = get_ideogram4_pipeline_class()
+        return pipeline_class.from_pretrained(
+            model_id,
+            **pipeline_kwargs,
+        )
+
+    @staticmethod
+    def _is_json_prompt(prompt: str) -> bool:
+        stripped = prompt.strip()
+        return stripped.startswith("{") and stripped.endswith("}")
+
+    def _should_upsample_prompt(self, prompt: str | list[str]) -> bool:
+        if self.pipe.prompt_enhancer_head is None:
+            return False
+        prompts = [prompt] if isinstance(prompt, str) else prompt
+        return all(not self._is_json_prompt(item) for item in prompts)
+
+    def _get_compiled_pipe_components(self) -> list[str]:
+        return ["transformer", "unconditional_transformer"]
+
+    def _run_pipe(self, input_args: dict) -> DiffusionOutput:
+        guidance_scale = input_args.get("guidance_scale")
+        guidance_schedule = (
+            None
+            if guidance_scale is not None
+            else _default_guidance_schedule(input_args["num_inference_steps"])
+        )
+        output = self.pipe(
+            prompt=input_args["prompt"],
+            height=input_args["height"],
+            width=input_args["width"],
+            num_inference_steps=input_args["num_inference_steps"],
+            guidance_scale=guidance_scale,
+            guidance_schedule=guidance_schedule,
+            prompt_upsampling=self._should_upsample_prompt(input_args["prompt"]),
+            max_sequence_length=input_args["max_sequence_length"],
+            generator=torch.Generator(device="cuda").manual_seed(input_args["seed"]),
+            output_type=input_args.get("output_type", "pil"),
+        )
+        return DiffusionOutput(images=output.images, pipe_args=input_args)
+
+    def _post_load_and_state_initialization(self, input_args: dict) -> None:
+        super()._post_load_and_state_initialization(input_args)
+        self.pipe.transformer._init_sp_state()
+        self.pipe.unconditional_transformer._init_sp_state()
+        if self.config.use_parallel_vae:
+            _setup_parallel_vae(self.pipe.vae)

--- a/xfuser/model_executor/models/transformers/transformer_ideogram4.py
+++ b/xfuser/model_executor/models/transformers/transformer_ideogram4.py
@@ -1,0 +1,284 @@
+import torch
+import torch.nn.functional as F
+
+from xfuser.core.distributed import (
+    get_sequence_parallel_rank,
+    get_sequence_parallel_world_size,
+)
+from xfuser.model_executor.layers.usp import USP
+from xfuser.model_executor.layers.attention_processor import (
+    xFuserAttentionProcessorRegister,
+)
+from xfuser.model_executor.models.transformers.transformers_utils import (
+    chunk_and_pad_sequence,
+    gather_and_unpad,
+)
+
+
+def _rotate_half(hidden_states: torch.Tensor) -> torch.Tensor:
+    half = hidden_states.shape[-1] // 2
+    return torch.cat((-hidden_states[..., half:], hidden_states[..., :half]), dim=-1)
+
+
+def _make_xfuser_ideogram4_attention_processor():
+    from diffusers.models.transformers.transformer_ideogram4 import (
+        Ideogram4AttnProcessor,
+    )
+
+    @xFuserAttentionProcessorRegister.register(Ideogram4AttnProcessor)
+    class xFuserIdeogram4AttnProcessor(Ideogram4AttnProcessor):
+        def __init__(self) -> None:
+            super().__init__()
+            self.attention_function = USP
+
+        def __call__(
+            self,
+            attn,
+            hidden_states: torch.Tensor,
+            attention_mask: torch.Tensor | None,
+            image_rotary_emb: tuple[torch.Tensor, torch.Tensor],
+        ) -> torch.Tensor:
+            query = attn.to_q(hidden_states).unflatten(
+                -1,
+                (attn.num_heads, attn.head_dim),
+            )
+            key = attn.to_k(hidden_states).unflatten(
+                -1,
+                (attn.num_heads, attn.head_dim),
+            )
+            value = attn.to_v(hidden_states).unflatten(
+                -1,
+                (attn.num_heads, attn.head_dim),
+            )
+
+            query = attn.norm_q(query)
+            key = attn.norm_k(key)
+
+            cos, sin = image_rotary_emb
+            cos = cos.unsqueeze(2)
+            sin = sin.unsqueeze(2)
+            query = (query * cos) + (_rotate_half(query) * sin)
+            key = (key * cos) + (_rotate_half(key) * sin)
+
+            hidden_states = self.attention_function(
+                query.transpose(1, 2),
+                key.transpose(1, 2),
+                value.transpose(1, 2),
+            ).transpose(1, 2)
+            hidden_states = hidden_states.flatten(2, 3).type_as(query)
+            return attn.to_out[0](hidden_states)
+
+    return xFuserIdeogram4AttnProcessor
+
+
+def _make_xfuser_ideogram4_transformer_wrapper():
+    from diffusers.models.modeling_outputs import Transformer2DModelOutput
+    from diffusers.models.transformers.transformer_ideogram4 import (
+        LLM_TOKEN_INDICATOR,
+        OUTPUT_IMAGE_INDICATOR,
+        Ideogram4Transformer2DModel,
+    )
+    from diffusers.utils import apply_lora_scale
+
+    processor_class = _make_xfuser_ideogram4_attention_processor()
+
+    class xFuserIdeogram4Transformer2DWrapper(Ideogram4Transformer2DModel):
+        def _install_xfuser_processors(self) -> None:
+            for layer in self.layers:
+                layer.attention.set_processor(processor_class())
+
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            model = super().from_pretrained(*args, **kwargs)
+            model.__class__ = cls
+            model._install_xfuser_processors()
+            return model
+
+        def _set_sequence_layout(
+            self,
+            num_pad_tokens: int,
+            num_text_tokens: int,
+            num_image_tokens: int,
+        ) -> None:
+            self._num_pad_tokens = num_pad_tokens
+            self._num_text_tokens = num_text_tokens
+            self._num_image_tokens = num_image_tokens
+
+        def _init_sp_state(self) -> None:
+            try:
+                self._sp_rank = get_sequence_parallel_rank()
+                self._sp_size = get_sequence_parallel_world_size()
+            except AssertionError:
+                self._sp_rank = 0
+                self._sp_size = 1
+
+        def _get_sequence_layout(
+            self,
+            indicator: torch.Tensor,
+        ) -> tuple[int, int, int]:
+            if hasattr(self, "_num_image_tokens"):
+                return (
+                    self._num_pad_tokens,
+                    self._num_text_tokens,
+                    self._num_image_tokens,
+                )
+
+            text_counts = (indicator == LLM_TOKEN_INDICATOR).sum(dim=1)
+            image_counts = (indicator == OUTPUT_IMAGE_INDICATOR).sum(dim=1)
+            pad_counts = indicator.shape[1] - text_counts - image_counts
+            if not (
+                torch.equal(text_counts, text_counts[:1].expand_as(text_counts))
+                and torch.equal(image_counts, image_counts[:1].expand_as(image_counts))
+                and torch.equal(pad_counts, pad_counts[:1].expand_as(pad_counts))
+            ):
+                raise ValueError(
+                    "Ideogram 4 xDiT requires prompts in the same batch to have equal token lengths."
+                )
+
+            layout = (
+                int(pad_counts[0].item()),
+                int(text_counts[0].item()),
+                int(image_counts[0].item()),
+            )
+            self._set_sequence_layout(*layout)
+            return layout
+
+        @apply_lora_scale("attention_kwargs")
+        def forward(
+            self,
+            hidden_states: torch.Tensor,
+            timestep: torch.Tensor,
+            encoder_hidden_states: torch.Tensor,
+            position_ids: torch.Tensor,
+            segment_ids: torch.Tensor,
+            indicator: torch.Tensor,
+            attention_kwargs: dict | None = None,
+            return_dict: bool = True,
+        ):
+            sp_rank = self._sp_rank
+            sp_size = self._sp_size
+
+            batch_size, _, in_channels = hidden_states.shape
+            if in_channels != self.in_channels:
+                raise ValueError(
+                    f"Expected last dim {self.in_channels}, got {in_channels}."
+                )
+
+            num_pad_tokens, num_text_tokens, num_image_tokens = (
+                self._get_sequence_layout(indicator)
+            )
+            text_start = num_pad_tokens
+            image_start = text_start + num_text_tokens
+
+            text_hidden_states = encoder_hidden_states[:, text_start:image_start]
+            text_hidden_states = self.llm_cond_norm(text_hidden_states)
+            text_hidden_states = self.llm_cond_proj(text_hidden_states)
+
+            image_hidden_states = hidden_states[:, image_start:]
+            image_hidden_states = self.input_proj(image_hidden_states)
+
+            t_cond = self.t_embedding(timestep)
+            if timestep.dim() == 1:
+                t_cond = t_cond.unsqueeze(1)
+            adaln_input = F.silu(self.adaln_proj(t_cond))
+
+            text_indicator_embedding = self.embed_image_indicator(
+                torch.zeros(
+                    batch_size,
+                    num_text_tokens,
+                    dtype=torch.long,
+                    device=hidden_states.device,
+                )
+            )
+            image_indicator_embedding = self.embed_image_indicator(
+                torch.ones(
+                    batch_size,
+                    num_image_tokens,
+                    dtype=torch.long,
+                    device=hidden_states.device,
+                )
+            )
+
+            hidden_states = torch.cat(
+                [
+                    text_hidden_states + text_indicator_embedding,
+                    image_hidden_states + image_indicator_embedding,
+                ],
+                dim=1,
+            )
+            position_ids = torch.cat(
+                [
+                    position_ids[:, text_start:image_start],
+                    position_ids[:, image_start:],
+                ],
+                dim=1,
+            )
+
+            sequence_length = num_text_tokens + num_image_tokens
+            pad_amount = (sp_size - sequence_length % sp_size) % sp_size
+            hidden_states = chunk_and_pad_sequence(
+                hidden_states,
+                sp_rank,
+                sp_size,
+                pad_amount,
+                dim=1,
+            )
+            position_ids = chunk_and_pad_sequence(
+                position_ids,
+                sp_rank,
+                sp_size,
+                pad_amount,
+                dim=1,
+            )
+
+            cos, sin = self.rotary_emb(position_ids)
+            image_rotary_emb = (
+                cos.to(hidden_states.dtype),
+                sin.to(hidden_states.dtype),
+            )
+
+            for block in self.layers:
+                if torch.is_grad_enabled() and self.gradient_checkpointing:
+                    hidden_states = self._gradient_checkpointing_func(
+                        block,
+                        hidden_states,
+                        None,
+                        image_rotary_emb,
+                        adaln_input,
+                    )
+                else:
+                    hidden_states = block(
+                        hidden_states,
+                        None,
+                        image_rotary_emb,
+                        adaln_input,
+                    )
+
+            output = self.final_layer(hidden_states, conditioning=adaln_input)
+            if sp_size > 1:
+                output = gather_and_unpad(output, pad_amount, dim=1)
+
+            pad_output = torch.zeros(
+                batch_size,
+                num_pad_tokens,
+                output.shape[-1],
+                dtype=output.dtype,
+                device=output.device,
+            )
+            output = torch.cat([pad_output, output], dim=1)
+
+            if not return_dict:
+                return (output,)
+            return Transformer2DModelOutput(sample=output)
+
+    return xFuserIdeogram4Transformer2DWrapper
+
+
+_wrapper_cls = None
+
+
+def get_ideogram4_transformer_wrapper_class():
+    global _wrapper_cls
+    if _wrapper_cls is None:
+        _wrapper_cls = _make_xfuser_ideogram4_transformer_wrapper()
+    return _wrapper_cls

--- a/xfuser/model_executor/pipelines/pipeline_ideogram4.py
+++ b/xfuser/model_executor/pipelines/pipeline_ideogram4.py
@@ -1,0 +1,497 @@
+from typing import Any, Callable
+
+import torch
+
+from xfuser.core.distributed import (
+    get_cfg_group,
+    get_classifier_free_guidance_rank,
+    get_classifier_free_guidance_world_size,
+    get_sequence_parallel_rank,
+    get_sequence_parallel_world_size,
+    get_sp_group,
+)
+
+
+def _broadcast_object_in_group(value, coordinator):
+    payload = [value]
+    torch.distributed.broadcast_object_list(
+        payload,
+        src=coordinator.first_rank,
+        group=coordinator.cpu_group,
+    )
+    return payload[0]
+
+
+def _clone_generator(
+    generator: torch.Generator | list[torch.Generator] | None,
+) -> torch.Generator | list[torch.Generator] | None:
+    if generator is None:
+        return None
+    if isinstance(generator, list):
+        return [_clone_generator(item) for item in generator]
+
+    clone = torch.Generator(device=generator.device)
+    clone.set_state(generator.get_state())
+    return clone
+
+
+def _make_xfuser_ideogram4_pipeline_class():
+    from diffusers.models.transformers.transformer_ideogram4 import (
+        LLM_TOKEN_INDICATOR,
+    )
+    from diffusers.pipelines.ideogram4.pipeline_ideogram4 import (
+        Ideogram4Pipeline,
+        Ideogram4PipelineOutput,
+        _expand_tensor_to_effective_batch,
+        _logit_normal_sigmas,
+        _resolution_aware_mu,
+    )
+
+    class xFuserIdeogram4Pipeline(Ideogram4Pipeline):
+        @staticmethod
+        def _layout_target(transformer):
+            return getattr(transformer, "_orig_mod", transformer)
+
+        def encode_prompt(
+            self,
+            prompt: str | list[str],
+            grid_h: int,
+            grid_w: int,
+            max_sequence_length: int,
+            device: torch.device,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            outputs = super().encode_prompt(
+                prompt=prompt,
+                grid_h=grid_h,
+                grid_w=grid_w,
+                max_sequence_length=max_sequence_length,
+                device=device,
+            )
+            _, _, _, indicator = outputs
+
+            text_counts = (indicator == LLM_TOKEN_INDICATOR).sum(dim=1)
+            if not torch.equal(text_counts, text_counts[:1].expand_as(text_counts)):
+                raise ValueError(
+                    "Ideogram 4 xDiT requires prompts in the same batch to have equal token lengths."
+                )
+
+            num_text_tokens = int(text_counts[0].item())
+            num_image_tokens = grid_h * grid_w
+            num_pad_tokens = max_sequence_length - num_text_tokens
+
+            transformer = self._layout_target(self.transformer)
+            unconditional_transformer = self._layout_target(
+                self.unconditional_transformer
+            )
+            transformer._set_sequence_layout(
+                num_pad_tokens,
+                num_text_tokens,
+                num_image_tokens,
+            )
+            unconditional_transformer._set_sequence_layout(
+                0,
+                0,
+                num_image_tokens,
+            )
+            return outputs
+
+        def _upsample_prompt_distributed(
+            self,
+            prompt: str | list[str],
+            height: int,
+            width: int,
+            temperature: float,
+            max_new_tokens: int,
+            generator: torch.Generator | list[torch.Generator] | None,
+        ) -> list[str]:
+            try:
+                cfg_rank = get_classifier_free_guidance_rank()
+                cfg_size = get_classifier_free_guidance_world_size()
+            except AssertionError:
+                cfg_rank = 0
+                cfg_size = 1
+            try:
+                sp_rank = get_sequence_parallel_rank()
+                sp_size = get_sequence_parallel_world_size()
+            except AssertionError:
+                sp_rank = 0
+                sp_size = 1
+
+            captions = None
+            if cfg_rank == 0 and sp_rank == 0:
+                captions = self.upsample_prompt(
+                    prompt,
+                    height=height,
+                    width=width,
+                    temperature=temperature,
+                    max_new_tokens=max_new_tokens,
+                    generator=_clone_generator(generator),
+                    device=self._execution_device,
+                )
+
+            if cfg_size > 1:
+                captions = _broadcast_object_in_group(captions, get_cfg_group())
+            if sp_size > 1:
+                captions = _broadcast_object_in_group(captions, get_sp_group())
+            return captions
+
+        @torch.no_grad()
+        def __call__(
+            self,
+            prompt: str | list[str] | None = None,
+            height: int = 2048,
+            width: int = 2048,
+            num_inference_steps: int = 48,
+            guidance_scale: float | None = None,
+            guidance_schedule: list[float] | torch.Tensor | None = (7.0,) * 45
+            + (3.0,) * 3,
+            mu: float = 0.0,
+            std: float = 1.5,
+            prompt_upsampling: bool = False,
+            prompt_upsampling_temperature: float = 1.0,
+            max_sequence_length: int = 2048,
+            num_images_per_prompt: int = 1,
+            generator: torch.Generator | list[torch.Generator] | None = None,
+            latents: torch.Tensor | None = None,
+            output_type: str = "pil",
+            return_dict: bool = True,
+            attention_kwargs: dict[str, Any] | None = None,
+            callback_on_step_end: (
+                Callable[
+                    ["Ideogram4Pipeline", int, int, dict[str, Any]],
+                    dict[str, Any],
+                ]
+                | None
+            ) = None,
+            callback_on_step_end_tensor_inputs: list[str] | tuple[str, ...] = (
+                "latents",
+            ),
+        ) -> Ideogram4PipelineOutput | tuple[Any]:
+            if prompt_upsampling:
+                prompt = self._upsample_prompt_distributed(
+                    prompt=prompt,
+                    height=height,
+                    width=width,
+                    temperature=prompt_upsampling_temperature,
+                    max_new_tokens=max_sequence_length,
+                    generator=generator,
+                )
+                prompt_upsampling = False
+
+            try:
+                cfg_rank = get_classifier_free_guidance_rank()
+                cfg_size = get_classifier_free_guidance_world_size()
+            except AssertionError:
+                cfg_rank = 0
+                cfg_size = 1
+
+            if cfg_size == 2:
+                return self._call_with_cfg_parallel(
+                    prompt=prompt,
+                    height=height,
+                    width=width,
+                    num_inference_steps=num_inference_steps,
+                    guidance_scale=guidance_scale,
+                    guidance_schedule=guidance_schedule,
+                    mu=mu,
+                    std=std,
+                    max_sequence_length=max_sequence_length,
+                    num_images_per_prompt=num_images_per_prompt,
+                    generator=generator,
+                    latents=latents,
+                    output_type=output_type,
+                    return_dict=return_dict,
+                    attention_kwargs=attention_kwargs,
+                    callback_on_step_end=callback_on_step_end,
+                    callback_on_step_end_tensor_inputs=callback_on_step_end_tensor_inputs,
+                    cfg_rank=cfg_rank,
+                )
+            if cfg_size != 1:
+                raise ValueError(
+                    f"Ideogram 4 CFG parallelism requires degree 1 or 2, got {cfg_size}."
+                )
+
+            return super().__call__(
+                prompt=prompt,
+                height=height,
+                width=width,
+                num_inference_steps=num_inference_steps,
+                guidance_scale=guidance_scale,
+                guidance_schedule=guidance_schedule,
+                mu=mu,
+                std=std,
+                prompt_upsampling=prompt_upsampling,
+                prompt_upsampling_temperature=prompt_upsampling_temperature,
+                max_sequence_length=max_sequence_length,
+                num_images_per_prompt=num_images_per_prompt,
+                generator=generator,
+                latents=latents,
+                output_type=output_type,
+                return_dict=return_dict,
+                attention_kwargs=attention_kwargs,
+                callback_on_step_end=callback_on_step_end,
+                callback_on_step_end_tensor_inputs=callback_on_step_end_tensor_inputs,
+            )
+
+        def _call_with_cfg_parallel(
+            self,
+            prompt: str | list[str] | None,
+            height: int,
+            width: int,
+            num_inference_steps: int,
+            guidance_scale: float | None,
+            guidance_schedule: list[float] | torch.Tensor | None,
+            mu: float,
+            std: float,
+            max_sequence_length: int,
+            num_images_per_prompt: int,
+            generator: torch.Generator | list[torch.Generator] | None,
+            latents: torch.Tensor | None,
+            output_type: str,
+            return_dict: bool,
+            attention_kwargs: dict[str, Any] | None,
+            callback_on_step_end: Callable | None,
+            callback_on_step_end_tensor_inputs: list[str] | tuple[str, ...],
+            cfg_rank: int,
+        ) -> Ideogram4PipelineOutput | tuple[Any]:
+            self.check_inputs(
+                prompt=prompt,
+                height=height,
+                width=width,
+                num_inference_steps=num_inference_steps,
+                guidance_scale=guidance_scale,
+                guidance_schedule=guidance_schedule,
+                callback_on_step_end_tensor_inputs=callback_on_step_end_tensor_inputs,
+            )
+
+            batch_size = 1 if isinstance(prompt, str) else len(prompt)
+            device = self._execution_device
+            self._guidance_scale = guidance_scale
+            self._attention_kwargs = attention_kwargs
+            self._interrupt = False
+
+            grid_h = height // (self.vae_scale_factor * self.patch_size)
+            grid_w = width // (self.vae_scale_factor * self.patch_size)
+            num_image_tokens = grid_h * grid_w
+
+            llm_features, position_ids, segment_ids, indicator = self.encode_prompt(
+                prompt=prompt,
+                grid_h=grid_h,
+                grid_w=grid_w,
+                max_sequence_length=max_sequence_length,
+                device=device,
+            )
+            llm_features = _expand_tensor_to_effective_batch(
+                llm_features,
+                batch_size,
+                num_images_per_prompt,
+            )
+            position_ids = _expand_tensor_to_effective_batch(
+                position_ids,
+                batch_size,
+                num_images_per_prompt,
+            )
+            segment_ids = _expand_tensor_to_effective_batch(
+                segment_ids,
+                batch_size,
+                num_images_per_prompt,
+            )
+            indicator = _expand_tensor_to_effective_batch(
+                indicator,
+                batch_size,
+                num_images_per_prompt,
+            )
+
+            effective_batch_size = batch_size * num_images_per_prompt
+            neg_llm_features = torch.zeros(
+                effective_batch_size,
+                num_image_tokens,
+                llm_features.shape[-1],
+                dtype=llm_features.dtype,
+                device=device,
+            )
+            neg_position_ids = position_ids[:, max_sequence_length:]
+            neg_segment_ids = segment_ids[:, max_sequence_length:]
+            neg_indicator = indicator[:, max_sequence_length:]
+
+            schedule_mu = _resolution_aware_mu(
+                height=height,
+                width=width,
+                base_mu=mu,
+            )
+            sigmas = _logit_normal_sigmas(
+                num_inference_steps,
+                schedule_mu,
+                std=std,
+                device=device,
+            )
+            self.scheduler.set_timesteps(sigmas=sigmas.tolist(), device=device)
+            timesteps = self.scheduler.timesteps
+            self._num_timesteps = len(timesteps)
+
+            if guidance_scale is not None:
+                guidance_schedule = [float(guidance_scale)] * num_inference_steps
+            guidance_weights = torch.as_tensor(
+                guidance_schedule,
+                dtype=torch.float32,
+                device=device,
+            )
+
+            latent_dim = self.transformer.config.in_channels
+            latents = self.prepare_latents(
+                batch_size=effective_batch_size,
+                num_image_tokens=num_image_tokens,
+                latent_dim=latent_dim,
+                dtype=torch.float32,
+                device=device,
+                generator=generator,
+                latents=latents,
+            )
+            text_z_padding = torch.zeros(
+                effective_batch_size,
+                max_sequence_length,
+                latent_dim,
+                dtype=torch.float32,
+                device=device,
+            )
+
+            llm_features = llm_features.to(self.transformer.dtype)
+            neg_llm_features = neg_llm_features.to(self.unconditional_transformer.dtype)
+
+            num_train_timesteps = self.scheduler.config.num_train_timesteps
+            with self.progress_bar(total=num_inference_steps) as progress_bar:
+                for step_index, timestep in enumerate(timesteps):
+                    if self.interrupt:
+                        continue
+
+                    model_timestep = 1.0 - (timestep.float() / num_train_timesteps)
+                    model_timestep = model_timestep.expand(effective_batch_size)
+
+                    if cfg_rank == 1:
+                        conditional_input = torch.cat(
+                            [text_z_padding, latents],
+                            dim=1,
+                        ).to(self.transformer.dtype)
+                        velocity = self.transformer(
+                            hidden_states=conditional_input,
+                            timestep=model_timestep.to(self.transformer.dtype),
+                            encoder_hidden_states=llm_features,
+                            position_ids=position_ids,
+                            segment_ids=segment_ids,
+                            indicator=indicator,
+                            attention_kwargs=self.attention_kwargs,
+                            return_dict=False,
+                        )[0][:, max_sequence_length:]
+                    else:
+                        velocity = self.unconditional_transformer(
+                            hidden_states=latents.to(
+                                self.unconditional_transformer.dtype
+                            ),
+                            timestep=model_timestep.to(
+                                self.unconditional_transformer.dtype
+                            ),
+                            encoder_hidden_states=neg_llm_features,
+                            position_ids=neg_position_ids,
+                            segment_ids=neg_segment_ids,
+                            indicator=neg_indicator,
+                            attention_kwargs=self.attention_kwargs,
+                            return_dict=False,
+                        )[0]
+
+                    (
+                        unconditional_velocity,
+                        conditional_velocity,
+                    ) = get_cfg_group().all_gather(
+                        velocity.to(torch.float32),
+                        separate_tensors=True,
+                    )
+                    self._guidance_scale = guidance_schedule[step_index]
+                    guidance_weight = guidance_weights[step_index]
+                    velocity = (
+                        guidance_weight * conditional_velocity
+                        + (1.0 - guidance_weight) * unconditional_velocity
+                    )
+                    latents = self.scheduler.step(
+                        -velocity,
+                        timestep,
+                        latents,
+                        return_dict=False,
+                    )[0]
+
+                    if callback_on_step_end is not None:
+                        callback_kwargs = {
+                            name: locals()[name]
+                            for name in callback_on_step_end_tensor_inputs
+                        }
+                        callback_outputs = callback_on_step_end(
+                            self,
+                            step_index,
+                            timestep,
+                            callback_kwargs,
+                        )
+                        latents = callback_outputs.pop("latents", latents)
+
+                    progress_bar.update()
+
+            if output_type == "latent":
+                image = latents
+            else:
+                latents = latents * torch.sqrt(
+                    self.vae.bn.running_var + self.vae.config.batch_norm_eps
+                ).view(1, 1, -1).to(device=latents.device, dtype=latents.dtype)
+                latents = latents + self.vae.bn.running_mean.view(1, 1, -1).to(
+                    device=latents.device,
+                    dtype=latents.dtype,
+                )
+
+                patch_size = self.patch_size
+                ae_channels = latents.shape[-1] // (patch_size * patch_size)
+                latents = latents.view(
+                    effective_batch_size,
+                    grid_h,
+                    grid_w,
+                    patch_size,
+                    patch_size,
+                    ae_channels,
+                )
+                latents = latents.permute(0, 5, 1, 3, 2, 4).contiguous()
+                latents = latents.view(
+                    effective_batch_size,
+                    ae_channels,
+                    grid_h * patch_size,
+                    grid_w * patch_size,
+                )
+                decoded = self.vae.decode(
+                    latents.to(self.vae.dtype),
+                    return_dict=False,
+                )[0]
+                image = self.image_processor.postprocess(
+                    decoded.float(),
+                    output_type=output_type,
+                )
+
+            self.maybe_free_model_hooks()
+            if not return_dict:
+                return (image,)
+            return Ideogram4PipelineOutput(images=image)
+
+        @classmethod
+        def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+            pipeline = super().from_pretrained(
+                pretrained_model_name_or_path,
+                **kwargs,
+            )
+            pipeline.__class__ = cls
+            return pipeline
+
+    return xFuserIdeogram4Pipeline
+
+
+_pipeline_cls = None
+
+
+def get_ideogram4_pipeline_class():
+    global _pipeline_cls
+    if _pipeline_cls is None:
+        _pipeline_cls = _make_xfuser_ideogram4_pipeline_class()
+    return _pipeline_cls


### PR DESCRIPTION
## Summary

Adds xDiT support for Ideogram 4 using the native Diffusers 0.39 `Ideogram4Pipeline`, `Ideogram4Transformer2DModel`, and
`Ideogram4AttnProcessor` implementations.

The integration supports the official `ideogram-ai/ideogram-4-fp8` checkpoint, BF16 Diffusers checkpoints, USP/Ulysses, CFG parallelism, FSDP, optional parallel VAE decode, AITER BF16/FP8 attention, and torchao FP8/FP4 GEMMs.

**Requires:** Diffusers 0.39.0 or newer.

## Related Work

This supersedes [jackyhkust/xDiT#4](https://github.com/jackyhkust/xDiT/pull/4). That PR established the original Ideogram 4 xDiT path and several important multi-GPU, FP8-attention, prompt-broadcast, and compile-correctness fixes.

This version replaces the earlier bespoke model implementation with the native Diffusers Ideogram 4 API, uses xDiT's shared USP and attention-backend infrastructure, validates the existing AITER BF16/FP8 interfaces with `torch.compile`, and includes a new 48-case benchmark matrix.

## Features

- **Native Diffusers integration:** subclasses Diffusers' Ideogram 4 model, processor, and pipeline classes rather than vendoring the architecture
- **Parallelism:** USP/Ulysses, CFG parallel, Ulysses + CFG, FSDP, optional parallel VAE decoder
- **Quantization:** AITER FP8 attention, torchao FP8 GEMMs, AITER/torchao FP4 GEMMs
- **Official FP8 checkpoint loading:** converts fused QKV checkpoint keys to Diffusers' split Q/K/V layout and dequantizes weights into standard BF16 `nn.Linear` modules before runtime GEMM quantization
- **Prompt handling:** structured JSON prompts are passed through unchanged; plain-text prompts use the Ideogram prompt-enhancer head when available
- **Distributed prompt enhancement:** generates one enhanced prompt and broadcasts it across CFG and sequence-parallel CPU process groups
- **torch.compile:** both conditional and unconditional transformers compile with zero graph breaks
- **AITER attention validation:** the existing BF16 and FP8 interfaces compile without an Ideogram-specific wrapper when used with a compatible AITER build
- **Unpacked Ulysses communication:** uses the standard separate Q/K/V USP all-to-all path; this is 1.3-7.1% faster than materializing a packed QKV communication buffer

## Usage

```bash
# Single GPU, native 2048x2048, BF16 attention
python -m xfuser.cli \
  --model ideogram-ai/ideogram-4-fp8 \
  --prompt "A polished summer solstice festival poster" \
  --height 2048 --width 2048 --num_inference_steps 48 \
  --attention_backend AITER --use_torch_compile

# Single GPU, FP8 attention + FP4 GEMMs
python -m xfuser.cli \
  --model ideogram-ai/ideogram-4-fp8 \
  --prompt "A polished summer solstice festival poster" \
  --height 2048 --width 2048 --num_inference_steps 48 \
  --attention_backend AITER_FP8 --use_fp4_gemms \
  --use_torch_compile

# Four GPUs, Ulysses degree 2 + CFG parallel
python -m xfuser.cli \
  --model ideogram-ai/ideogram-4-fp8 \
  --prompt "$(cat benchmark/ideogram4/prompt_typography.json)" \
  --height 2048 --width 2048 --num_inference_steps 48 \
  --attention_backend AITER_FP8 --use_fp4_gemms \
  --ulysses_degree 2 --use_cfg_parallel --nproc_per_node 4 \
  --use_torch_compile
```

Ideogram 4 has 18 attention heads, so supported Ulysses degrees are `1`, `2`,
`3`, `6`, `9`, and `18`.

## Performance

Tested with `ideogram-ai/ideogram-4-fp8` on MI355X:

- 48 inference steps
- Seed 42
- Structured typography JSON prompt
- `torch.compile` enabled
- Five warmup calls
- Four measured iterations, with the first discarded
- PIL output, including VAE decode
- AITER commit `4a1cc773f34cbfc74387259e51262556ee38edd0`

### 1024x1024

| Parallel mode | BF16 | FP8 attention | FP8 GEMMs | FP4 GEMMs | FP8 attention + FP8 GEMMs | FP8 attention + FP4 GEMMs |
|---|---:|---:|---:|---:|---:|---:|
| U1 | 9.83s | 8.21s | 6.86s | 5.83s | 5.36s | 4.39s |
| U2 | 8.23s | 6.86s | 7.16s | 6.47s | 5.83s | 5.17s |
| CFG2 | 5.18s | 4.29s | 3.62s | 3.05s | 2.83s | **2.27s** |
| U2CFG2 | 4.32s | 3.62s | 3.73s | 3.31s | 3.03s | 2.63s |

Best result: **2.27s**, a **4.33x speedup** over U1 BF16.

### 2048x2048

| Parallel mode | BF16 | FP8 attention | FP8 GEMMs | FP4 GEMMs | FP8 attention + FP8 GEMMs | FP8 attention + FP4 GEMMs |
|---|---:|---:|---:|---:|---:|---:|
| U1 | 65.05s | 33.84s | 55.96s | 52.04s | 24.59s | 20.63s |
| U2 | 39.69s | 26.86s | 35.18s | 33.09s | 22.37s | 20.37s |
| CFG2 | 34.36s | 17.53s | 29.43s | 27.51s | 12.59s | 10.45s |
| U2CFG2 | 20.39s | 13.83s | 17.88s | 16.81s | 11.38s | **10.37s** |

Best result: **10.37s**, a **6.27x speedup** over U1 BF16.

### Packed vs Unpacked Ulysses

The initial implementation stacked Q, K, and V into one packed input all-to-all. Three separate Q/K/V collectives are faster for Ideogram 4 because the messages are bandwidth-bound and packing requires additional local tensor movement.

| Resolution | Mode | Minimum gain | Maximum gain |
|---|---|---:|---:|
| 1024x1024 | U2 / U2CFG2 | 1.35% | 6.69% |
| 2048x2048 | U2 / U2CFG2 | 1.76% | 7.12% |

## Architecture Notes

Ideogram 4 uses separate conditional and unconditional transformers rather than
running CFG as a doubled batch through one transformer.

- The conditional transformer processes text plus image tokens.
- The unconditional transformer processes image tokens only.
- CFG parallelism assigns one transformer branch to each CFG rank and gathers  one velocity tensor per denoising step.
- Ulysses chunks the compact text/image sequence across sequence-parallel ranks.
- The attention processor delegates to the existing `USP` interface, including   the configured AITER attention backend.

The FP8 checkpoint stores fused QKV weights and per-output-channel scales. The loader converts those keys to Diffusers' split `to_q`, `to_k`, and `to_v` modules, dequantizes to BF16, and leaves runtime FP8/FP4 GEMM selection to the existing xDiT quantization path.

## torch.compile and AITER

On gfx950, FP8 attention requires an AITER build containing the head-dimension 256 kernel `fmha_fwd_hd256_fp8_gfx950`, merged through ROCm/AITER PR 3732. This was validated against the official `amdsiloai/pytorch-xdit:v26.6` image by pulling the PR 3732 fully with its contents as it did not cherry-pick cleanly onto the version that the image ships with.

## Known Limitations

- Diffusers 0.39.0 or newer is required.
- AITER FP8 attention on gfx950 requires the HD256 FP8 FMHA kernel.
- Prompts in one batch must produce equal text-token lengths.
- PipeFusion and tensor parallelism are not implemented for Ideogram 4.
- The optional `outlines` package is recommended for schema-constrained prompt   enhancement. Without it, Diffusers runs prompt enhancement unconstrained.
