### PR TITLE
Keep AITER FP8 attention as a plain function for torch.compile

### DIFF
--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -862,14 +862,7 @@ def _quantize_aiter_fp8_inputs(query, key, value):
     )
 
 
-@torch.library.custom_op("xfuser::aiter_fp8_attention", mutates_args=())
-def _aiter_fp8_attention_kernel(
-    query: torch.Tensor,
-    key: torch.Tensor,
-    value: torch.Tensor,
-    softmax_scale: float,
-    is_causal: bool,
-) -> torch.Tensor:
+def _aiter_fp8_dense_attention(query, key, value, softmax_scale, is_causal):
     quant_q, quant_k, quant_v, q_descale, k_descale, v_descale = (
         _quantize_aiter_fp8_inputs(query, key, value)
     )
@@ -888,17 +881,6 @@ def _aiter_fp8_attention_kernel(
         softmax_scale=softmax_scale,
         **kwargs,
     )
-
-
-@_aiter_fp8_attention_kernel.register_fake
-def _aiter_fp8_attention_kernel_fake(
-    query,
-    key,
-    value,
-    softmax_scale,
-    is_causal,
-):
-    return torch.empty_like(query)
 
 
 @torch.library.custom_op("xfuser::aiter_fp8_varlen_attention", mutates_args=())
@@ -998,7 +980,7 @@ def _aiter_fp8_attn_call(query, key, value, dropout_p, is_causal, attention_kwar
             is_causal,
         ).reshape(batch_size, sequence_length, num_heads, head_dim)
     else:
-        output = _aiter_fp8_attention_kernel(
+        output = _aiter_fp8_dense_attention(
             query,
             key,
             value,


### PR DESCRIPTION
# What?
PR #747 added support for Minimax-H3. It also unified how the FP8 attention is called. It created a new custom op for the FP8 kernel, which includes both the quantization and calling the AITER kernel. This PR changes that op to be a standard python function instead.

# Why?
As the quant + kernel were in a custom op, they were opaque for torch compile. This was problematic, as torch couldn't fuse the kernels, causing a few % e2e regression when using FP8 attention.

# How?

Drops the custom op entirely and keeps it as native python function. Torch.compile can now see the calls and properly fuse the kernels. This PR only affects the non-varlen path.

# Tests

### Wan 2.2 with FP8 attention (before this PR)

https://github.com/user-attachments/assets/6f192991-5640-4fb7-bc9d-42bda17cf19c


e2e: 36.07s

## Wan 2.2 with FP8 attention (this PR)

https://github.com/user-attachments/assets/243495b0-cdfe-437f-a1a2-f5287707bbcb

e2e: 33.5s


MiniMax-H3 also tested; works still as intended.