### PR TITLE
[Model] Add MiniMax-H3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ The following open-sourced DiT Models are released with xDiT in day 1.
 | [🟢 Krea2-Raw](https://huggingface.co/krea/Krea-2-Raw) | ❎ | ✔️ | ❎ | ❎ | ✔️ | NA |
 | [🟢 Krea2-Turbo](https://huggingface.co/krea/Krea-2-Turbo) | ❎ | ✔️ | ❎ | ❎ | ✔️ | NA |
 | [🟢 Ideogram 4](https://huggingface.co/ideogram-ai/ideogram-4-fp8) | ✔️ | ✔️ | ❎ | ❎ | ✔️ | NA |
+| [🎬 MiniMax-H3](https://huggingface.co/MiniMaxAI/MiniMax-H3) | ❎ | ✔️ | ❎ | ❎ | ✔️ | NA |
 | [🔴 PixArt-Sigma](https://huggingface.co/PixArt-alpha/PixArt-Sigma-XL-2-1024-MS) | ✔️ | ✔️ | ✔️ | ❎ | ❎ | [Report](./docs/performance/pixart_alpha_legacy.md) |
 | [🟢 PixArt-alpha](https://huggingface.co/PixArt-alpha/PixArt-alpha) | ✔️ | ✔️ | ✔️ | ❎ | ❎ | [Report](./docs/performance/pixart_alpha_legacy.md) |
 | [🟠 Stable Diffusion 3](https://huggingface.co/stabilityai/stable-diffusion-3-medium-diffusers) | ✔️ | ✔️ | ✔️ | ❎ | ✔️ | [Report](./docs/performance/sd3.md) |

--- a/docs/runner/runner.md
+++ b/docs/runner/runner.md
@@ -103,8 +103,7 @@ Individual model classes that inherit from `xFuserModel`:
 | Krea2-Raw | `krea/krea-2-raw`, `krea/Krea-2-Raw`, `Krea-2-Raw` |
 | Krea2-Turbo | `krea/krea-2-turbo`, `krea/Krea-2-Turbo`, `Krea-2-Turbo` |
 | Ideogram 4 | `Ideogram-4`, `ideogram-ai/ideogram-v4`, `ideogram-ai/ideogram-4-nf4`, `ideogram-ai/ideogram-4-fp8` |
-
-
+| MiniMax-H3 | `MiniMaxAI/MiniMax-H3`, `MiniMax-H3`, `MiniMax-H3-Ref2VA` |
 
 ## CLI Arguments
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
             "yunchang>=0.6.0",
             "einops",
             "diffusers>=0.33.0",
-            "av", # For LTX-2 model
+            "av", # For video encoding with audio
             "peft", # For LTX-2 LoRA
             "numpy",
         ],

--- a/tests/core/test_aiter_fp8_varlen.py
+++ b/tests/core/test_aiter_fp8_varlen.py
@@ -1,0 +1,100 @@
+from types import SimpleNamespace
+
+import torch
+
+
+def test_aiter_fp8_uses_varlen_metadata(monkeypatch):
+    from xfuser.core.distributed import attention_backend
+
+    calls = {}
+
+    def per_tensor_quant(tensor, **kwargs):
+        return tensor, torch.tensor(1.0)
+
+    def varlen_func(query, key, value, **kwargs):
+        calls["query_shape"] = query.shape
+        calls["key_shape"] = key.shape
+        calls["value_shape"] = value.shape
+        calls["kwargs"] = kwargs
+        return query
+
+    fake_aiter = SimpleNamespace(
+        dtypes=SimpleNamespace(fp8=torch.float8_e4m3fn),
+        per_tensor_quant=per_tensor_quant,
+        flash_attn_fp8_pertensor_func=lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("fixed-length FP8 attention should not be called")
+        ),
+        flash_attn_varlen_fp8_pertensor_func=varlen_func,
+    )
+    monkeypatch.setattr(attention_backend, "aiter", fake_aiter)
+    monkeypatch.setattr(attention_backend, "AITER_FP8_HAS_DESCALE", True)
+    monkeypatch.setattr(
+        attention_backend,
+        "FP8_HADAMARD_MATRIX",
+        {torch.device("cpu"): None},
+    )
+
+    query = torch.randn(1, 2, 4, 128)
+    key = torch.randn(1, 2, 4, 128)
+    value = torch.randn(1, 2, 4, 128)
+    output, lse = attention_backend._aiter_fp8_attn_call(
+        query,
+        key,
+        value,
+        dropout_p=0.0,
+        is_causal=False,
+        attention_kwargs={
+            "indices_k": torch.tensor([0, 1, 2]),
+            "cu_seqlens_k": torch.tensor([0, 3], dtype=torch.int32),
+            "max_seqlen_k": 3,
+        },
+    )
+
+    assert output.shape == query.shape
+    assert lse is None
+    assert calls["query_shape"] == (4, 2, 128)
+    assert calls["key_shape"] == (3, 2, 128)
+    assert calls["value_shape"] == (3, 2, 128)
+    assert calls["kwargs"]["max_seqlen_q"] == 4
+    assert calls["kwargs"]["max_seqlen_k"] == 3
+
+
+def test_aiter_fp8_compiles_without_dtype_rewrite(monkeypatch):
+    from xfuser.core.distributed import attention_backend
+
+    def per_tensor_quant(tensor, **kwargs):
+        return tensor, torch.tensor(1.0)
+
+    fake_aiter = SimpleNamespace(
+        dtypes=SimpleNamespace(fp8=torch.float8_e4m3fn),
+        per_tensor_quant=per_tensor_quant,
+        flash_attn_fp8_pertensor_func=lambda query, key, value, **kwargs: query.to(
+            torch.bfloat16
+        ),
+    )
+    monkeypatch.setattr(attention_backend, "aiter", fake_aiter)
+    monkeypatch.setattr(attention_backend, "AITER_FP8_HAS_DESCALE", True)
+    monkeypatch.setattr(
+        attention_backend,
+        "FP8_HADAMARD_MATRIX",
+        {torch.device("cpu"): None},
+    )
+
+    def attention(query, key, value):
+        return attention_backend._aiter_fp8_attn_call(
+            query,
+            key,
+            value,
+            dropout_p=0.0,
+            is_causal=False,
+        )[0]
+
+    query = torch.randn(1, 2, 4, 128, dtype=torch.bfloat16)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+    compiled = torch.compile(attention, fullgraph=True)
+
+    output = compiled(query, key, value)
+    assert output.shape == query.shape
+    assert output.dtype == torch.bfloat16
+    assert torch.isfinite(output).all()

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -1,0 +1,12 @@
+from xfuser.cli import get_nproc_from_args
+
+
+def test_text_encoder_tp_reuses_model_ranks():
+    args = [
+        "--ulysses_degree",
+        "8",
+        "--text_encoder_tp_degree",
+        "8",
+    ]
+
+    assert get_nproc_from_args(args) == 8

--- a/tests/core/test_video_utils.py
+++ b/tests/core/test_video_utils.py
@@ -1,0 +1,28 @@
+import pytest
+import torch
+
+
+def test_encode_video_with_audio(tmp_path):
+    av = pytest.importorskip("av")
+
+    from xfuser.core.utils.video_utils import encode_video_with_audio
+
+    video = torch.zeros(4, 16, 16, 3, dtype=torch.uint8)
+    video[:, :, :, 0] = torch.arange(4, dtype=torch.uint8)[:, None, None] * 50
+    audio = torch.zeros(2, 3200)
+    output_path = tmp_path / "test.mp4"
+
+    encode_video_with_audio(
+        video,
+        fps=4,
+        output_path=str(output_path),
+        audio=audio,
+        audio_sample_rate=32000,
+    )
+
+    container = av.open(output_path)
+    assert [stream.type for stream in container.streams] == ["video", "audio"]
+    frames = list(container.decode(video=0))
+    assert len(frames) == 4
+    assert frames[0].width == 16
+    assert frames[0].height == 16

--- a/tests/test_minimax_h3.py
+++ b/tests/test_minimax_h3.py
@@ -1,0 +1,479 @@
+from types import SimpleNamespace
+
+import inspect
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+
+def _tiny_config():
+    return {
+        "num_attention_heads": 2,
+        "attention_head_dim": 16,
+        "hidden_size": 24,
+        "num_layers": 2,
+        "num_refiner_layers": 2,
+        "ffn_dim": 32,
+        "in_channels": 4,
+        "audio_in_channels": 6,
+        "patch_size": (1, 2, 2),
+        "text_dim": 8,
+        "freq_dim": 8,
+        "time_embed_hidden_dim": 24,
+        "time_embed_dim": 16,
+        "rope_freq_dim": 2,
+    }
+
+
+def _tiny_inputs(device):
+    text_tokens = 4
+    audio_tokens = 12
+    video_tokens = 48
+    sequence_length = text_tokens + audio_tokens + video_tokens
+    text_indices = torch.arange(text_tokens, device=device)
+    audio_indices = torch.arange(
+        text_tokens,
+        text_tokens + audio_tokens,
+        device=device,
+    )
+    video_indices = torch.arange(
+        text_tokens + audio_tokens,
+        sequence_length,
+        device=device,
+    )
+
+    token_tags = torch.empty(sequence_length, dtype=torch.long, device=device)
+    token_tags[text_indices] = 1
+    token_tags[audio_indices] = 2
+    token_tags[video_indices] = 0
+
+    timestep_indices = torch.zeros(
+        sequence_length,
+        dtype=torch.long,
+        device=device,
+    )
+    timestep_indices[audio_indices] = 1
+
+    position_ids = torch.zeros(
+        sequence_length,
+        3,
+        dtype=torch.float32,
+        device=device,
+    )
+    position_ids[:, 0] = torch.arange(
+        sequence_length,
+        dtype=torch.float32,
+        device=device,
+    )
+
+    generator = torch.Generator(device="cpu").manual_seed(0)
+    return {
+        "hidden_states": torch.randn(
+            1,
+            video_tokens,
+            16,
+            generator=generator,
+            device=device,
+        ),
+        "audio_hidden_states": torch.randn(
+            1,
+            audio_tokens,
+            6,
+            generator=generator,
+            device=device,
+        ),
+        "encoder_hidden_states": torch.randn(
+            1,
+            text_tokens,
+            8,
+            generator=generator,
+            device=device,
+        ),
+        "timestep": torch.tensor([0.7, 0.3], device=device),
+        "timestep_indices": timestep_indices,
+        "token_tags": token_tags,
+        "position_ids": position_ids,
+        "video_indices": video_indices,
+        "audio_indices": audio_indices,
+        "text_indices": text_indices,
+    }
+
+
+def test_minimax_h3_wrapper_matches_diffusers_u1(monkeypatch):
+    from diffusers import MiniMaxH3Transformer3DModel
+
+    from xfuser.core.distributed.attention_backend import AttentionBackendType
+    from xfuser.model_executor.models.transformers import transformer_minimax_h3
+    from xfuser.model_executor.models.transformers.transformer_minimax_h3 import (
+        xFuserMiniMaxH3Transformer3DWrapper,
+    )
+
+    monkeypatch.setattr(
+        transformer_minimax_h3,
+        "get_ulysses_parallel_world_size",
+        lambda: 1,
+    )
+    monkeypatch.setattr(
+        transformer_minimax_h3,
+        "get_ulysses_parallel_rank",
+        lambda: 0,
+    )
+
+    config = _tiny_config()
+    base = MiniMaxH3Transformer3DModel(**config).eval()
+    wrapped = xFuserMiniMaxH3Transformer3DWrapper(
+        **config,
+        attention_backend=AttentionBackendType.SDPA,
+    ).eval()
+    wrapped.load_state_dict(base.state_dict())
+    inputs = _tiny_inputs(torch.device("cpu"))
+
+    with torch.no_grad():
+        expected = base(**inputs)
+        actual = wrapped(**inputs)
+        wrapped.fuse_qkv_projections()
+        fused_actual = wrapped(**inputs)
+
+    torch.testing.assert_close(actual.sample, expected.sample)
+    torch.testing.assert_close(actual.audio_sample, expected.audio_sample)
+    torch.testing.assert_close(fused_actual.sample, expected.sample)
+    torch.testing.assert_close(fused_actual.audio_sample, expected.audio_sample)
+
+
+def test_minimax_h3_padding_alignment():
+    from xfuser.model_executor.models.transformers.transformer_minimax_h3 import (
+        xFuserMiniMaxH3Transformer3DWrapper,
+    )
+
+    hidden_states = torch.randn(1, 65, 8)
+    timestep_indices = torch.zeros(65, dtype=torch.long)
+    token_tags = torch.zeros(65, dtype=torch.long)
+    position_ids = torch.zeros(65, 3)
+
+    padded = xFuserMiniMaxH3Transformer3DWrapper._pad_rows(
+        hidden_states,
+        timestep_indices,
+        token_tags,
+        position_ids,
+    )
+
+    assert padded[-1] == 63
+    assert padded[0].shape[1] == 128
+    assert padded[1].shape == (128,)
+    assert padded[2].shape == (128,)
+    assert padded[3].shape == (128, 3)
+    assert torch.all(padded[2][65:] == -1)
+
+
+def test_minimax_h3_runner_registration():
+    import xfuser.model_executor.models.runner_models
+    from xfuser.model_executor.models.runner_models.base_model import MODEL_REGISTRY
+
+    assert "MiniMaxAI/MiniMax-H3" in MODEL_REGISTRY
+    assert "MiniMax-H3" in MODEL_REGISTRY
+    assert "MiniMax-H3-Ref2VA" in MODEL_REGISTRY
+
+
+def test_minimax_h3_fp8_quantization_policy():
+    from xfuser.model_executor.models.runner_models.minimax_h3 import (
+        xFuserMiniMaxH3Model,
+        xFuserMiniMaxH3Ref2VAModel,
+    )
+
+    expected = ("attn.to_qkv", "ff.net.0.proj")
+    assert xFuserMiniMaxH3Model.settings.fp8_gemm_include_suffixes == expected
+    assert xFuserMiniMaxH3Ref2VAModel.settings.fp8_gemm_include_suffixes == expected
+
+
+def test_minimax_h3_fp4_quantization_policy():
+    from xfuser.model_executor.models.runner_models.minimax_h3 import (
+        xFuserMiniMaxH3Model,
+        xFuserMiniMaxH3Ref2VAModel,
+    )
+
+    expected = ("attn.to_out.0", "ff.net.2", "adaln_proj.linear")
+    assert xFuserMiniMaxH3Model.settings.fp8_precision_override_suffixes == expected
+    assert (
+        xFuserMiniMaxH3Ref2VAModel.settings.fp8_precision_override_suffixes
+        == expected
+    )
+
+
+def test_minimax_h3_text_encoder_tp_plan():
+    from torch.distributed.tensor.parallel import ColwiseParallel, RowwiseParallel
+
+    from xfuser.model_executor.models.runner_models.minimax_h3 import (
+        xFuserMiniMaxH3Model,
+    )
+
+    plan = xFuserMiniMaxH3Model._build_text_encoder_tp_plan(2)
+
+    assert len(plan) == 14
+    assert isinstance(plan["layers.0.self_attn.q_proj"], ColwiseParallel)
+    assert isinstance(plan["layers.0.self_attn.o_proj"], RowwiseParallel)
+    assert isinstance(plan["layers.1.mlp.gate_proj"], ColwiseParallel)
+    assert isinstance(plan["layers.1.mlp.down_proj"], RowwiseParallel)
+
+
+def test_text_encoder_tp_requires_model_capability():
+    from xfuser.config import xFuserArgs
+    from xfuser.model_executor.models.runner_models.base_model import (
+        DiffusionOutput,
+        ModelSettings,
+        xFuserModel,
+    )
+
+    class UnsupportedTextEncoderTPModel(xFuserModel):
+        settings = ModelSettings(model_name="unsupported-text-encoder-tp")
+
+        def _load_model(self):
+            raise NotImplementedError
+
+        def _run_pipe(self, input_args: dict) -> DiffusionOutput:
+            raise NotImplementedError
+
+    config = xFuserArgs(
+        model="unsupported-text-encoder-tp",
+        text_encoder_tp_degree=2,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="does not support text_encoder_tp_degree",
+    ):
+        UnsupportedTextEncoderTPModel(config)
+
+    from xfuser.model_executor.models.runner_models.minimax_h3 import (
+        xFuserMiniMaxH3Model,
+    )
+
+    assert xFuserMiniMaxH3Model.capabilities.text_encoder_tp_degree
+
+
+def test_minimax_h3_patches_shared_qwen_encoder_helper(monkeypatch):
+    from diffusers.modular_pipelines.minimax_h3 import encoders
+
+    from xfuser.model_executor.models.runner_models import minimax_h3
+
+    expected = torch.randn(1, 4, 8)
+    calls = []
+
+    def fake_get_prompt_embeds(*args, **kwargs):
+        calls.append((args, kwargs))
+        return expected
+
+    monkeypatch.setattr(encoders, "get_qwen3vl_prompt_embeds", fake_get_prompt_embeds)
+    monkeypatch.setattr(encoders, "_xfuser_broadcast_patched", False, raising=False)
+    monkeypatch.setattr(
+        minimax_h3,
+        "get_world_group",
+        lambda: SimpleNamespace(world_size=1),
+    )
+
+    minimax_h3._patch_minimax_h3_text_encoder_broadcast()
+    actual = encoders.get_qwen3vl_prompt_embeds(
+        SimpleNamespace(device=torch.device("cpu"), dtype=torch.bfloat16),
+        object(),
+        [1, 2, 3],
+    )
+
+    assert actual is expected
+    assert len(calls) == 1
+    assert encoders._xfuser_broadcast_patched
+
+
+class _FakeMiniMaxPipe:
+    def __init__(self):
+        self.text_encoder = SimpleNamespace(lm_head=object())
+        self.loaded_dtype = None
+
+    def update_components(self, **components):
+        for name, component in components.items():
+            setattr(self, name, component)
+
+    def load_components(self, dtype):
+        self.loaded_dtype = dtype
+
+
+class _FakeTransformer:
+    def __init__(self):
+        self.qkv_fused = False
+
+    def fuse_qkv_projections(self):
+        self.qkv_fused = True
+
+
+@pytest.mark.parametrize(
+    ("task", "expected_workflow"),
+    [("t2va", "t2va"), ("i2va", "fl2va"), ("fl2va", "fl2va")],
+)
+def test_minimax_h3_loads_task_workflow(
+    monkeypatch,
+    task,
+    expected_workflow,
+):
+    from diffusers import ModularPipeline
+
+    from xfuser.model_executor.models.runner_models import minimax_h3
+    from xfuser.model_executor.models.runner_models.minimax_h3 import (
+        xFuserMiniMaxH3Model,
+    )
+    from xfuser.model_executor.models.transformers.transformer_minimax_h3 import (
+        xFuserMiniMaxH3Transformer3DWrapper,
+    )
+
+    pipe = _FakeMiniMaxPipe()
+    transformer = _FakeTransformer()
+    workflows = []
+
+    def fake_from_pretrained(model_name, workflow):
+        workflows.append((model_name, workflow))
+        return pipe
+
+    monkeypatch.setattr(ModularPipeline, "from_pretrained", fake_from_pretrained)
+    monkeypatch.setattr(
+        xFuserMiniMaxH3Transformer3DWrapper,
+        "from_pretrained",
+        lambda *args, **kwargs: transformer,
+    )
+    monkeypatch.setattr(
+        minimax_h3,
+        "_patch_minimax_h3_text_encoder_broadcast",
+        lambda: None,
+    )
+    monkeypatch.setattr(minimax_h3, "log", lambda message: None)
+
+    model = object.__new__(xFuserMiniMaxH3Model)
+    model.config = SimpleNamespace(task=task, text_encoder_tp_degree=1)
+    model._parallelize_text_encoder = lambda text_encoder: None
+
+    actual = model._load_model()
+
+    assert actual is pipe
+    assert workflows == [(model.settings.model_name, expected_workflow)]
+    assert pipe.transformer is transformer
+    assert transformer.qkv_fused
+    assert pipe.loaded_dtype == torch.bfloat16
+    assert pipe.text_encoder.lm_head is None
+
+
+def test_minimax_h3_ref2va_loads_workflow(monkeypatch):
+    from diffusers import ModularPipeline
+
+    from xfuser.model_executor.models.runner_models import minimax_h3
+    from xfuser.model_executor.models.runner_models.minimax_h3 import (
+        xFuserMiniMaxH3Ref2VAModel,
+    )
+    from xfuser.model_executor.models.transformers.transformer_minimax_h3 import (
+        xFuserMiniMaxH3Transformer3DWrapper,
+    )
+
+    pipe = _FakeMiniMaxPipe()
+    transformer = _FakeTransformer()
+    workflows = []
+
+    def fake_from_pretrained(model_name, workflow):
+        workflows.append((model_name, workflow))
+        return pipe
+
+    monkeypatch.setattr(ModularPipeline, "from_pretrained", fake_from_pretrained)
+    monkeypatch.setattr(
+        xFuserMiniMaxH3Transformer3DWrapper,
+        "from_pretrained",
+        lambda *args, **kwargs: transformer,
+    )
+    monkeypatch.setattr(
+        minimax_h3,
+        "_patch_minimax_h3_text_encoder_broadcast",
+        lambda: None,
+    )
+    monkeypatch.setattr(minimax_h3, "log", lambda message: None)
+
+    model = object.__new__(xFuserMiniMaxH3Ref2VAModel)
+    model.config = SimpleNamespace(text_encoder_tp_degree=1)
+    model._parallelize_text_encoder = lambda text_encoder: None
+
+    actual = model._load_model()
+
+    assert actual is pipe
+    assert workflows == [(model.settings.model_name, "ref2va")]
+    assert pipe.transformer_ref is transformer
+    assert transformer.qkv_fused
+    assert not hasattr(pipe, "transformer")
+
+
+def test_minimax_h3_ref2va_runtime_state_uses_ref_transformer():
+    from xfuser.model_executor.models.runner_models.minimax_h3 import (
+        xFuserMiniMaxH3Ref2VAModel,
+    )
+
+    transformer = object()
+    model = object.__new__(xFuserMiniMaxH3Ref2VAModel)
+    model.pipe = SimpleNamespace(transformer_ref=transformer)
+
+    runtime_pipeline = model._get_runtime_state_pipeline()
+
+    assert runtime_pipeline.transformer is transformer
+    assert not hasattr(model.pipe, "transformer")
+
+
+def test_minimax_h3_compile_preserves_forward_signature():
+    from xfuser.model_executor.models.runner_models.minimax_h3 import (
+        xFuserMiniMaxH3Model,
+    )
+    from xfuser.model_executor.models.transformers.transformer_minimax_h3 import (
+        xFuserMiniMaxH3Transformer3DWrapper,
+    )
+
+    transformer = xFuserMiniMaxH3Transformer3DWrapper(**_tiny_config()).eval()
+    model = object.__new__(xFuserMiniMaxH3Model)
+    model.config = SimpleNamespace(fully_shard_degree=1)
+    model.pipe = SimpleNamespace(transformer=transformer)
+    model._enable_compute_comm_overlap = lambda: None
+    model._get_compile_mode = lambda: "default"
+    model._run_timed_pipe = lambda input_args: None
+
+    model._compile_model({"num_inference_steps": 50})
+
+    parameters = inspect.signature(model.pipe.transformer.forward).parameters
+    assert "token_tags" in parameters
+    assert "position_ids" in parameters
+
+
+def test_minimax_h3_ref2va_uses_typed_image_references():
+    from diffusers.modular_pipelines.minimax_h3 import MiniMaxH3ImageReference
+
+    from xfuser.model_executor.models.runner_models.minimax_h3 import (
+        xFuserMiniMaxH3Ref2VAModel,
+    )
+
+    captured = {}
+
+    def fake_pipe(**kwargs):
+        captured.update(kwargs)
+        return {
+            "videos": np.zeros((1, 1, 1, 1, 3), dtype=np.float32),
+            "audio": torch.zeros(1, 2, 1),
+            "sampling_rate": 24_000,
+        }
+
+    model = object.__new__(xFuserMiniMaxH3Ref2VAModel)
+    model.pipe = fake_pipe
+    image = Image.new("RGB", (32, 32))
+
+    model._run_pipe(
+        {
+            "prompt": "Animate this reference.",
+            "input_images": [image],
+            "height": 32,
+            "width": 32,
+            "num_frames": 5,
+            "num_inference_steps": 1,
+            "seed": 0,
+        }
+    )
+
+    assert len(captured["references"]) == 1
+    assert isinstance(captured["references"][0], MiniMaxH3ImageReference)
+    assert captured["references"][0].image is image

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -93,6 +93,7 @@ class xFuserArgs:
     ring_degree: Optional[int] = 1
     # tensor parallel
     tensor_parallel_degree: int = 1
+    text_encoder_tp_degree: int = 1
     split_scheme: Optional[str] = "row"
     # ray arguments
     use_ray: bool = False
@@ -323,6 +324,12 @@ class xFuserArgs:
             help="Tensor parallel degree.",
         )
         parallel_group.add_argument(
+            "--text_encoder_tp_degree",
+            type=int,
+            default=1,
+            help="Tensor parallel degree for supported text encoders, reusing the existing model ranks.",
+        )
+        parallel_group.add_argument(
             "--split_scheme",
             type=str,
             default="row",
@@ -523,6 +530,12 @@ class xFuserArgs:
             type=int,
             default=1,
             help="Tensor parallel degree.",
+        )
+        parser.add_argument(
+            "--text_encoder_tp_degree",
+            type=int,
+            default=1,
+            help="Tensor parallel degree for supported text encoders, reusing the existing model ranks.",
         )
         parser.add_argument(
             "--fully_shard_degree",

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -815,6 +815,148 @@ def _fp8_hadamard_rotate(x: torch.Tensor, R: torch.Tensor) -> torch.Tensor:
     return torch.matmul(x.unflatten(-1, (d // block_r, block_r)), R).flatten(-2)
 
 
+def _quantize_aiter_fp8_inputs(query, key, value):
+    quant_dtype = aiter.dtypes.fp8
+    dtype_max = torch.finfo(quant_dtype).max
+    if AITER_FP8_HAS_DESCALE:
+        if AITER_FP8_STATIC_SCALE_WITH_DESCALE is None:
+            scale = None
+        else:
+            scale = torch.tensor(
+                AITER_FP8_STATIC_SCALE_WITH_DESCALE,
+                dtype=torch.float32,
+                device=query.device,
+            )
+    else:
+        scale = torch.tensor(
+            AITER_FP8_STATIC_SCALE_NO_DESCALE,
+            dtype=torch.float32,
+            device=query.device,
+        )
+
+    quant_q, q_descale = aiter.per_tensor_quant(
+        query,
+        scale=scale,
+        quant_dtype=quant_dtype,
+        dtypeMax=dtype_max,
+    )
+    quant_k, k_descale = aiter.per_tensor_quant(
+        key,
+        scale=scale,
+        quant_dtype=quant_dtype,
+        dtypeMax=dtype_max,
+    )
+    quant_v, v_descale = aiter.per_tensor_quant(
+        value,
+        scale=scale,
+        quant_dtype=quant_dtype,
+        dtypeMax=dtype_max,
+    )
+    return (
+        quant_q.to(quant_dtype),
+        quant_k.to(quant_dtype),
+        quant_v.to(quant_dtype),
+        q_descale,
+        k_descale,
+        v_descale,
+    )
+
+
+@torch.library.custom_op("xfuser::aiter_fp8_attention", mutates_args=())
+def _aiter_fp8_attention_kernel(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    softmax_scale: float,
+    is_causal: bool,
+) -> torch.Tensor:
+    quant_q, quant_k, quant_v, q_descale, k_descale, v_descale = (
+        _quantize_aiter_fp8_inputs(query, key, value)
+    )
+    kwargs = {}
+    if AITER_FP8_HAS_DESCALE:
+        kwargs = {
+            "q_descale": q_descale,
+            "k_descale": k_descale,
+            "v_descale": v_descale,
+        }
+    return aiter.flash_attn_fp8_pertensor_func(
+        quant_q,
+        quant_k,
+        quant_v,
+        causal=is_causal,
+        softmax_scale=softmax_scale,
+        **kwargs,
+    )
+
+
+@_aiter_fp8_attention_kernel.register_fake
+def _aiter_fp8_attention_kernel_fake(
+    query,
+    key,
+    value,
+    softmax_scale,
+    is_causal,
+):
+    return torch.empty_like(query)
+
+
+@torch.library.custom_op("xfuser::aiter_fp8_varlen_attention", mutates_args=())
+def _aiter_fp8_varlen_attention_kernel(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    softmax_scale: float,
+    is_causal: bool,
+) -> torch.Tensor:
+    quant_q, quant_k, quant_v, q_descale, k_descale, v_descale = (
+        _quantize_aiter_fp8_inputs(query, key, value)
+    )
+    kwargs = {}
+    if AITER_FP8_HAS_DESCALE:
+        kwargs = {
+            "q_descale": q_descale,
+            "k_descale": k_descale,
+            "v_descale": v_descale,
+        }
+    varlen_func = getattr(aiter, "flash_attn_varlen_fp8_pertensor_func", None)
+    if varlen_func is None:
+        raise RuntimeError(
+            "AITER varlen FP8 flash attention is not available, please update AITER."
+        )
+    return varlen_func(
+        quant_q,
+        quant_k,
+        quant_v,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        softmax_scale=softmax_scale,
+        causal=is_causal,
+        **kwargs,
+    )
+
+
+@_aiter_fp8_varlen_attention_kernel.register_fake
+def _aiter_fp8_varlen_attention_kernel_fake(
+    query,
+    key,
+    value,
+    cu_seqlens_q,
+    cu_seqlens_k,
+    max_seqlen_q,
+    max_seqlen_k,
+    softmax_scale,
+    is_causal,
+):
+    return torch.empty_like(query)
+
+
 @register_attention_function(AttentionBackendType.AITER_FP8)
 def _aiter_fp8_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs=None):
     """
@@ -830,47 +972,42 @@ def _aiter_fp8_attn_call(query, key, value, dropout_p, is_causal, attention_kwar
     query = _fp8_hadamard_rotate(query, R).contiguous()
     key = _fp8_hadamard_rotate(key, R).contiguous()
 
-    softmax_lse = None
-    quant_dtype = aiter.dtypes.fp8
-    dtypeMax = torch.finfo(quant_dtype).max
-    if AITER_FP8_HAS_DESCALE:
-        # If AITER_FP8_STATIC_SCALE_WITH_DESCALE is not set, use dynamic scaling.
-        # Set the environment variable XFUSER_AITER_FP8_STATIC_SCALE_WITH_DESCALE
-        # to a float value (i.e 2.5) to use static scaling.
-        if AITER_FP8_STATIC_SCALE_WITH_DESCALE is None:
-            scale = None
-        else:
-            scale=torch.tensor(AITER_FP8_STATIC_SCALE_WITH_DESCALE, dtype=torch.float32, device=query.device)
+    packed = _varlen_pack_keys(query, key, value, attention_kwargs)
+    if packed is not None:
+        (
+            query,
+            key,
+            value,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            max_seqlen_k,
+            batch_size,
+            sequence_length,
+            num_heads,
+            head_dim,
+        ) = packed
+        output = _aiter_fp8_varlen_attention_kernel(
+            query,
+            key,
+            value,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            sequence_length,
+            max_seqlen_k,
+            head_dim**-0.5,
+            is_causal,
+        ).reshape(batch_size, sequence_length, num_heads, head_dim)
     else:
-        # Use static scale of 1.0, since descale is not available.
-        scale = torch.tensor(AITER_FP8_STATIC_SCALE_NO_DESCALE, dtype=torch.float32, device=query.device)
-    quant_q, q_descale = aiter.per_tensor_quant(query,
-                                                scale=scale,
-                                                quant_dtype=quant_dtype,
-                                                dtypeMax=dtypeMax)
-    quant_k, k_descale = aiter.per_tensor_quant(key,
-                                                scale=scale,
-                                                quant_dtype=quant_dtype,
-                                                dtypeMax=dtypeMax)
-    quant_v, v_descale = aiter.per_tensor_quant(value,
-                                                scale=scale,
-                                                quant_dtype=quant_dtype,
-                                                dtypeMax=dtypeMax)
+        output = _aiter_fp8_attention_kernel(
+            query,
+            key,
+            value,
+            query.shape[-1] ** -0.5,
+            is_causal,
+        )
 
-    kwargs = {}
-    if AITER_FP8_HAS_DESCALE:
-        kwargs = {
-                "q_descale": q_descale,
-                "k_descale": k_descale,
-                "v_descale": v_descale,
-            }
-    output = aiter.flash_attn_fp8_pertensor_func(
-        quant_q, quant_k, quant_v,
-        causal=is_causal,
-        **kwargs
-    )
     output = torch.permute(output, [0, 2, 1, 3])
-    return output, softmax_lse
+    return output, None
 
 @register_attention_function(AttentionBackendType.AITER)
 def _aiter_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs=None):

--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -5,7 +5,7 @@ import torch
 import functools
 import numpy as np
 from PIL.Image import Image
-from typing import Callable, Optional
+from typing import Callable, Optional, Tuple
 from xfuser.envs import _is_cuda, _is_hip, PACKAGES_CHECKER
 
 logger = logging.getLogger(__name__)
@@ -334,13 +334,18 @@ def quantize_linear_layers_to_int8(
 
 def quantize_linear_layers_to_fp8(module_or_module_list_to_quantize: torch.nn.Module | torch.nn.ModuleList,
     filter_fn: Optional[Callable[[torch.nn.Module, str], bool]] = None,
+    include_suffixes: Optional[Tuple[str, ...]] = None,
     device: Optional[torch.device] = None) -> None:
     """Quantize all linear layers in the given module or module list to FP8."""
     from torchao.quantization.granularity import PerTensor
     from torchao.quantization.quant_api import Float8DynamicActivationFloat8WeightConfig, quantize_, _is_linear
 
     if filter_fn is None:
-        filter_fn = _is_linear
+        if include_suffixes:
+            def filter_fn(module, fqn):
+                return _is_linear(module, fqn) and fqn.endswith(include_suffixes)
+        else:
+            filter_fn = _is_linear
     config = Float8DynamicActivationFloat8WeightConfig(
                 granularity=PerTensor(),
                 set_inductor_config=False,
@@ -359,6 +364,8 @@ def quantize_linear_layers_to_fp8(module_or_module_list_to_quantize: torch.nn.Mo
 
 def quantize_linear_layers_to_fp8_blockscale(
     model: torch.nn.Module,
+    parent_name: str = "",
+    include_suffixes: Optional[Tuple[str, ...]] = None,
     device: Optional[torch.device] = None,
 ) -> None:
     """Replace nn.Linear layers with xFuserFP8BlockScaleLinear (AITER gemm_a8w8_blockscale).
@@ -369,7 +376,10 @@ def quantize_linear_layers_to_fp8_blockscale(
     from xfuser.model_executor.layers.fp8_linear import xFuserFP8BlockScaleLinear
 
     for name, module in list(model.named_children()):
-        if isinstance(module, torch.nn.Linear):
+        full_name = f"{parent_name}.{name}" if parent_name else name
+        if isinstance(module, torch.nn.Linear) and (
+            not include_suffixes or full_name.endswith(include_suffixes)
+        ):
             weight = module.weight.data
             bias = module.bias.data if module.bias is not None else None
             fp8_layer = xFuserFP8BlockScaleLinear(
@@ -387,7 +397,12 @@ def quantize_linear_layers_to_fp8_blockscale(
             del weight, bias
             setattr(model, name, fp8_layer)
         elif next(module.children(), None) is not None:
-            quantize_linear_layers_to_fp8_blockscale(module, device=device)
+            quantize_linear_layers_to_fp8_blockscale(
+                module,
+                parent_name=full_name,
+                include_suffixes=include_suffixes,
+                device=device,
+            )
 
 
 def load_dataset_prompts(dataset_path: str) -> list[str]:

--- a/xfuser/core/utils/video_utils.py
+++ b/xfuser/core/utils/video_utils.py
@@ -1,0 +1,137 @@
+from fractions import Fraction
+from itertools import chain
+from typing import Iterator
+
+import numpy as np
+import PIL.Image
+import torch
+
+
+def _import_av():
+    try:
+        import av
+    except ImportError as error:
+        raise ImportError(
+            "PyAV is required to encode videos with audio. Install it with `pip install av`."
+        ) from error
+    return av
+
+
+def _prepare_audio_stream(container, audio_sample_rate: int, audio_bitrate: int):
+    audio_stream = container.add_stream("aac", rate=audio_sample_rate)
+    audio_stream.bit_rate = audio_bitrate
+    audio_stream.codec_context.sample_rate = audio_sample_rate
+    audio_stream.codec_context.layout = "stereo"
+    audio_stream.codec_context.time_base = Fraction(1, audio_sample_rate)
+    return audio_stream
+
+
+def _write_audio(container, audio_stream, samples, audio_sample_rate: int, av_module) -> None:
+    if samples.ndim == 1:
+        samples = samples[:, None]
+    if samples.shape[1] != 2 and samples.shape[0] == 2:
+        samples = samples.T
+    if samples.shape[1] != 2:
+        raise ValueError(f"Expected stereo audio, got shape {tuple(samples.shape)}.")
+
+    if samples.dtype != torch.int16:
+        samples = torch.clip(samples, -1.0, 1.0)
+        samples = (samples * 32767.0).to(torch.int16)
+
+    frame = av_module.AudioFrame.from_ndarray(
+        samples.contiguous().reshape(1, -1).cpu().numpy(),
+        format="s16",
+        layout="stereo",
+    )
+    frame.sample_rate = audio_sample_rate
+
+    codec_context = audio_stream.codec_context
+    resampler = av_module.audio.resampler.AudioResampler(
+        format=codec_context.format or "fltp",
+        layout=codec_context.layout or "stereo",
+        rate=codec_context.sample_rate or audio_sample_rate,
+    )
+    next_pts = 0
+    for resampled_frame in resampler.resample(frame):
+        if resampled_frame.pts is None:
+            resampled_frame.pts = next_pts
+        next_pts += resampled_frame.samples
+        resampled_frame.sample_rate = audio_sample_rate
+        container.mux(audio_stream.encode(resampled_frame))
+
+    for packet in audio_stream.encode():
+        container.mux(packet)
+
+
+def encode_video_with_audio(
+    video: list[PIL.Image.Image] | np.ndarray | torch.Tensor | Iterator[torch.Tensor],
+    fps: int,
+    output_path: str,
+    audio: torch.Tensor | None = None,
+    audio_sample_rate: int | None = None,
+    video_chunks_number: int = 1,
+    video_codec: str = "libx264",
+    pixel_format: str = "yuv420p",
+    crf: int = 12,
+    preset: str = "medium",
+    audio_bitrate: int = 192_000,
+) -> None:
+    """Encode RGB video frames with optional stereo audio and explicit quality controls.
+
+    Tensor inputs are expected to be uint8 RGB frames in ``[F, H, W, C]`` format.
+    NumPy inputs may instead contain normalized floating-point values in ``[0, 1]``.
+    """
+    av = _import_av()
+
+    if isinstance(video, list):
+        video = torch.from_numpy(np.stack([np.asarray(frame) for frame in video]))
+    elif isinstance(video, np.ndarray):
+        if np.all((video >= 0) & (video <= 1)):
+            video = (video * 255).round().astype(np.uint8)
+        video = torch.from_numpy(video)
+
+    if isinstance(video, torch.Tensor):
+        video = iter(torch.tensor_split(video, video_chunks_number, dim=0))
+
+    first_chunk = next(video)
+    _, height, width, _ = first_chunk.shape
+
+    container = av.open(output_path, mode="w")
+    video_stream = container.add_stream(video_codec, rate=int(fps))
+    video_stream.width = width
+    video_stream.height = height
+    video_stream.pix_fmt = pixel_format
+    video_stream.options = {
+        "crf": str(crf),
+        "preset": preset,
+    }
+
+    audio_stream = None
+    if audio is not None:
+        if audio_sample_rate is None:
+            raise ValueError("audio_sample_rate is required when audio is provided.")
+        audio_stream = _prepare_audio_stream(
+            container,
+            audio_sample_rate=audio_sample_rate,
+            audio_bitrate=audio_bitrate,
+        )
+
+    for video_chunk in chain([first_chunk], video):
+        for frame_array in video_chunk.to("cpu").numpy():
+            frame = av.VideoFrame.from_ndarray(frame_array, format="rgb24")
+            for packet in video_stream.encode(frame):
+                container.mux(packet)
+
+    for packet in video_stream.encode():
+        container.mux(packet)
+
+    if audio is not None:
+        _write_audio(
+            container,
+            audio_stream,
+            audio,
+            audio_sample_rate,
+            av,
+        )
+
+    container.close()

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -119,6 +119,7 @@ class ModelCapabilities:
     pipefusion_parallel_degree: bool = False
     data_parallel_degree: bool = True
     tensor_parallel_degree: bool = False
+    text_encoder_tp_degree: bool = False
     use_cfg_parallel: bool = False
     use_parallel_vae: bool = False
     use_parallel_vae_encoder: bool = False
@@ -165,6 +166,7 @@ class ModelSettings:
     fps: Optional[int] = None
     int8_gemm_module_list: List[str] = None
     fp8_gemm_module_list: List[str] = None
+    fp8_gemm_include_suffixes: Optional[Tuple[str, ...]] = None
     fp4_gemm_module_list: List[str] = None
     fp8_precision_overrides: Tuple[str] = None
     fp8_precision_override_suffixes: Tuple[str] = None
@@ -307,7 +309,7 @@ class xFuserModel(abc.ABC):
         self.pipe = self._load_model_checked()
 
         log("Initializing runtime state...")
-        initialize_runtime_state(self.pipe, self.engine_config)
+        initialize_runtime_state(self._get_runtime_state_pipeline(), self.engine_config)
 
         self._post_load_and_state_initialization(input_args)
         self._enable_options()
@@ -339,6 +341,9 @@ class xFuserModel(abc.ABC):
         elif self.config.enable_model_cpu_offload:
             log("Enabling model CPU offload...")
             self.pipe.enable_model_cpu_offload()
+
+    def _get_runtime_state_pipeline(self):
+        return self.pipe
 
 
     def _validate_config(self, config: xFuserArgs) -> None:
@@ -746,7 +751,9 @@ class xFuserModel(abc.ABC):
                 for module_name in self.settings.fp8_gemm_module_list:
                     log(f"Quantizing {module_name} to FP8 block-scale (AITER)...")
                     quantize_linear_layers_to_fp8_blockscale(
-                        rgetattr(self.pipe, module_name), device=f"cuda:{local_rank}"
+                        rgetattr(self.pipe, module_name),
+                        include_suffixes=self.settings.fp8_gemm_include_suffixes,
+                        device=f"cuda:{local_rank}",
                     )
             if not offload_requested:
                 self.pipe = self.pipe.to(f"cuda:{local_rank}")
@@ -758,7 +765,11 @@ class xFuserModel(abc.ABC):
             if self.config.use_fp8_gemms and not _use_aiter_fp8_rdna4():
                 for module_name in self.settings.fp8_gemm_module_list:
                     log(f"Quantizing {module_name} to FP8 (torchao)...")
-                    quantize_linear_layers_to_fp8(rgetattr(self.pipe, module_name), device=f"cuda:{local_rank}")
+                    quantize_linear_layers_to_fp8(
+                        rgetattr(self.pipe, module_name),
+                        include_suffixes=self.settings.fp8_gemm_include_suffixes,
+                        device=f"cuda:{local_rank}",
+                    )
             if self.config.use_int8_gemms:
                 for module_name in self.settings.int8_gemm_module_list:
                     log(f"Quantizing {module_name} to W8A8 INT8 (torchao)...")
@@ -919,9 +930,17 @@ class xFuserModel(abc.ABC):
                     )
             elif use_fp8_here:
                 if _use_aiter_fp8_rdna4():
-                    quantize_linear_layers_to_fp8_blockscale(block, device=device)
+                    quantize_linear_layers_to_fp8_blockscale(
+                        block,
+                        include_suffixes=self.settings.fp8_gemm_include_suffixes,
+                        device=device,
+                    )
                 else:
-                    quantize_linear_layers_to_fp8(block, device=device)
+                    quantize_linear_layers_to_fp8(
+                        block,
+                        include_suffixes=self.settings.fp8_gemm_include_suffixes,
+                        device=device,
+                    )
             else:
                 # use_int8_here
                 quantize_linear_layers_to_int8(block, device=device, min_layer_size=512)
@@ -951,7 +970,11 @@ class xFuserModel(abc.ABC):
                 continue
             log(f"Quantizing linear layers in {module_name} to FP8...")
             module = rgetattr(self.pipe, module_name)
-            quantize_linear_layers_to_fp8(module, device=f"cuda:{local_rank}")
+            quantize_linear_layers_to_fp8(
+                module,
+                include_suffixes=self.settings.fp8_gemm_include_suffixes,
+                device=f"cuda:{local_rank}",
+            )
 
     def _setup_nvfp4_gemms(self, local_rank):
         for module_name in self.settings.fp4_gemm_module_list:
@@ -968,7 +991,11 @@ class xFuserModel(abc.ABC):
                 continue
             log(f"Quantizing linear layers in {module_name} to FP8...")
             module = rgetattr(self.pipe, module_name)
-            quantize_linear_layers_to_fp8(module, device=f"cuda:{local_rank}")
+            quantize_linear_layers_to_fp8(
+                module,
+                include_suffixes=self.settings.fp8_gemm_include_suffixes,
+                device=f"cuda:{local_rank}",
+            )
 
     def _calculate_hybrid_attention_step_multiplier(self, input_args: dict) -> int:
         return 1

--- a/xfuser/model_executor/models/runner_models/ltx.py
+++ b/xfuser/model_executor/models/runner_models/ltx.py
@@ -15,6 +15,7 @@ from xfuser.model_executor.models.runner_models.base_model import (
 from xfuser.core.utils.runner_utils import (
     log,
 )
+from xfuser.core.utils.video_utils import encode_video_with_audio
 
 DEFAULT_NEGATIVE_PROMPT = "" \
 "blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, " \
@@ -198,7 +199,6 @@ class xFuserLTX23VideoModel(xFuserModel):
         self._run_timed_pipe(compile_args)
 
     def save_output(self, output: DiffusionOutput) -> None:
-        from diffusers.pipelines.ltx2.export_utils import encode_video
         pipe_args = output.pipe_args
         output = output.videos
         audio_sample_rate = self.pipe.vocoder.config.output_sampling_rate
@@ -208,7 +208,13 @@ class xFuserLTX23VideoModel(xFuserModel):
             video = torch.from_numpy(video)
             output_name = self.get_output_name(pipe_args[i])
             output_path = f"{self.config.output_directory}/{output_name}_{i}.mp4"
-            encode_video(video[0], audio=audio[0].float().cpu(), audio_sample_rate=audio_sample_rate, fps=self.settings.fps, output_path=output_path)
+            encode_video_with_audio(
+                video[0],
+                audio=audio[0].float().cpu(),
+                audio_sample_rate=audio_sample_rate,
+                fps=self.settings.fps,
+                output_path=output_path,
+            )
             log(f"Output video saved to {output_path}")
 
     def _post_load_and_state_initialization(self, input_args: dict) -> None:
@@ -341,7 +347,6 @@ class xFuserLTX2VideoModel(xFuserModel):
         self._run_timed_pipe(compile_args)
 
     def save_output(self, output: DiffusionOutput) -> None:
-        from diffusers.pipelines.ltx2.export_utils import encode_video
         pipe_args = output.pipe_args
         output = output.videos
         for i, video_object in enumerate(output):
@@ -350,7 +355,13 @@ class xFuserLTX2VideoModel(xFuserModel):
             video = torch.from_numpy(video)
             output_name = self.get_output_name(pipe_args[i])
             output_path = f"{self.config.output_directory}/{output_name}_{i}.mp4"
-            encode_video(video[0], audio=audio[0].float().cpu(), audio_sample_rate=24000, fps=self.settings.fps, output_path=output_path)
+            encode_video_with_audio(
+                video[0],
+                audio=audio[0].float().cpu(),
+                audio_sample_rate=24000,
+                fps=self.settings.fps,
+                output_path=output_path,
+            )
             log(f"Output video saved to {output_path}")
 
     def _post_load_and_state_initialization(self, input_args: dict) -> None:

--- a/xfuser/model_executor/models/runner_models/minimax_h3.py
+++ b/xfuser/model_executor/models/runner_models/minimax_h3.py
@@ -1,0 +1,543 @@
+from __future__ import annotations
+
+import copy
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+
+from xfuser.core.distributed.attention_backend import AttentionBackendType
+from xfuser.core.distributed import get_world_group
+from xfuser.core.utils.runner_utils import log
+from xfuser.core.utils.video_utils import encode_video_with_audio
+from xfuser.model_executor.models.runner_models.base_model import (
+    DIFFUSERS_FROM_SOURCE,
+    DefaultInputValues,
+    DiffusionOutput,
+    ModelCapabilities,
+    ModelSettings,
+    _parse_attention_backend,
+    register_model,
+    xFuserModel,
+)
+
+
+_SUPPORTED_ATTN_BACKENDS = frozenset({
+    AttentionBackendType.AITER,
+    AttentionBackendType.AITER_FP8,
+})
+_SUPPORTED_ULYSSES_DEGREES = frozenset({1, 2, 4, 8})
+_SUPPORTED_TASKS = frozenset({"t2va", "i2va", "l2va", "fl2va", "ref2va"})
+
+
+def _patch_minimax_h3_text_encoder_broadcast() -> None:
+    from diffusers.modular_pipelines.minimax_h3 import encoders
+
+    if getattr(encoders, "_xfuser_broadcast_patched", False):
+        return
+
+    original_get_prompt_embeds = encoders.get_qwen3vl_prompt_embeds
+
+    def distributed_get_prompt_embeds(
+        text_encoder,
+        processor,
+        token_ids,
+        vision_inputs=None,
+        text_encoder_layer=50,
+        device=None,
+        dtype=None,
+    ):
+        world_group = get_world_group()
+        if world_group.world_size == 1:
+            return original_get_prompt_embeds(
+                text_encoder,
+                processor,
+                token_ids,
+                vision_inputs,
+                text_encoder_layer=text_encoder_layer,
+                device=device,
+                dtype=dtype,
+            )
+
+        device = device or text_encoder.device
+        dtype = dtype or text_encoder.dtype
+        source_rank = world_group.first_rank
+        metadata = [None]
+
+        if world_group.rank == source_rank:
+            prompt_embeds = original_get_prompt_embeds(
+                text_encoder,
+                processor,
+                token_ids,
+                vision_inputs,
+                text_encoder_layer=text_encoder_layer,
+                device=device,
+                dtype=dtype,
+            )
+            metadata[0] = tuple(prompt_embeds.shape)
+
+        torch.distributed.broadcast_object_list(
+            metadata,
+            src=source_rank,
+            group=world_group.cpu_group,
+        )
+        if world_group.rank != source_rank:
+            prompt_embeds = torch.empty(
+                metadata[0],
+                dtype=dtype,
+                device=device,
+            )
+
+        torch.distributed.broadcast(
+            prompt_embeds,
+            src=source_rank,
+            group=world_group.device_group,
+        )
+        return prompt_embeds
+
+    encoders.get_qwen3vl_prompt_embeds = distributed_get_prompt_embeds
+    encoders._xfuser_broadcast_patched = True
+
+
+class MiniMaxH3DiffusionOutput(DiffusionOutput):
+    def __init__(
+        self,
+        videos,
+        audio,
+        audio_sample_rate: int,
+        pipe_args,
+    ) -> None:
+        super().__init__(videos=videos, pipe_args=pipe_args)
+        self.audio = audio
+        self.audio_sample_rate = audio_sample_rate
+
+
+@register_model("MiniMaxAI/MiniMax-H3")
+@register_model("MiniMax-H3")
+class xFuserMiniMaxH3Model(xFuserModel):
+    # Native MiniMax-H3 is on Diffusers main from f53d552, but not in a release yet.
+    min_diffusers_version = DIFFUSERS_FROM_SOURCE
+
+    default_input_values = DefaultInputValues(
+        height=768,
+        width=1344,
+        num_frames=124,
+        num_inference_steps=50,
+    )
+
+    settings = ModelSettings(
+        model_name="MiniMaxAI/MiniMax-H3",
+        output_name="minimax_h3",
+        model_output_type="video",
+        fps=24,
+        resolution_divisor=32,
+        fp8_gemm_module_list=["transformer.transformer_blocks"],
+        fp8_gemm_include_suffixes=("attn.to_qkv", "ff.net.0.proj"),
+        fp4_gemm_module_list=["transformer.transformer_blocks"],
+        fp8_precision_override_suffixes=(
+            "attn.to_out.0",
+            "ff.net.2",
+            "adaln_proj.linear",
+        ),
+        fsdp_strategy={
+            "transformer": {
+                "wrap_attrs": ["transformer_blocks"],
+                "dtype": torch.bfloat16,
+            },
+        },
+        valid_tasks=["t2va", "i2va", "l2va", "fl2va"],
+    )
+
+    capabilities = ModelCapabilities(
+        ulysses_degree=True,
+        ring_degree=False,
+        data_parallel_degree=False,
+        text_encoder_tp_degree=True,
+        use_cfg_parallel=False,
+        use_parallel_vae=False,
+        fully_shard_degree=True,
+        use_fp8_gemms=True,
+        use_fp4_gemms=True,
+        enable_slicing=False,
+        enable_tiling=False,
+    )
+    _transformer_component_name = "transformer"
+
+    def _get_runtime_state_pipeline(self):
+        if self._transformer_component_name == "transformer":
+            return self.pipe
+        return SimpleNamespace(
+            transformer=getattr(self.pipe, self._transformer_component_name)
+        )
+
+    def _validate_config(self, config) -> None:
+        if config.task is None:
+            if self.settings.valid_tasks == ["ref2va"]:
+                config.task = "ref2va"
+            elif len(config.input_images) == 0:
+                config.task = "t2va"
+            elif len(config.input_images) == 1:
+                config.task = "i2va"
+            else:
+                config.task = "fl2va"
+        super()._validate_config(config)
+        backend = _parse_attention_backend(
+            config.attention_backend,
+            "attention backend",
+        )
+        if backend is not None and backend not in _SUPPORTED_ATTN_BACKENDS:
+            supported = ", ".join(sorted(item.name for item in _SUPPORTED_ATTN_BACKENDS))
+            raise ValueError(
+                f"MiniMax-H3 currently supports only packed varlen AITER attention. "
+                f"Supported backends: {supported}."
+            )
+        if backend == AttentionBackendType.AITER_FP8:
+            try:
+                from aiter import flash_attn_varlen_fp8_pertensor_func  # noqa: F401
+            except ImportError:
+                raise RuntimeError(
+                    "MiniMax-H3 FP8 attention requires AITER varlen FP8 flash attention."
+                ) from None
+
+        ulysses_degree = config.ulysses_degree or 1
+        if ulysses_degree not in _SUPPORTED_ULYSSES_DEGREES:
+            raise ValueError(
+                "MiniMax-H3 Ulysses degree must divide both 56 attention heads "
+                "and the 64-row packed-sequence alignment. Supported values: "
+                f"{sorted(_SUPPORTED_ULYSSES_DEGREES)}."
+            )
+        text_encoder_tp_degree = config.text_encoder_tp_degree or 1
+        if text_encoder_tp_degree not in (1, ulysses_degree):
+            raise ValueError(
+                "MiniMax-H3 text encoder TP reuses the Ulysses ranks, so "
+                "--text_encoder_tp_degree must be 1 or match --ulysses_degree."
+            )
+        if text_encoder_tp_degree > 1 and (
+            config.enable_model_cpu_offload or config.enable_sequential_cpu_offload
+        ):
+            raise ValueError(
+                "MiniMax-H3 text encoder TP is incompatible with CPU offloading."
+            )
+        if config.batch_size is not None or config.dataset_path is not None:
+            raise ValueError(
+                "MiniMax-H3 packs one request into one audiovisual sequence and "
+                "does not support runner batching or dataset batching."
+            )
+        if config.task is not None and config.task not in _SUPPORTED_TASKS:
+            raise ValueError(
+                f"Unsupported MiniMax-H3 task {config.task!r}. "
+                f"Supported tasks: {sorted(_SUPPORTED_TASKS)}."
+            )
+
+    def preprocess_args(self, input_args: dict) -> dict:
+        args = super().preprocess_args(input_args)
+        if isinstance(args.get("prompt"), list) and len(args["prompt"]) == 1:
+            args["prompt"] = args["prompt"][0]
+        return args
+
+    def _load_model(self):
+        from diffusers import ModularPipeline
+        from xfuser.model_executor.models.transformers.transformer_minimax_h3 import (
+            xFuserMiniMaxH3Transformer3DWrapper,
+        )
+
+        workflow = "t2va" if self.config.task == "t2va" else "fl2va"
+        log(f"Loading {self.settings.model_name} {workflow.upper()} components")
+        if self.config.text_encoder_tp_degree <= 1:
+            _patch_minimax_h3_text_encoder_broadcast()
+        pipe = ModularPipeline.from_pretrained(
+            self.settings.model_name,
+            workflow=workflow,
+        )
+        transformer = xFuserMiniMaxH3Transformer3DWrapper.from_pretrained(
+            self.settings.model_name,
+            subfolder="transformer",
+            dtype=torch.bfloat16,
+        )
+        pipe.update_components(transformer=transformer)
+        pipe.load_components(dtype=torch.bfloat16)
+        pipe.transformer.fuse_qkv_projections()
+        pipe.text_encoder.lm_head = None
+        self._parallelize_text_encoder(pipe.text_encoder)
+        return pipe
+
+    @staticmethod
+    def _build_text_encoder_tp_plan(num_layers: int):
+        from torch.distributed.tensor.parallel import (
+            ColwiseParallel,
+            RowwiseParallel,
+        )
+
+        plan = {}
+        for layer_index in range(num_layers):
+            prefix = f"layers.{layer_index}"
+            plan.update(
+                {
+                    f"{prefix}.self_attn.q_proj": ColwiseParallel(),
+                    f"{prefix}.self_attn.k_proj": ColwiseParallel(),
+                    f"{prefix}.self_attn.v_proj": ColwiseParallel(),
+                    f"{prefix}.self_attn.o_proj": RowwiseParallel(),
+                    f"{prefix}.mlp.gate_proj": ColwiseParallel(),
+                    f"{prefix}.mlp.up_proj": ColwiseParallel(),
+                    f"{prefix}.mlp.down_proj": RowwiseParallel(),
+                }
+            )
+        return plan
+
+    def _parallelize_text_encoder(self, text_encoder) -> None:
+        degree = self.config.text_encoder_tp_degree or 1
+        if degree <= 1:
+            return
+
+        from torch.distributed.device_mesh import DeviceMesh
+        from torch.distributed.tensor.parallel import parallelize_module
+
+        world_group = get_world_group()
+        if degree != world_group.world_size:
+            raise ValueError(
+                f"MiniMax-H3 text encoder TP degree {degree} must match world size "
+                f"{world_group.world_size}."
+            )
+
+        device = torch.device(f"cuda:{world_group.local_rank}")
+        language_model = text_encoder.model.language_model
+        text_encoder.to(device)
+        mesh = DeviceMesh.from_group(world_group.device_group, "cuda")
+        parallelize_module(
+            language_model,
+            device_mesh=mesh,
+            parallelize_plan=self._build_text_encoder_tp_plan(
+                len(language_model.layers)
+            ),
+            src_data_rank=None,
+        )
+        text_encoder._xfuser_tp_mesh = mesh
+        log(f"Sharded MiniMax-H3 Qwen3-VL text encoder with TP{degree}.")
+
+    def _run_pipe(self, input_args: dict) -> DiffusionOutput:
+        prompt = input_args["prompt"]
+        if isinstance(prompt, list):
+            if len(prompt) != 1:
+                raise ValueError("MiniMax-H3 currently supports one prompt per request.")
+            prompt = prompt[0]
+
+        pipe_args = {
+            "prompt": prompt,
+            "height": input_args["height"],
+            "width": input_args["width"],
+            "num_frames": input_args["num_frames"],
+            "num_inference_steps": input_args["num_inference_steps"],
+            "generator": torch.Generator(device="cuda").manual_seed(
+                input_args["seed"]
+            ),
+            "output_type": "np",
+        }
+        images = input_args.get("input_images") or []
+        task = input_args.get("task")
+        if task is None:
+            task = "t2va" if not images else ("i2va" if len(images) == 1 else "fl2va")
+        if task == "t2va":
+            if images:
+                raise ValueError("T2VA does not accept input images.")
+        elif task == "i2va":
+            if len(images) != 1:
+                raise ValueError("I2VA requires exactly one first-frame image.")
+            pipe_args["image"] = images[0]
+        elif task == "l2va":
+            if len(images) != 1:
+                raise ValueError("L2VA requires exactly one last-frame image.")
+            pipe_args["last_image"] = images[0]
+        else:
+            if len(images) != 2:
+                raise ValueError(
+                    "FL2VA requires two input images: first frame followed by last frame."
+                )
+            pipe_args["image"] = images[0]
+            pipe_args["last_image"] = images[1]
+
+        state = self.pipe(
+            **pipe_args,
+        )
+        videos = state.get("videos")
+        audio = state.get("audio")
+        sampling_rate = int(state.get("sampling_rate"))
+        return MiniMaxH3DiffusionOutput(
+            videos=videos,
+            audio=audio,
+            audio_sample_rate=sampling_rate,
+            pipe_args=input_args,
+        )
+
+    def _validate_args(self, input_args: dict) -> None:
+        super()._validate_args(input_args)
+        prompt = input_args["prompt"]
+        if isinstance(prompt, list) and len(prompt) != 1:
+            raise ValueError("MiniMax-H3 currently supports one prompt per request.")
+        if input_args.get("negative_prompt") is not None:
+            raise ValueError(
+                "MiniMax-H3 is guidance-distilled and does not accept a negative prompt."
+            )
+
+    def _compile_model(self, input_args: dict) -> None:
+        if self.config.fully_shard_degree > 1:
+            super()._compile_model(input_args)
+            return
+        self._enable_compute_comm_overlap()
+        transformer = getattr(self.pipe, self._transformer_component_name)
+        transformer.forward = torch.compile(
+            transformer.forward,
+            mode=self._get_compile_mode(),
+            fullgraph=True,
+        )
+        compile_args = copy.deepcopy(input_args)
+        compile_args["num_inference_steps"] = 3
+        self._run_timed_pipe(compile_args)
+
+    def _run_warmup_calls(self, input_args: dict) -> None:
+        if not self.config.warmup_calls:
+            return
+        log(
+            f"Warming up MiniMax-H3 with {self.config.warmup_calls} "
+            "three-point calls..."
+        )
+        warmup_args = copy.deepcopy(input_args)
+        warmup_args["num_inference_steps"] = 3
+        for iteration in range(self.config.warmup_calls):
+            log(f"Warmup iteration {iteration + 1}/{self.config.warmup_calls}")
+            self._run_timed_pipe(warmup_args)
+        log("Warmup complete.")
+
+    @staticmethod
+    def _video_to_uint8(video) -> torch.Tensor:
+        if isinstance(video, torch.Tensor):
+            if video.dtype == torch.uint8:
+                return video.cpu()
+            video = video.detach().float().cpu().numpy()
+        if isinstance(video, list):
+            video = np.stack([np.asarray(frame) for frame in video])
+        if video.dtype != np.uint8:
+            video = (video * 255.0).round().clip(0, 255).astype("uint8")
+        return torch.from_numpy(video)
+
+    def save_output(self, output: DiffusionOutput) -> None:
+        audio = output.audio
+        if isinstance(audio, list):
+            audio_items = audio
+        elif isinstance(audio, torch.Tensor) and audio.ndim >= 3:
+            audio_items = list(audio)
+        else:
+            audio_items = [audio]
+
+        for index, (video, pipe_args) in enumerate(output.get_outputs()):
+            video = self._video_to_uint8(video)
+            audio_item = audio_items[min(index, len(audio_items) - 1)]
+            if not isinstance(audio_item, torch.Tensor):
+                audio_item = torch.as_tensor(audio_item)
+            output_name = self.get_output_name(pipe_args)
+            output_path = f"{self.config.output_directory}/{output_name}_{index}.mp4"
+            encode_video_with_audio(
+                video,
+                audio=audio_item.float().cpu(),
+                audio_sample_rate=output.audio_sample_rate,
+                fps=self.settings.fps,
+                output_path=output_path,
+            )
+            log(f"Output video with audio saved to {output_path}")
+
+
+@register_model("MiniMax-H3-Ref2VA")
+class xFuserMiniMaxH3Ref2VAModel(xFuserMiniMaxH3Model):
+    _transformer_component_name = "transformer_ref"
+    settings = ModelSettings(
+        model_name="MiniMaxAI/MiniMax-H3",
+        output_name="minimax_h3_ref2va",
+        model_output_type="video",
+        fps=24,
+        resolution_divisor=32,
+        fp8_gemm_module_list=["transformer_ref.transformer_blocks"],
+        fp8_gemm_include_suffixes=("attn.to_qkv", "ff.net.0.proj"),
+        fp4_gemm_module_list=["transformer_ref.transformer_blocks"],
+        fp8_precision_override_suffixes=(
+            "attn.to_out.0",
+            "ff.net.2",
+            "adaln_proj.linear",
+        ),
+        fsdp_strategy={
+            "transformer_ref": {
+                "wrap_attrs": ["transformer_blocks"],
+                "dtype": torch.bfloat16,
+            },
+        },
+        valid_tasks=["ref2va"],
+    )
+
+    def _load_model(self):
+        from diffusers import ModularPipeline
+        from xfuser.model_executor.models.transformers.transformer_minimax_h3 import (
+            xFuserMiniMaxH3Transformer3DWrapper,
+        )
+
+        log(f"Loading {self.settings.model_name} Ref2VA components")
+        if self.config.text_encoder_tp_degree <= 1:
+            _patch_minimax_h3_text_encoder_broadcast()
+        pipe = ModularPipeline.from_pretrained(
+            self.settings.model_name,
+            workflow="ref2va",
+        )
+        transformer = xFuserMiniMaxH3Transformer3DWrapper.from_pretrained(
+            self.settings.model_name,
+            subfolder="transformer_ref",
+            dtype=torch.bfloat16,
+        )
+        pipe.update_components(transformer_ref=transformer)
+        pipe.load_components(dtype=torch.bfloat16)
+        pipe.transformer_ref.fuse_qkv_projections()
+        pipe.text_encoder.lm_head = None
+        self._parallelize_text_encoder(pipe.text_encoder)
+        return pipe
+
+    def _run_pipe(self, input_args: dict) -> DiffusionOutput:
+        from diffusers.modular_pipelines.minimax_h3 import MiniMaxH3ImageReference
+
+        prompt = input_args["prompt"]
+        if isinstance(prompt, list):
+            if len(prompt) != 1:
+                raise ValueError("MiniMax-H3 Ref2VA supports one prompt per request.")
+            prompt = prompt[0]
+
+        images = input_args.get("input_images") or []
+        if not images:
+            raise ValueError(
+                "MiniMax-H3 Ref2VA currently requires at least one image reference."
+            )
+        references = [MiniMaxH3ImageReference(image=image) for image in images]
+        state = self.pipe(
+            prompt=prompt,
+            references=references,
+            height=input_args["height"],
+            width=input_args["width"],
+            num_frames=input_args["num_frames"],
+            num_inference_steps=input_args["num_inference_steps"],
+            generator=torch.Generator(device="cuda").manual_seed(
+                input_args["seed"]
+            ),
+            output_type="np",
+        )
+        return MiniMaxH3DiffusionOutput(
+            videos=state.get("videos"),
+            audio=state.get("audio"),
+            audio_sample_rate=int(state.get("sampling_rate")),
+            pipe_args=input_args,
+        )
+
+    def _validate_args(self, input_args: dict) -> None:
+        xFuserModel._validate_args(self, input_args)
+        if input_args.get("negative_prompt") is not None:
+            raise ValueError(
+                "MiniMax-H3 is guidance-distilled and does not accept a negative prompt."
+            )
+        if not input_args.get("input_images"):
+            raise ValueError(
+                "MiniMax-H3 Ref2VA currently requires image references through "
+                "--input_images."
+            )

--- a/xfuser/model_executor/models/transformers/transformer_minimax_h3.py
+++ b/xfuser/model_executor/models/transformers/transformer_minimax_h3.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from diffusers.models.transformers.transformer_minimax_h3 import (
+    MINIMAX_H3_MODALITY_NUM,
+    MiniMaxH3AttnProcessor,
+    MiniMaxH3Transformer3DModel,
+    MiniMaxH3TransformerOutput,
+    _apply_rotary_emb,
+)
+from diffusers.utils import apply_lora_scale
+
+from xfuser.core.distributed import (
+    get_sp_group,
+    get_ulysses_parallel_rank,
+    get_ulysses_parallel_world_size,
+)
+from xfuser.model_executor.layers.usp import USP, attention
+
+
+MINIMAX_H3_PACKED_SEQUENCE_ALIGNMENT = 64
+
+
+class xFuserMiniMaxH3AttnProcessor(MiniMaxH3AttnProcessor):
+    def __init__(
+        self,
+        use_ulysses_parallel_attention: bool,
+        attention_kwargs: dict[str, Any] | None = None,
+        backend=None,
+    ) -> None:
+        super().__init__()
+        self.use_ulysses_parallel_attention = use_ulysses_parallel_attention
+        self.attention_kwargs = attention_kwargs
+        self.backend = backend
+
+    def __call__(
+        self,
+        attn,
+        hidden_states: torch.Tensor,
+        rotary_emb: tuple[torch.Tensor, torch.Tensor] | None = None,
+        attention_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if attention_mask is not None:
+            raise ValueError(
+                "MiniMax-H3 xDiT attention expects padding to be represented by "
+                "the varlen metadata prepared by the transformer wrapper."
+            )
+
+        if attn.fused_projections:
+            query, key, value = attn.to_qkv(hidden_states).chunk(3, dim=-1)
+        else:
+            query = attn.to_q(hidden_states)
+            key = attn.to_k(hidden_states)
+            value = attn.to_v(hidden_states)
+
+        query = query.unflatten(-1, (attn.heads, -1))
+        key = key.unflatten(-1, (attn.heads, -1))
+        value = value.unflatten(-1, (attn.heads, -1))
+
+        query = attn.norm_q(query)
+        key = attn.norm_k(key)
+
+        if rotary_emb is not None:
+            query = _apply_rotary_emb(query, *rotary_emb)
+            key = _apply_rotary_emb(key, *rotary_emb)
+
+        use_ulysses = (
+            self.use_ulysses_parallel_attention
+            and get_ulysses_parallel_world_size() > 1
+        )
+        attention_function = USP if use_ulysses else attention
+        attention_args = {
+            "dropout_p": 0.0,
+            "is_causal": False,
+            "attention_kwargs": self.attention_kwargs,
+            "head_balance_layer": attn,
+            "backend": self.backend,
+        }
+        if use_ulysses:
+            attention_args["combine_qkv_a2a"] = True
+        hidden_states = attention_function(
+            query.transpose(1, 2),
+            key.transpose(1, 2),
+            value.transpose(1, 2),
+            **attention_args,
+        ).transpose(1, 2)
+
+        hidden_states = hidden_states.flatten(2, 3).type_as(query)
+        hidden_states = attn.to_out[0](hidden_states)
+        hidden_states = attn.to_out[1](hidden_states)
+        return hidden_states
+
+
+class xFuserMiniMaxH3Transformer3DWrapper(MiniMaxH3Transformer3DModel):
+    def __init__(self, *args, attention_backend=None, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._usp_attention_kwargs: dict[str, Any] = {}
+
+        for block in self.token_refiner.refiner_blocks:
+            block.attn.set_processor(
+                xFuserMiniMaxH3AttnProcessor(
+                    use_ulysses_parallel_attention=False,
+                    backend=attention_backend,
+                )
+            )
+
+        for block in self.transformer_blocks:
+            block.attn.set_processor(
+                xFuserMiniMaxH3AttnProcessor(
+                    use_ulysses_parallel_attention=True,
+                    attention_kwargs=self._usp_attention_kwargs,
+                    backend=attention_backend,
+                )
+            )
+
+    @staticmethod
+    def _pad_rows(
+        hidden_states: torch.Tensor,
+        timestep_indices: torch.Tensor,
+        token_tags: torch.Tensor,
+        position_ids: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int]:
+        sequence_length = position_ids.shape[0]
+        padded_length = (
+            (sequence_length + MINIMAX_H3_PACKED_SEQUENCE_ALIGNMENT - 1)
+            // MINIMAX_H3_PACKED_SEQUENCE_ALIGNMENT
+            * MINIMAX_H3_PACKED_SEQUENCE_ALIGNMENT
+        )
+        pad_amount = padded_length - sequence_length
+        if pad_amount == 0:
+            return hidden_states, timestep_indices, token_tags, position_ids, 0
+
+        hidden_states = torch.cat(
+            (
+                hidden_states,
+                hidden_states.new_zeros(
+                    hidden_states.shape[0],
+                    pad_amount,
+                    hidden_states.shape[-1],
+                ),
+            ),
+            dim=1,
+        )
+        timestep_indices = torch.cat(
+            (
+                timestep_indices,
+                timestep_indices.new_zeros(pad_amount),
+            )
+        )
+        token_tags = torch.cat(
+            (
+                token_tags,
+                token_tags.new_full((pad_amount,), -1),
+            )
+        )
+        position_ids = torch.cat(
+            (
+                position_ids,
+                position_ids.new_zeros(pad_amount, position_ids.shape[-1]),
+            ),
+            dim=0,
+        )
+        return hidden_states, timestep_indices, token_tags, position_ids, pad_amount
+
+    @apply_lora_scale("attention_kwargs")
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        audio_hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        timestep: torch.Tensor,
+        timestep_indices: torch.Tensor,
+        token_tags: torch.Tensor,
+        position_ids: torch.Tensor,
+        video_indices: torch.Tensor,
+        audio_indices: torch.Tensor,
+        text_indices: torch.Tensor,
+        attention_kwargs: dict[str, Any] | None = None,
+        return_dict: bool = True,
+    ) -> MiniMaxH3TransformerOutput | tuple[torch.Tensor, torch.Tensor]:
+        if position_ids.ndim != 2 or position_ids.shape[-1] != 3:
+            raise ValueError(
+                f"`position_ids` must be a `(seq_len, 3)` tensor, got {list(position_ids.shape)}."
+            )
+        sequence_length = position_ids.shape[0]
+        if token_tags.shape != (sequence_length,) or timestep_indices.shape != (
+            sequence_length,
+        ):
+            raise ValueError(
+                "`token_tags` and `timestep_indices` must both be `(seq_len,)` "
+                f"tensors matching `position_ids`, got {list(token_tags.shape)} "
+                f"and {list(timestep_indices.shape)} for seq_len={sequence_length}."
+            )
+
+        video_embeds = self.proj_in(hidden_states.to(self.proj_in.weight.dtype))
+        audio_embeds = self.audio_proj_in(
+            audio_hidden_states.to(self.audio_proj_in.weight.dtype)
+        )
+        text_embeds = self.context_embedder(
+            encoder_hidden_states.to(self.context_embedder.weight.dtype)
+        )
+        text_embeds = self.token_refiner(text_embeds)
+
+        packed_hidden_states = text_embeds.new_zeros(
+            (text_embeds.shape[0], sequence_length, text_embeds.shape[-1])
+        )
+        packed_hidden_states = packed_hidden_states.index_copy(
+            1, text_indices, text_embeds
+        )
+        packed_hidden_states = packed_hidden_states.index_copy(
+            1, video_indices, video_embeds.to(text_embeds.dtype)
+        )
+        packed_hidden_states = packed_hidden_states.index_copy(
+            1, audio_indices, audio_embeds.to(text_embeds.dtype)
+        )
+
+        temb = self.time_proj(timestep)
+        temb = self.time_embedder(
+            temb.to(self.time_embedder.linear_1.weight.dtype)
+        )
+
+        (
+            packed_hidden_states,
+            padded_timestep_indices,
+            padded_token_tags,
+            padded_position_ids,
+            pad_amount,
+        ) = self._pad_rows(
+            packed_hidden_states,
+            timestep_indices,
+            token_tags,
+            position_ids,
+        )
+
+        padded_length = padded_position_ids.shape[0]
+        ulysses_world_size = get_ulysses_parallel_world_size()
+        ulysses_rank = get_ulysses_parallel_rank()
+        if padded_length % ulysses_world_size:
+            raise ValueError(
+                f"MiniMax-H3 padded sequence length {padded_length} must be "
+                f"divisible by Ulysses degree {ulysses_world_size}."
+            )
+
+        local_sequence_length = padded_length // ulysses_world_size
+        local_start = ulysses_rank * local_sequence_length
+        local_stop = local_start + local_sequence_length
+
+        rotary_emb = self.rope(padded_position_ids)
+        rotary_emb = (
+            rotary_emb[0][local_start:local_stop],
+            rotary_emb[1][local_start:local_stop],
+        )
+
+        packed_hidden_states = packed_hidden_states[:, local_start:local_stop]
+        local_timestep_indices = padded_timestep_indices[local_start:local_stop]
+        local_token_tags = padded_token_tags[local_start:local_stop]
+        adaln_indices = (
+            local_timestep_indices * MINIMAX_H3_MODALITY_NUM
+            + local_token_tags.clamp(min=0)
+        )
+
+        if pad_amount:
+            indices_k = torch.arange(
+                sequence_length,
+                dtype=torch.long,
+                device=packed_hidden_states.device,
+            )
+            self._usp_attention_kwargs.update(
+                {
+                    "indices_k": indices_k,
+                    "cu_seqlens_k": torch.tensor(
+                        [0, sequence_length],
+                        dtype=torch.int32,
+                        device=packed_hidden_states.device,
+                    ),
+                    "max_seqlen_k": sequence_length,
+                }
+            )
+        else:
+            self._usp_attention_kwargs.pop("indices_k", None)
+            self._usp_attention_kwargs.pop("cu_seqlens_k", None)
+            self._usp_attention_kwargs.pop("max_seqlen_k", None)
+
+        for block in self.transformer_blocks:
+            if torch.is_grad_enabled() and self.gradient_checkpointing:
+                packed_hidden_states = self._gradient_checkpointing_func(
+                    block,
+                    packed_hidden_states,
+                    temb,
+                    adaln_indices,
+                    rotary_emb,
+                    None,
+                )
+            else:
+                packed_hidden_states = block(
+                    packed_hidden_states,
+                    temb,
+                    adaln_indices,
+                    rotary_emb,
+                    None,
+                )
+
+        packed_hidden_states = self.norm_out(
+            packed_hidden_states,
+            temb,
+            local_timestep_indices,
+        ).to(self.proj_out.weight.dtype)
+        local_video_output = self.proj_out(packed_hidden_states)
+        local_audio_output = self.audio_proj_out(packed_hidden_states)
+
+        if ulysses_world_size > 1:
+            video_width = local_video_output.shape[-1]
+            packed_output = get_sp_group().all_gather(
+                torch.cat((local_video_output, local_audio_output), dim=-1),
+                dim=1,
+            )
+            local_video_output, local_audio_output = packed_output.split(
+                (video_width, packed_output.shape[-1] - video_width),
+                dim=-1,
+            )
+
+        local_video_output = local_video_output[:, :sequence_length]
+        local_audio_output = local_audio_output[:, :sequence_length]
+        video_output = local_video_output.index_select(1, video_indices)
+        audio_output = local_audio_output.index_select(1, audio_indices)
+
+        if not return_dict:
+            return (video_output, audio_output)
+        return MiniMaxH3TransformerOutput(
+            sample=video_output,
+            audio_sample=audio_output,
+        )


### PR DESCRIPTION
# Add MiniMax-H3 Audio-Video Generation Support

## Summary

Adds xDiT support for MiniMax-H3 joint video and stereo-audio generation.

The integration supports FL2VA T2VA, first-frame I2VA, last-frame L2VA, first+last-frame FL2VA, and Ref2VA image references. It includes Ulysses, same-rank FSDP, Qwen3-VL tensor parallelism, fullgraph `torch.compile`, AITER BF16/FP8 attention, selective FP8/FP4 GEMMs, and quality-controlled audio-video encoding.

## Features

- **Generation modes:** T2VA, I2VA, L2VA, FL2VA, and Ref2VA image references
- **Joint output:** 124-frame video at 24 fps with synchronized 32 kHz stereo audio
- **Sequence parallelism:** Ulysses degrees 1, 2, 4, and 8
- **Padding correctness:** packed-varlen attention excludes alignment padding
- **FSDP:** Ulysses and FSDP can reuse the same ranks
- **Qwen3-VL TP:** text encoder TP reuses Ulysses ranks and saves 50.86 GiB per GPU at TP8
- **Attention:** AITER BF16 and gfx950 FP8 ASM attention
- **GEMMs:** selective torchao FP8 and AITER MXFP4 policies
- **Compilation:** full transformer `torch.compile(fullgraph=True)`
- **Encoding:** shared CRF-controlled H.264 + AAC encoder for MiniMax-H3 and LTX

## Usage

```bash
# Compiled single-GPU BF16 baseline
python -m xfuser.cli \
  --model MiniMaxAI/MiniMax-H3 \
  --prompt "A red fox trots through a snowy pine forest." \
  --height 544 --width 960 --num_frames 124 \
  --num_inference_steps 50 \
  --attention_backend AITER \
  --use_torch_compile

# U8 + Qwen3-VL TP8 + selective FP8 GEMMs + FP8 attention
python -m xfuser.cli \
  --model MiniMaxAI/MiniMax-H3 \
  --prompt "A red fox trots through a snowy pine forest." \
  --height 544 --width 960 --num_frames 124 \
  --num_inference_steps 50 \
  --ulysses_degree 8 --text_encoder_tp_degree 8 \
  --attention_backend AITER_FP8 --use_fp8_gemms \
  --use_torch_compile

# Fastest validated configuration: selective FP4 GEMMs + FP8 attention
python -m xfuser.cli \
  --model MiniMaxAI/MiniMax-H3 \
  --prompt "A red fox trots through a snowy pine forest." \
  --height 544 --width 960 --num_frames 124 \
  --num_inference_steps 50 \
  --ulysses_degree 8 --text_encoder_tp_degree 8 \
  --attention_backend AITER_FP8 --use_fp4_gemms \
  --use_torch_compile

# First-frame I2VA
python -m xfuser.cli \
  --model MiniMaxAI/MiniMax-H3 \
  --prompt "The subject begins to move." \
  --input_images first_frame.png

# Last-frame L2VA
python -m xfuser.cli \
  --model MiniMaxAI/MiniMax-H3 \
  --prompt "The scene resolves into the supplied image." \
  --task l2va --input_images last_frame.png

# First+last-frame FL2VA
python -m xfuser.cli \
  --model MiniMaxAI/MiniMax-H3 \
  --prompt "A continuous transition between both frames." \
  --input_images first_frame.png last_frame.png

# Ref2VA with ordered image references
python -m xfuser.cli \
  --model MiniMax-H3-Ref2VA \
  --prompt "Use the referenced character and visual style." \
  --input_images reference_1.png reference_2.png
```

`--text_encoder_tp_degree` reuses the model ranks and must be 1 or match the Ulysses degree. It does not multiply the process count.



https://github.com/user-attachments/assets/87163de1-58a2-4ea3-91fa-5fa8ada103df




## Performance

Tested on MI355X with:

- 960x544 output
- 124 frames
- 50 inference steps
- seed 42
- `torch.compile(fullgraph=True)`
- one three-step warmup
- median of measured iterations
- video/audio decode included
- MP4 encoding excluded

| Configuration | Median | Speedup vs U1 |
|---|---:|---:|
| U1 BF16 | 61.56s | 1.00x |
| U8 + Qwen TP8, BF16 | 13.45s | 4.58x |
| U8 + Qwen TP8, selective FP8 GEMMs | 12.26s | 5.02x |
| U8 + Qwen TP8, FP8 attention | 12.73s | 4.84x |
| U8 + Qwen TP8, selective FP8 GEMMs + FP8 attention | 11.48s | 5.36x |
| U8 + Qwen TP8, selective FP4 GEMMs | 11.33s | 5.43x |
| U8 + Qwen TP8, selective FP4 GEMMs + FP8 attention | **10.54s** | **5.84x** |

## Precision Policies

### Selective FP8 GEMMs

FP8:

- fused attention QKV
- fused SwiGLU gate/up

BF16:

- attention output
- MLP down
- AdaLN projection

### Selective FP4 GEMMs

FP4:

- fused attention QKV
- fused SwiGLU gate/up

FP8:

- attention output
- MLP down
- AdaLN projection

Full FP4 was faster but produced an unacceptable trajectory shift, so it is not used as the model default.

## Implementation Notes

- MiniMax-H3 packs text, video, and audio rows into one audiovisual sequence.
- The wrapper pads the packed sequence to 64 rows and passes live-key metadata to AITER varlen attention.
- Ulysses uses combined QKV all-to-all communication.
- FP8 attention dispatches the gfx950  `fmha_fwd_hd128_fp8_group_gfx950` ASM kernel.
- FP8 quantization and the AITER ASM call use `torch.library.custom_op`  boundaries to preserve FP8 dtypes under fullgraph compilation.
- Qwen3-VL TP uses replicated embeddings/norms, column-sharded QKV and gate/up,  and row-sharded attention output and MLP down projections.
- The unused Qwen language-model head is removed.
- Rank-0 text encoding with embedding broadcast remains available when text  encoder TP is disabled.

## Validation

- Tiny Diffusers transformer and xDiT wrapper match at U1.
- Fused QKV matches split Q/K/V output.
- U2 and U8 aligned and padded transformer outputs match the reference.
- Real padded FP8 varlen attention is finite and closely matches BF16.
- Fullgraph compile passes with packed BF16 and FP8 attention.
- Qwen3-VL TP8 output matches rank-0 encoding closely.
- FL2VA, Ref2VA, FP8 GEMM, FP4 GEMM, and FP8 attention examples were generated with synchronized audio.


## Known Limitations

- Ref2VA video and audio reference CLI inputs are not exposed yet.
- Video and audio VAE encoding/decoding are replicated; parallel VAE paths are not implemented.
- Qwen3-VL vision-tower and embedding parameters remain replicated under text encoder TP.
- PipeFusion is not implemented for MiniMax-H3.
