### PR TITLE
Remove unused numba from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ if __name__ == "__main__":
             "diffusers>=0.33.0",
             "av", # For LTX-2 model
             "peft", # For LTX-2 LoRA
-            "numba",
             "numpy",
         ],
         extras_require={


### PR DESCRIPTION
# What?
Remove install dependency on `numba`.

# Why?

numba was added in #700 (Sparge attention) for an early `@njit` Gilbert curve prototype. Then, `gilbert.py` was rewritten in PyTorch before merging the PR and no longer imports numba. Keeping numba in install_requires pulls llvmlite and conflicts with common stacks that pin numpy>=2.5 (numba wheels require numpy<2.5).

[Inspecting the code base in main today](https://github.com/search?q=repo%3Axdit-project%2FxDiT+numba&type=code), there is no `import numba` statements or other lines of code referencing numba, so the dependency is dead weight and should be removed.