### PR TITLE
FP8 Ulysses All-to-All Communication

### DIFF
--- a/tests/test_fp8_comms_state.py
+++ b/tests/test_fp8_comms_state.py
@@ -1,0 +1,184 @@
+import pytest
+import torch
+import torch.nn as nn
+
+from xfuser.core.distributed.attention_backend import (
+    AttentionBackendType,
+    FP8_HADAMARD_MATRIX,
+    rotate_qk_for_fp8_comms,
+)
+from xfuser.core.distributed.fp8_comms import Fp8CommsState
+
+# FP8_HADAMARD_MATRIX is keyed per device and only holds cuda entries on a GPU
+# host (no cpu key), so rotation tests must use whatever device it was built for.
+_HB_DEVICE = next(iter(FP8_HADAMARD_MATRIX))
+
+
+class _FakeBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.attn1 = nn.Module()
+
+
+class _FakeTransformer(nn.Module):
+    def __init__(self, num_layers: int = 3):
+        super().__init__()
+        self.blocks = nn.ModuleList([_FakeBlock() for _ in range(num_layers)])
+        for i, block in enumerate(self.blocks):
+            for name in ("fp8_q_scale", "fp8_k_scale", "fp8_v_scale", "fp8_o_scale"):
+                block.attn1.register_buffer(name, torch.ones(1, dtype=torch.float32))
+            block.attn1.register_buffer(
+                "fp8_comms_layer_idx", torch.tensor([i], dtype=torch.long)
+            )
+
+
+def test_per_layer_running_max_and_scatter():
+    fp8 = Fp8CommsState()
+    model = _FakeTransformer(num_layers=2)
+    fp8.register_model(model, num_layers=2)
+
+    layer_idx = torch.tensor([0], dtype=torch.long)
+    q = torch.tensor([[[[2.0, -1.0]]]])
+    k = torch.tensor([[[[4.0]]]])
+    v = torch.tensor([[[[0.5]]]])
+    fp8.update_running_max(model, layer_idx, q, k, v)
+
+    layer_idx_1 = torch.tensor([1], dtype=torch.long)
+    fp8.update_running_max(model, layer_idx_1, q * 3, k * 2, v * 4)
+
+    model_state = fp8.get_model_state(model)
+    assert model_state.q_running_max[0].item() == 2.0
+    assert model_state.q_running_max[1].item() == 6.0
+    assert model_state.k_running_max[1].item() == 8.0
+    assert model_state.v_running_max[1].item() == 2.0
+
+    fp8._scatter_scales_to_model(
+        model,
+        model_state.q_running_max / 100.0,
+        model_state.k_running_max / 100.0,
+        model_state.v_running_max / 100.0,
+        model_state.o_running_max / 100.0,
+    )
+
+    assert model.blocks[0].attn1.fp8_q_scale.item() == pytest.approx(0.02)
+    assert model.blocks[1].attn1.fp8_k_scale.item() == pytest.approx(0.08)
+
+
+def test_fixed_scale_broadcast():
+    fp8 = Fp8CommsState(fixed_scale=0.5)
+    model = _FakeTransformer(num_layers=2)
+    fp8.register_model(model, num_layers=2)
+
+    assert fp8.get_model_state(model).synced is True
+    assert model.blocks[0].attn1.fp8_q_scale.item() == 0.5
+    assert model.blocks[1].attn1.fp8_v_scale.item() == 0.5
+    assert model.blocks[1].attn1.fp8_o_scale.item() == 0.5
+
+
+def test_unexercised_model_has_zero_running_max():
+    fp8 = Fp8CommsState()
+    model = _FakeTransformer(num_layers=1)
+    fp8.register_model(model, num_layers=1)
+
+    model_state = fp8.get_model_state(model)
+    assert model_state.synced is False
+    assert model_state.q_running_max.max() == 0
+
+
+def _outlier_qk(head_dim: int = 128, seq: int = 64, dtype=torch.bfloat16, device=_HB_DEVICE):
+    """Q/K with a per-channel outlier, the distribution the rotation exists to fix.
+
+    Seeded on CPU for determinism, then moved to ``device`` so the rotation can
+    index FP8_HADAMARD_MATRIX (which only has the host's real device as a key).
+    """
+    torch.manual_seed(0)
+    q = torch.randn(1, seq, 2, head_dim, dtype=dtype)
+    q[..., 7] *= 30
+    k = torch.randn(1, seq, 2, head_dim, dtype=dtype)
+    k[..., 19] *= 20
+    return q.to(device), k.to(device)
+
+
+def test_rotation_is_qk_preserving():
+    # Tolerances reflect the matrix being stored in bf16: rounding 1/sqrt(128) leaves
+    # R @ R.T off the identity by ~2e-4, so scores move by ~5e-4 relative.
+    q, k = _outlier_qk(dtype=torch.float32)
+    q_rot, k_rot = rotate_qk_for_fp8_comms(q, k, AttentionBackendType.AITER_FP8)
+
+    scores = torch.matmul(q, k.transpose(-1, -2))
+    scores_rot = torch.matmul(q_rot, k_rot.transpose(-1, -2))
+    torch.testing.assert_close(scores, scores_rot, rtol=5e-3, atol=5e-2)
+
+
+def test_rotation_shrinks_outlier_amax():
+    # The rotation only helps because it moves amax, which is exactly why the
+    # calibration has to measure the rotated tensor and not the input.
+    q, k = _outlier_qk()
+    q_rot, k_rot = rotate_qk_for_fp8_comms(q, k, AttentionBackendType.AITER_FP8)
+    assert q_rot.abs().amax() < q.abs().amax()
+    assert k_rot.abs().amax() < k.abs().amax()
+
+
+def test_rotation_is_a_noop_for_backends_that_do_not_rotate():
+    # Only AITER_FP8 rotates; any other backend returns the inputs untouched, so
+    # the head_dim never reaches the rotation and device does not matter here.
+    q, k = _outlier_qk(head_dim=8, seq=4, device="cpu")
+    q_out, k_out = rotate_qk_for_fp8_comms(q, k, AttentionBackendType.SDPA)
+    assert q_out is q and k_out is k
+
+
+def test_hadamard_matrix_is_orthonormal():
+    R = FP8_HADAMARD_MATRIX[_HB_DEVICE].float()
+    torch.testing.assert_close(
+        R @ R.T, torch.eye(R.shape[0], device=R.device), rtol=0, atol=1e-3
+    )
+
+
+def test_calibrated_scale_matches_the_rotated_tensor():
+    """The frozen scale must describe the tensor that is actually quantized.
+
+    Calibrating on unrotated amaxes leaves the scale too small for the rotated
+    tensor whenever rotation raises amax, which clips; ``safety_factor`` alone only
+    covers 1/0.85 of that.
+    """
+    fp8_max = torch.finfo(torch.float8_e4m3fn).max
+    safety_factor = 0.85
+    fp8 = Fp8CommsState(safety_factor=safety_factor)
+    model = _FakeTransformer(num_layers=1)
+    fp8.register_model(model, num_layers=1)
+    # Running-max buffers default to CPU; move them to the rotation device so the
+    # in-place maximum in update_running_max stays on one device.
+    fp8.get_model_state(model).to_device_(_HB_DEVICE)
+
+    q, k = _outlier_qk()
+    v = torch.randn(1, 64, 2, 128, dtype=torch.bfloat16, device=_HB_DEVICE)
+    q_rot, k_rot = rotate_qk_for_fp8_comms(q, k, AttentionBackendType.AITER_FP8)
+
+    fp8.update_running_max(
+        model, torch.tensor([0], dtype=torch.long, device=_HB_DEVICE), q_rot, k_rot, v
+    )
+    model_state = fp8.get_model_state(model)
+
+    assert model_state.q_running_max[0].item() == pytest.approx(
+        q_rot.abs().amax().float().item()
+    )
+    assert model_state.q_running_max[0].item() != pytest.approx(
+        q.abs().amax().float().item()
+    )
+
+    scales = torch.stack(
+        [
+            model_state.q_running_max,
+            model_state.k_running_max,
+            model_state.v_running_max,
+            model_state.o_running_max,
+        ]
+    ).clamp(min=1e-6) / (fp8_max * safety_factor)
+    fp8._scatter_scales_to_model(model, scales[0], scales[1], scales[2], scales[3])
+
+    # Quantizing the rotated tensor with the frozen scale must stay inside the
+    # representable range, with the headroom safety_factor promises.
+    q_scale = model.blocks[0].attn1.fp8_q_scale.item()
+    assert (q_rot.float() / q_scale).abs().amax().item() == pytest.approx(
+        fp8_max * safety_factor, rel=1e-2
+    )

--- a/tests/test_fp8_comms_state.py
+++ b/tests/test_fp8_comms_state.py
@@ -93,9 +93,9 @@ def _outlier_qk(head_dim: int = 128, seq: int = 64, dtype=torch.bfloat16, device
     """
     torch.manual_seed(0)
     q = torch.randn(1, seq, 2, head_dim, dtype=dtype)
-    q[..., 7] *= 30
+    q[..., 7 % head_dim] *= 30
     k = torch.randn(1, seq, 2, head_dim, dtype=dtype)
-    k[..., 19] *= 20
+    k[..., 19 % head_dim] *= 20
     return q.to(device), k.to(device)
 
 

--- a/tests/test_fp8_comms_state.py
+++ b/tests/test_fp8_comms_state.py
@@ -9,8 +9,6 @@ from xfuser.core.distributed.attention_backend import (
 )
 from xfuser.core.distributed.fp8_comms import Fp8CommsState
 
-# FP8_HADAMARD_MATRIX is keyed per device and only holds cuda entries on a GPU
-# host (no cpu key), so rotation tests must use whatever device it was built for.
 _HB_DEVICE = next(iter(FP8_HADAMARD_MATRIX))
 
 

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -11,6 +11,7 @@ import torch.distributed
 from xfuser.logger import init_logger
 from xfuser.core.distributed import init_distributed_environment
 from xfuser.config.config import (
+    DEFAULT_FP8_COMMS_SAFETY_FACTOR,
     EngineConfig,
     FastAttnConfig,
     ParallelConfig,
@@ -152,6 +153,9 @@ class xFuserArgs:
     use_fp4_gemms: bool = False
     fp8_precision_override_prefix_patterns: Optional[str] = None
     fp8_precision_override_suffix_patterns: Optional[str] = None
+    use_fp8_comms: bool = False
+    fp8_comms_scale: Optional[float] = None
+    fp8_comms_safety_factor: float = DEFAULT_FP8_COMMS_SAFETY_FACTOR
     # Model runner specific
     num_iterations: int = 1
     profile: bool = False
@@ -517,6 +521,25 @@ class xFuserArgs:
             action="store_true",
             help="Quantize the transformer linear layers (selected models only).",
         )
+        runtime_group.add_argument(
+            "--use_fp8_comms",
+            action="store_true",
+            help="Quantize Ulysses all-to-all communication to FP8.",
+        )
+        runtime_group.add_argument(
+            "--fp8_comms_scale",
+            type=float,
+            default=None,
+            help="Override the model-specific FP8 communication scale.",
+        )
+        runtime_group.add_argument(
+            "--fp8_comms_safety_factor",
+            type=float,
+            default=DEFAULT_FP8_COMMS_SAFETY_FACTOR,
+            help="Safety factor for the calibrated FP8 comms scale: scale = amax / "
+                 "(FP8_MAX * safety_factor). LOWER it (e.g. 0.4) to enlarge the scale and "
+                 "leave more headroom before fp8 saturation. Default 0.85.",
+        )
 
         # DiTFastAttn arguments
         fast_attn_group = parser.add_argument_group("DiTFastAttn Options")
@@ -814,7 +837,25 @@ class xFuserArgs:
             default=None,
             help="Comma-delimited FQN suffix patterns to keep in FP8 during FP4 GEMMs.",
         )
-
+        parser.add_argument(
+            "--use_fp8_comms",
+            action="store_true",
+            help="Quantize Ulysses all-to-all communication to FP8.",
+        )
+        parser.add_argument(
+            "--fp8_comms_scale",
+            type=float,
+            default=None,
+            help="Override the model-specific FP8 communication scale.",
+        )
+        parser.add_argument(
+            "--fp8_comms_safety_factor",
+            type=float,
+            default=DEFAULT_FP8_COMMS_SAFETY_FACTOR,
+            help="Safety factor for the calibrated FP8 comms scale: scale = amax / "
+                 "(FP8_MAX * safety_factor). LOWER it (e.g. 0.4) to enlarge the scale and "
+                 "leave more headroom before fp8 saturation. Default 0.85.",
+        )
         parser.add_argument(
             "--num_iterations",
             type=int,
@@ -1201,6 +1242,9 @@ class xFuserArgs:
             use_vsa_static_block_mask=self.use_vsa_static_block_mask,
             use_vsa_first_frame_mask=self.use_vsa_first_frame_mask,
             vsa_collect_density=self.vsa_collect_density,
+            use_fp8_comms=self.use_fp8_comms,
+            fp8_comms_scale=self.fp8_comms_scale,
+            fp8_comms_safety_factor=self.fp8_comms_safety_factor,
         )
 
         parallel_config = ParallelConfig(

--- a/xfuser/config/config.py
+++ b/xfuser/config/config.py
@@ -16,6 +16,8 @@ from typing import Union, Optional, List
 
 env_info = PACKAGES_CHECKER.get_packages_info()
 HAS_LONG_CTX_ATTN = env_info["has_long_ctx_attn"]
+
+DEFAULT_FP8_COMMS_SAFETY_FACTOR = 0.85
 HAS_FLASH_ATTN = env_info["has_flash_attn"]
 
 
@@ -80,6 +82,9 @@ class RuntimeConfig:
     use_vsa_static_block_mask: bool = True
     use_vsa_first_frame_mask: bool = True
     vsa_collect_density: bool = False
+    use_fp8_comms: bool = False
+    fp8_comms_scale: Optional[float] = None
+    fp8_comms_safety_factor: float = DEFAULT_FP8_COMMS_SAFETY_FACTOR
 
     def __post_init__(self):
         check_packages()

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -144,12 +144,11 @@ def _build_hadamard_matrix(block_r, dtype=torch.bfloat16, allow_sylvester_fallba
 
 def _replicate_hadamard_per_device(hadamard):
     """Replicate a single Hadamard matrix on each available device, keyed by
-    torch.device (all GPUs if CUDA is available, else CPU). A None matrix maps
+    torch.device (CPU plus all GPUs when CUDA is available). A None matrix maps
     to None on every device."""
+    devices = [torch.device("cpu")]
     if torch.cuda.is_available():
-        devices = [torch.device(f"cuda:{i}") for i in range(torch.cuda.device_count())]
-    else:
-        devices = [torch.device("cpu")]
+        devices += [torch.device(f"cuda:{i}") for i in range(torch.cuda.device_count())]
     return {
         device: (hadamard.to(device) if hadamard is not None else None)
         for device in devices
@@ -389,8 +388,11 @@ def _build_aiter_mla_metadata(batch_size, q_seq_len, kv_seq_len, num_heads, num_
 
 aten = torch.ops.aten
 env_info = PACKAGES_CHECKER.get_packages_info()
+AITER_FP8_DTYPE = torch.float8_e4m3fn  # fallback; fp8 comms requires aiter
+FP8_HADAMARD_MATRIX = _aiter_hadamard_matrix(128)
 if env_info["has_aiter"]:
     import aiter
+    AITER_FP8_DTYPE = aiter.dtypes.fp8
     from aiter import flash_attn_func as flash_attn_func_aiter
     from aiter import flash_attn_varlen_func as flash_attn_varlen_func_aiter
     try:
@@ -689,6 +691,13 @@ def _mha_v4_sparge_tile():
     return {"BLOCK_M": 256, "BLOCK_N": _AITER_MHA_V4.kv_tile}
 
 
+_FP8_INPUT_DTYPES = (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
+
+SUPPORTS_PRE_QUANTIZATION_BACKENDS = {
+    AttentionBackendType.AITER_FP8,
+}
+
+
 def register_attention_function(backend_type):
     """
     Decorator to register attention functions with their corresponding backend type.
@@ -951,6 +960,24 @@ def _fp8_hadamard_rotate(x: torch.Tensor, R: torch.Tensor) -> torch.Tensor:
     return torch.matmul(x.unflatten(-1, (d // block_r, block_r)), R).flatten(-2)
 
 
+def rotate_qk_for_fp8_comms(query, key, backend):
+    """Rotate Q,K exactly as the fp8-comms path does before quantizing them.
+
+    Returns the inputs untouched for backends whose fp8-comms path does not rotate,
+    so callers can apply this unconditionally. Single definition shared by the
+    quantization site in USP and the calibration site in the attention processor:
+    both must measure and quantize the same distribution, otherwise the frozen
+    per-layer scale describes a tensor that is never quantized.
+    """
+    if backend != AttentionBackendType.AITER_FP8:
+        return query, key
+    R = _get_fp8_hadamard_matrix(query.shape[-1], query.device)
+    return (
+        _fp8_hadamard_rotate(query, R).contiguous(),
+        _fp8_hadamard_rotate(key, R).contiguous(),
+    )
+
+
 def _quantize_aiter_fp8_inputs(query, key, value):
     quant_dtype = aiter.dtypes.fp8
     dtype_max = torch.finfo(quant_dtype).max
@@ -1102,9 +1129,28 @@ def _aiter_fp8_attn_call(query, key, value, dropout_p, is_causal, attention_kwar
     then calls attention through AITER
     """
     _validate_aiter_low_precision_dropout(dropout_p)
+    attention_kwargs = attention_kwargs or {}
+    pre_quantized = attention_kwargs.get("pre_quantized", False)
+
     query = torch.permute(query, [0, 2, 1, 3]).contiguous()
     key = torch.permute(key, [0, 2, 1, 3]).contiguous()
     value = torch.permute(value, [0, 2, 1, 3]).contiguous()
+
+    if pre_quantized:
+        # Q/K/V arrive already FP8 from fp8 comms (quantized before the Ulysses
+        # all-to-all).
+        output = aiter.flash_attn_fp8_pertensor_func(
+            query,
+            key,
+            value,
+            causal=is_causal,
+            softmax_scale=query.shape[-1] ** -0.5,
+            q_descale=attention_kwargs["q_descale"],
+            k_descale=attention_kwargs["k_descale"],
+            v_descale=attention_kwargs["v_descale"],
+        )
+        output = torch.permute(output, [0, 2, 1, 3])
+        return output, None
 
     packed = _varlen_pack_keys(query, key, value, attention_kwargs)
     use_mha_v4 = packed is None and _use_aiter_mha_v4_fp8(query, is_causal)

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -691,8 +691,6 @@ def _mha_v4_sparge_tile():
     return {"BLOCK_M": 256, "BLOCK_N": _AITER_MHA_V4.kv_tile}
 
 
-_FP8_INPUT_DTYPES = (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
-
 SUPPORTS_PRE_QUANTIZATION_BACKENDS = {
     AttentionBackendType.AITER_FP8,
 }

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -143,10 +143,9 @@ def _build_hadamard_matrix(block_r, dtype=torch.bfloat16, allow_sylvester_fallba
 
 
 def _replicate_hadamard_per_device(hadamard):
-    """Replicate a single Hadamard matrix on each available device, keyed by
-    torch.device (CPU plus all GPUs when CUDA is available). A None matrix maps
-    to None on every device."""
-    devices = [torch.device("cpu")]
+    """Replicate a single Hadamard matrix on each visible GPU, keyed by
+    torch.device. A None matrix maps to None on every device."""
+    devices = []
     if torch.cuda.is_available():
         devices += [torch.device(f"cuda:{i}") for i in range(torch.cuda.device_count())]
     return {
@@ -389,7 +388,7 @@ def _build_aiter_mla_metadata(batch_size, q_seq_len, kv_seq_len, num_heads, num_
 aten = torch.ops.aten
 env_info = PACKAGES_CHECKER.get_packages_info()
 AITER_FP8_DTYPE = torch.float8_e4m3fn  # fallback; fp8 comms requires aiter
-FP8_HADAMARD_MATRIX = _aiter_hadamard_matrix(128)
+FP8_HADAMARD_MATRIX = {}
 if env_info["has_aiter"]:
     import aiter
     AITER_FP8_DTYPE = aiter.dtypes.fp8

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -1139,6 +1139,12 @@ def _aiter_fp8_attn_call(query, key, value, dropout_p, is_causal, attention_kwar
     if pre_quantized:
         # Q/K/V arrive already FP8 from fp8 comms (quantized before the Ulysses
         # all-to-all).
+        if (attention_kwargs or {}).get("indices_k") is not None:
+            raise NotImplementedError(
+                "fp8 comms pre-quantized attention does not support varlen packing; "
+                "the indices_k mask would be silently dropped and dense attention would "
+                "run over padded keys."
+            )
         output = aiter.flash_attn_fp8_pertensor_func(
             query,
             key,

--- a/xfuser/core/distributed/fp8_comms.py
+++ b/xfuser/core/distributed/fp8_comms.py
@@ -1,0 +1,540 @@
+"""FP8 Ulysses all-to-all communication.
+
+Encapsulates the whole fp8-comms feature -- per-layer calibration state, the
+calibration lifecycle, the per-step observation hooks, and the quantized
+all-to-all helpers -- so that runtime_state / base_model / usp / transformer_wan
+only make thin calls into it. Modelled on VAEManager (runner_models/vae_manager.py).
+
+This module is a leaf: it imports nothing from usp / attention_backend /
+runtime_state / base_model at module scope. Those are imported lazily inside the
+methods that need them (once, at startup, or via the already-established lazy
+pattern in the compiled attention path), which keeps the import graph acyclic.
+"""
+import copy
+import os
+from typing import NamedTuple, Optional
+
+import torch
+import torch.distributed as dist
+
+import xfuser.envs as envs
+from xfuser.logger import init_logger
+from xfuser.config.config import DEFAULT_FP8_COMMS_SAFETY_FACTOR
+
+if torch.cuda.is_available() or envs._is_npu():
+    from yunchang.globals import PROCESS_GROUP
+else:
+    PROCESS_GROUP = None
+
+logger = init_logger(__name__)
+
+_FP8_LOG_SCALES = bool(os.environ.get("XFUSER_FP8_LOG_SCALES"))
+_FP8_DTYPES = (
+    torch.float8_e4m3fn,
+    torch.float8_e4m3fnuz,
+    torch.float8_e5m2,
+    torch.float8_e5m2fnuz,
+)
+
+
+class Fp8CommsCall(NamedTuple):
+    """The per-layer fp8-comms scales for one attention call.
+
+    A single opaque argument threaded through USP so the attention signature does
+    not need a separate parameter per scale. ``None`` at a call site means fp8 comms
+    is off for that call. A NamedTuple (not a plain object) so torch.compile traces
+    the field access without a graph break.
+    """
+
+    q_scale: torch.Tensor
+    k_scale: torch.Tensor
+    v_scale: torch.Tensor
+    o_scale: torch.Tensor
+
+
+class Fp8CommsModelState:
+    """Per-transformer FP8 comms calibration state (one entry per self-attn layer)."""
+
+    def __init__(self, num_layers: int):
+        self.num_layers = num_layers
+        self.q_running_max = torch.zeros(num_layers, dtype=torch.float32)
+        self.k_running_max = torch.zeros(num_layers, dtype=torch.float32)
+        self.v_running_max = torch.zeros(num_layers, dtype=torch.float32)
+        self.o_running_max = torch.zeros(num_layers, dtype=torch.float32)
+        self.synced = False
+
+    def to_device_(self, device: torch.device):
+        self.q_running_max = self.q_running_max.to(device)
+        self.k_running_max = self.k_running_max.to(device)
+        self.v_running_max = self.v_running_max.to(device)
+        self.o_running_max = self.o_running_max.to(device)
+
+
+class Fp8CommsState:
+    """Holds all state for FP8 Ulysses all-to-all communication.
+
+    Per-layer scales live on each attn1 module as compile-friendly buffers; this class
+    holds per-model running amaxes during calibration only.
+    """
+
+    def __init__(
+        self,
+        fixed_scale: Optional[float] = None,
+        safety_factor: float = DEFAULT_FP8_COMMS_SAFETY_FACTOR,
+    ):
+        self.fixed_scale = fixed_scale
+        # Calibrated per-layer scale = amax / (FP8_MAX * safety_factor). A smaller
+        # safety_factor enlarges the scale, so the calibrated amax maps further below
+        # FP8_MAX and live values above the calibrated peak no longer clip.
+        self.safety_factor = safety_factor
+        self._models: dict[int, Fp8CommsModelState] = {}
+        self.calibrated_model_ids: set = set()
+
+    @classmethod
+    def from_config(cls, config) -> "Optional[Fp8CommsState]":
+        """Build the state from an EngineConfig, or None when fp8-comms is off / inapplicable."""
+        runtime_config = config.runtime_config
+        if not runtime_config.use_fp8_comms:
+            return None
+        ulysses_degree = config.parallel_config.sp_config.ulysses_degree or 1
+        if ulysses_degree <= 1:
+            logger.warning(
+                "--use_fp8_comms is set but ulysses_degree <= 1. "
+                "FP8 communication will not be applied."
+            )
+            return None
+        scale = runtime_config.fp8_comms_scale
+        safety_factor = runtime_config.fp8_comms_safety_factor
+        if scale is not None:
+            logger.warning(f"FP8 communication enabled with fixed scale {scale}.")
+        else:
+            logger.warning(
+                "FP8 communication enabled with static per-layer scaling "
+                f"(calibrated once before inference; safety_factor={safety_factor})."
+            )
+        return cls(fixed_scale=scale, safety_factor=safety_factor)
+
+    # ---- per-model registration / state ------------------------------------
+
+    def register_model(self, model, num_layers: int) -> None:
+        """Register a transformer for per-layer FP8 comms calibration."""
+        model_id = id(model)
+        if model_id in self._models:
+            return
+        self._models[model_id] = Fp8CommsModelState(num_layers)
+        if self.fixed_scale is not None:
+            self.apply_fixed_scales_to_model(model)
+            self._models[model_id].synced = True
+            self.calibrated_model_ids.add(model_id)
+
+    def get_model_state(self, model) -> Optional[Fp8CommsModelState]:
+        return self._models.get(id(model))
+
+    def apply_fixed_scales_to_model(self, model) -> None:
+        """Broadcast a fixed scale to all self-attention layer buffers."""
+        scale = float(self.fixed_scale)
+        for block in model.blocks:
+            block.attn1.fp8_q_scale.fill_(scale)
+            block.attn1.fp8_k_scale.fill_(scale)
+            block.attn1.fp8_v_scale.fill_(scale)
+            block.attn1.fp8_o_scale.fill_(scale)
+
+    def to_device_(self, device: torch.device):
+        for model_state in self._models.values():
+            model_state.to_device_(device)
+
+    # ---- calibration amax accumulation (compiled-region safe) --------------
+
+    def update_running_max(
+        self,
+        model,
+        layer_idx: torch.Tensor,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+    ):
+        """Update running amaxes in-place for one layer. Safe inside compiled region when unsynced."""
+        model_state = self._models.get(id(model))
+        if model_state is None or model_state.synced:
+            return
+        idx = layer_idx.reshape(-1).long()
+        q_amax = q.abs().amax().reshape(1)
+        k_amax = k.abs().amax().reshape(1)
+        v_amax = v.abs().amax().reshape(1)
+        model_state.q_running_max.index_copy_(
+            0, idx, torch.maximum(model_state.q_running_max.index_select(0, idx), q_amax)
+        )
+        model_state.k_running_max.index_copy_(
+            0, idx, torch.maximum(model_state.k_running_max.index_select(0, idx), k_amax)
+        )
+        model_state.v_running_max.index_copy_(
+            0, idx, torch.maximum(model_state.v_running_max.index_select(0, idx), v_amax)
+        )
+
+    def update_o_running_max(
+        self,
+        model,
+        layer_idx: torch.Tensor,
+        o_descale: torch.Tensor,
+    ):
+        """Update o running amaxes in-place for one layer. Safe inside compiled region when unsynced."""
+        model_state = self._models.get(id(model))
+        if model_state is None or model_state.synced:
+            return
+        idx = layer_idx.reshape(-1).long()
+        o_amax = o_descale.abs().amax().reshape(1)
+        model_state.o_running_max.index_copy_(
+            0, idx, torch.maximum(model_state.o_running_max.index_select(0, idx), o_amax)
+        )
+
+    def _scatter_scales_to_model(
+        self,
+        model,
+        q_scales: torch.Tensor,
+        k_scales: torch.Tensor,
+        v_scales: torch.Tensor,
+        o_scales: torch.Tensor,
+    ):
+        for i, block in enumerate(model.blocks):
+            block.attn1.fp8_q_scale.copy_(q_scales[i : i + 1])
+            block.attn1.fp8_k_scale.copy_(k_scales[i : i + 1])
+            block.attn1.fp8_v_scale.copy_(v_scales[i : i + 1])
+            block.attn1.fp8_o_scale.copy_(o_scales[i : i + 1])
+
+    def sync(self, model) -> None:
+        """All-reduce per-layer running amaxes and scatter scales into attn1 buffers.
+
+        Call outside the compiled region after a calibration forward pass.
+        """
+        if self.fixed_scale is not None or model is None:
+            return
+        model_state = self.get_model_state(model)
+        if model_state is None or model_state.synced:
+            return
+        if (
+            model_state.q_running_max.max() == 0
+            and model_state.k_running_max.max() == 0
+            and model_state.v_running_max.max() == 0
+        ):
+            return
+        from xfuser.core.distributed.attention_backend import AITER_FP8_DTYPE
+
+        dtype_max = torch.finfo(AITER_FP8_DTYPE).max
+        maxes = torch.stack(
+            [
+                model_state.q_running_max,
+                model_state.k_running_max,
+                model_state.v_running_max,
+                model_state.o_running_max,
+            ],
+            dim=0,
+        )
+        dist.all_reduce(maxes, op=dist.ReduceOp.MAX, group=PROCESS_GROUP.ULYSSES_PG)
+        # A smaller safety_factor enlarges the scale so live values above the
+        # calibrated amax still map below FP8_MAX -> no clipping. Free for fp8.
+        scales = maxes.clamp(min=1e-6) / (dtype_max * self.safety_factor)
+        self._scatter_scales_to_model(model, scales[0], scales[1], scales[2], scales[3])
+        model_state.q_running_max.zero_()
+        model_state.k_running_max.zero_()
+        model_state.v_running_max.zero_()
+        model_state.o_running_max.zero_()
+        model_state.synced = True
+        self.calibrated_model_ids.add(id(model))
+        if dist.get_rank() == 0:
+            q_scales, k_scales, v_scales, o_scales = scales[0], scales[1], scales[2], scales[3]
+            logger.info(
+                f"[fp8_comms] {model.__class__.__name__} per-layer scales synced: "
+                f"q=[{q_scales.min().item():.6f}, {q_scales.max().item():.6f}] "
+                f"k=[{k_scales.min().item():.6f}, {k_scales.max().item():.6f}] "
+                f"v=[{v_scales.min().item():.6f}, {v_scales.max().item():.6f}] "
+                f"o=[{o_scales.min().item():.6f}, {o_scales.max().item():.6f}] "
+                f"(amax q={maxes[0].max().item():.4f} k={maxes[1].max().item():.4f} "
+                f"v={maxes[2].max().item():.4f} o={maxes[3].max().item():.4f})"
+            )
+
+    # ---- lifecycle hooks (called from base_model, thin) --------------------
+
+    def register_models(self, pipe) -> None:
+        """Register the pipe's transformer(s) and move running-max buffers to GPU."""
+        for name in ("transformer", "transformer_2"):
+            transformer = getattr(pipe, name, None)
+            if transformer is not None and hasattr(transformer, "register_fp8_comms_state"):
+                transformer.register_fp8_comms_state(self)
+        if torch.cuda.is_available():
+            self.to_device_(torch.device("cuda", torch.cuda.current_device()))
+
+    def needs_calibration(self) -> bool:
+        """Dynamic (calibrated) scaling needs a throwaway pass; fixed scale does not."""
+        return self.fixed_scale is None
+
+    def calibrate(
+        self,
+        pipe,
+        input_args: dict,
+        run_pipe_fn,
+        split_prompts_fn=None,
+        batch_size: Optional[int] = None,
+    ) -> None:
+        """Run one throwaway pipe call to calibrate per-layer FP8 comms scales.
+
+        ``run_pipe_fn`` / ``split_prompts_fn`` are supplied by the runner so this class
+        stays free of runner internals.
+        """
+        from xfuser.core.utils.runner_utils import log
+
+        log("Calibrating FP8 comms scales (throwaway inference pass)...")
+        calib_args = copy.deepcopy(input_args)
+        if split_prompts_fn is not None:
+            calib_args = split_prompts_fn(calib_args)
+        if batch_size and isinstance(calib_args.get("prompt"), list):
+            calib_args["prompt"] = calib_args["prompt"][:batch_size]
+        run_pipe_fn(calib_args)
+        for name in ("transformer", "transformer_2"):
+            transformer = getattr(pipe, name, None)
+            if transformer is not None:
+                self.sync(transformer)
+        log("FP8 comms calibration complete.")
+
+    # ---- per-step observation hooks (called from the transformer forward) --
+
+    def observe_qkv(self, attn, query, key, value, backend) -> bool:
+        """During calibration, measure amaxes on the tensors USP will quantize.
+
+        USP Hadamard-rotates Q,K before the fp8 all-to-all, so measure rotated copies
+        (measurement-only; the flowing tensors are untouched). Returns whether this
+        model's scales are already synced (i.e. fp8 comms may be applied this step).
+        """
+        fp8_owner = getattr(attn, "fp8_comms_owner", None)
+        if fp8_owner is None or not hasattr(attn, "fp8_comms_layer_idx"):
+            return False
+        model_state = self.get_model_state(fp8_owner)
+        if model_state is None:
+            return False
+        if not model_state.synced:
+            from xfuser.core.distributed.attention_backend import rotate_qk_for_fp8_comms
+
+            calib_query, calib_key = rotate_qk_for_fp8_comms(query, key, backend)
+            self.update_running_max(
+                fp8_owner, attn.fp8_comms_layer_idx, calib_query, calib_key, value
+            )
+        return model_state.synced
+
+    def observe_output(self, attn, out) -> None:
+        """During calibration, measure the attention-output amax for one layer."""
+        fp8_owner = getattr(attn, "fp8_comms_owner", None)
+        if fp8_owner is None or not hasattr(attn, "fp8_comms_layer_idx"):
+            return
+        self.update_o_running_max(fp8_owner, attn.fp8_comms_layer_idx, out)
+
+
+# ---- attention-processor hooks (called from the transformer, thin) ---------
+#
+# Free functions (not methods) so callers never need a `fp8_comms is None` guard,
+# and so the transformer never touches fp8 buffer names or the backend gate.
+
+
+def install_fp8_comms_layer_state(transformer) -> None:
+    """Register the per-layer fp8-comms buffers on each self-attention module.
+
+    Owns the buffer contract (names/shapes + owner link). Buffers are non-persistent
+    (kept out of the state_dict) and registered pre-compile so torch.compile captures
+    them as graph inputs. Called after the model is loaded/moved to its device (via
+    register_fp8_comms_state), so each buffer is placed on its module's device rather
+    than defaulting to CPU.
+    """
+    for layer_idx, block in enumerate(transformer.blocks):
+        attn = block.attn1
+        device = next(attn.parameters()).device
+        for name in ("fp8_q_scale", "fp8_k_scale", "fp8_v_scale", "fp8_o_scale"):
+            attn.register_buffer(
+                name, torch.ones(1, dtype=torch.float32, device=device), persistent=False
+            )
+        attn.register_buffer(
+            "fp8_comms_layer_idx",
+            torch.tensor([layer_idx], dtype=torch.long, device=device),
+            persistent=False,
+        )
+        # Plain attribute (not an nn.Module child) so the transformer is not
+        # registered as a submodule of attn (which would recurse forever).
+        object.__setattr__(attn, "fp8_comms_owner", transformer)
+
+
+def fp8_attention_kwargs(fp8_comms, attn, query, key, value, is_cross_attention, backend) -> dict:
+    """Extras to splat into the attention call for fp8 comms, or ``{}`` when it does not apply.
+
+    Also accumulates calibration amaxes as a side effect (via observe_qkv), which happens on
+    every self-attn call regardless of the step's backend; fp8 comms is only *applied* once the
+    scales are synced and the current backend supports pre-quantization.
+    """
+    if is_cross_attention or fp8_comms is None:
+        return {}
+    synced = fp8_comms.observe_qkv(attn, query, key, value, backend)
+    if not synced:
+        return {}
+    from xfuser.core.distributed.attention_backend import SUPPORTS_PRE_QUANTIZATION_BACKENDS
+
+    if backend not in SUPPORTS_PRE_QUANTIZATION_BACKENDS:
+        return {}
+    return {
+        "fp8_comms": Fp8CommsCall(
+            attn.fp8_q_scale,
+            attn.fp8_k_scale,
+            attn.fp8_v_scale,
+            attn.fp8_o_scale,
+        )
+    }
+
+
+def fp8_observe_output(fp8_comms, attn, out, is_cross_attention) -> None:
+    """Measure the attention-output amax for calibration (no-op when fp8 comms is off/cross-attn)."""
+    if is_cross_attention or fp8_comms is None:
+        return
+    fp8_comms.observe_output(attn, out)
+
+
+# ---- quantized all-to-all helpers (called from USP, thin) ------------------
+
+
+def _per_tensor_quant(x: torch.Tensor, scale_t: torch.Tensor):
+    """Quantize x to FP8 using a fixed pre-allocated scale tensor. Returns (x_fp8, descale)."""
+    import aiter
+
+    fp8_dtype = aiter.dtypes.fp8
+    return aiter.per_tensor_quant(
+        x, scale=scale_t, quant_dtype=fp8_dtype, dtypeMax=torch.finfo(fp8_dtype).max
+    )
+
+
+def fp8_comms_input_all_to_all(query, key, value, q_scale, k_scale, v_scale, backend):
+    """Rotate Q,K, quantize Q/K/V to FP8 using per-layer scales, and run interleaved
+    input all-to-alls. Returns (query, key, value, attn_kwargs_update, qkv_amaxes)."""
+    from xfuser.core.distributed.attention_backend import rotate_qk_for_fp8_comms
+    from xfuser.model_executor.layers.usp import _ft_c_input_all_to_all
+
+    query, key = rotate_qk_for_fp8_comms(query, key, backend)
+    q_fp8, q_descale = _per_tensor_quant(query, q_scale)
+    query = _ft_c_input_all_to_all(q_fp8)
+    k_fp8, k_descale = _per_tensor_quant(key, k_scale)
+    key = _ft_c_input_all_to_all(k_fp8)
+    v_fp8, v_descale = _per_tensor_quant(value, v_scale)
+    value = _ft_c_input_all_to_all(v_fp8)
+
+    qkv_amaxes = (
+        (q_descale.item(), k_descale.item(), v_descale.item()) if _FP8_LOG_SCALES else None
+    )
+    attn_kwargs_update = {
+        "pre_quantized": True,
+        "q_descale": q_descale,
+        "k_descale": k_descale,
+        "v_descale": v_descale,
+    }
+    return query, key, value, attn_kwargs_update, qkv_amaxes
+
+
+def fp8_comms_output_all_to_all(out: torch.Tensor, o_scale: torch.Tensor, qkv_amaxes=None):
+    """Quantize attention output to FP8, run output all-to-all, dequantize back."""
+    from xfuser.model_executor.layers.usp import _ft_c_output_all_to_all
+
+    if _FP8_LOG_SCALES and qkv_amaxes is not None:
+        out_amax = out.abs().amax().item()
+        rank = dist.get_rank()
+        q_amax, k_amax, v_amax = qkv_amaxes
+        logger.info(
+            f"[fp8_scales rank{rank}] q_amax={q_amax:.4f} k_amax={k_amax:.4f} "
+            f"v_amax={v_amax:.4f} out_amax={out_amax:.4f}"
+        )
+    if o_scale is None:
+        raise RuntimeError("FP8 comms requires per-layer scale buffers fp8_o_scale")
+    restore_dtype = out.dtype if out.dtype not in _FP8_DTYPES else torch.bfloat16
+    if out.dtype not in _FP8_DTYPES:
+        out_fp8, out_descale = _per_tensor_quant(out, o_scale)
+    else:
+        out_fp8, out_descale = out, o_scale
+    return (_ft_c_output_all_to_all(out_fp8).float() * out_descale).to(restore_dtype)
+
+
+# ---- config validation (module-level, mirrors validate_vae_config) ---------
+
+
+def setup_fp8_comms(
+    fp8_comms,
+    pipe,
+    input_args,
+    run_pipe_fn,
+    split_prompts_fn=None,
+    batch_size=None,
+) -> None:
+    """Register the pipe's transformers and run calibration if needed.
+
+    No-op when fp8 comms is off (``fp8_comms is None``). Owns the register -> calibrate
+    sequence so the runner only makes one call; ``run_pipe_fn``/``split_prompts_fn`` are
+    runner callbacks (calibration must run the pipe, which the runner owns).
+    """
+    if fp8_comms is None:
+        return
+    fp8_comms.register_models(pipe)
+    if fp8_comms.needs_calibration():
+        fp8_comms.calibrate(
+            pipe,
+            input_args,
+            run_pipe_fn,
+            split_prompts_fn=split_prompts_fn,
+            batch_size=batch_size,
+        )
+
+
+def validate_fp8_comms_config(config, capabilities, settings) -> None:
+    """Raise if --use_fp8_comms is requested but unsupported by the model/config; no-op if off."""
+    if not config.use_fp8_comms:
+        return
+    from xfuser.core.distributed.attention_backend import (
+        AttentionBackendType,
+        SUPPORTS_PRE_QUANTIZATION_BACKENDS,
+    )
+    from xfuser.core.distributed.attention_schedule import AttentionSchedule
+
+    def _parse(name, kind):
+        if name is None:
+            return None
+        try:
+            return AttentionBackendType[name.upper()]
+        except KeyError:
+            raise ValueError(f"Invalid {kind}: {name}")
+
+    if not capabilities.use_fp8_comms:
+        raise ValueError(f"Model {settings.model_name} does not support --use_fp8_comms.")
+    if (config.ulysses_degree or 1) <= 1:
+        raise ValueError("--use_fp8_comms requires ulysses_degree > 1.")
+    effective_backends = set()
+    if config.attention_backend:
+        effective_backends.add(_parse(config.attention_backend, "attention backend"))
+    if config.use_hybrid_attn_schedule:
+        if config.hybrid_attn_schedule:
+            effective_backends.update(
+                AttentionSchedule.from_comma_delimited_string(
+                    config.hybrid_attn_schedule
+                ).backends
+            )
+        else:
+            if config.hybrid_attn_low_precision_backend:
+                effective_backends.add(
+                    _parse(
+                        config.hybrid_attn_low_precision_backend,
+                        "hybrid low-precision attention backend",
+                    )
+                )
+            if config.hybrid_attn_high_precision_backend:
+                effective_backends.add(
+                    _parse(
+                        config.hybrid_attn_high_precision_backend,
+                        "hybrid high-precision attention backend",
+                    )
+                )
+    if not effective_backends & SUPPORTS_PRE_QUANTIZATION_BACKENDS:
+        raise ValueError(
+            f"--use_fp8_comms requires an attention backend that supports pre-quantization "
+            f"({', '.join(b.name for b in SUPPORTS_PRE_QUANTIZATION_BACKENDS)}). "
+            f"Set --attention_backend, --hybrid_attn_schedule, or "
+            f"--hybrid_attn_low_precision_backend / --hybrid_attn_high_precision_backend "
+            f"so at least one scheduled backend supports pre-quantization."
+        )

--- a/xfuser/core/distributed/fp8_comms.py
+++ b/xfuser/core/distributed/fp8_comms.py
@@ -82,6 +82,10 @@ class Fp8CommsState:
         fixed_scale: Optional[float] = None,
         safety_factor: float = DEFAULT_FP8_COMMS_SAFETY_FACTOR,
     ):
+        if fixed_scale is not None and fixed_scale <= 0:
+            raise ValueError(f"fp8_comms_scale must be positive, got {fixed_scale}.")
+        if safety_factor <= 0:
+            raise ValueError(f"fp8_comms_safety_factor must be positive, got {safety_factor}.")
         self.fixed_scale = fixed_scale
         # Calibrated per-layer scale = amax / (FP8_MAX * safety_factor). A smaller
         # safety_factor enlarges the scale, so the calibrated amax maps further below
@@ -98,11 +102,7 @@ class Fp8CommsState:
             return None
         ulysses_degree = config.parallel_config.sp_config.ulysses_degree or 1
         if ulysses_degree <= 1:
-            logger.warning(
-                "--use_fp8_comms is set but ulysses_degree <= 1. "
-                "FP8 communication will not be applied."
-            )
-            return None
+            raise ValueError("--use_fp8_comms requires ulysses_degree > 1.")
         scale = runtime_config.fp8_comms_scale
         safety_factor = runtime_config.fp8_comms_safety_factor
         if scale is not None:
@@ -216,6 +216,12 @@ class Fp8CommsState:
             and model_state.k_running_max.max() == 0
             and model_state.v_running_max.max() == 0
         ):
+            logger.warning(
+                f"[fp8_comms] calibration observed no activations for "
+                f"{model.__class__.__name__}; fp8 comms will NOT activate and the run "
+                f"falls back to bf16 communication. The calibration pass never ran a "
+                f"pre-quantization backend (AITER_FP8) on the self-attention layers."
+            )
             return
         from xfuser.core.distributed.attention_backend import AITER_FP8_DTYPE
 
@@ -362,10 +368,9 @@ def install_fp8_comms_layer_state(transformer) -> None:
 def fp8_attention_kwargs(fp8_comms, attn, query, key, value, is_cross_attention, backend) -> dict:
     """Extras to splat into the attention call for fp8 comms, or ``{}`` when it does not apply.
 
-    Also accumulates calibration amaxes as a side effect (via observe_qkv). Observation is
-    gated on the backend first: only pre-quantization backends rotate Q/K before quantizing,
-    and calibration must measure the rotated distribution. Observing on a hybrid step whose
-    backend does not rotate would record the (larger) unrotated amax and inflate the scale.
+    Gates on the backend before observing: calibration must measure the rotated Q/K, and only
+    pre-quantization backends rotate, so observing on a non-rotating hybrid step would inflate
+    the scale with the unrotated amax.
     """
     if is_cross_attention or fp8_comms is None:
         return {}
@@ -490,6 +495,7 @@ def validate_fp8_comms_config(config, capabilities, settings) -> None:
     if not config.use_fp8_comms:
         return
     from xfuser.core.distributed.attention_backend import (
+        AITER_FP8_HAS_DESCALE,
         AttentionBackendType,
         SUPPORTS_PRE_QUANTIZATION_BACKENDS,
     )
@@ -540,3 +546,13 @@ def validate_fp8_comms_config(config, capabilities, settings) -> None:
             f"--hybrid_attn_low_precision_backend / --hybrid_attn_high_precision_backend "
             f"so at least one scheduled backend supports pre-quantization."
         )
+    if not AITER_FP8_HAS_DESCALE:
+        raise ValueError(
+            "--use_fp8_comms needs an AITER build whose flash_attn_fp8_pertensor_func "
+            "accepts q_descale/k_descale/v_descale; this build does not. Update AITER."
+        )
+    logger.info(
+        "fp8 comms feeds pre-quantized Q/K/V to the dense FP8 attention kernel; "
+        "AITER MHA v4 is bypassed on the AITER_FP8 self-attention path where it "
+        "would otherwise be selected."
+    )

--- a/xfuser/core/distributed/fp8_comms.py
+++ b/xfuser/core/distributed/fp8_comms.py
@@ -28,7 +28,7 @@ else:
 
 logger = init_logger(__name__)
 
-_FP8_LOG_SCALES = bool(os.environ.get("XFUSER_FP8_LOG_SCALES"))
+_FP8_LOG_SCALES = os.environ.get("XFUSER_FP8_LOG_SCALES", "").lower() in ("1", "true")
 class Fp8CommsCall(NamedTuple):
     """The per-layer fp8-comms scales for one attention call.
 
@@ -479,8 +479,8 @@ def validate_fp8_comms_config(config, capabilities, settings) -> None:
     """Raise if --use_fp8_comms is requested but unsupported by the model/config; no-op if off."""
     if not config.use_fp8_comms:
         return
+    from xfuser.core.distributed import attention_backend as ab
     from xfuser.core.distributed.attention_backend import (
-        AITER_FP8_HAS_DESCALE,
         AttentionBackendType,
         SUPPORTS_PRE_QUANTIZATION_BACKENDS,
     )
@@ -539,10 +539,10 @@ def validate_fp8_comms_config(config, capabilities, settings) -> None:
             f"--hybrid_attn_low_precision_backend / --hybrid_attn_high_precision_backend "
             f"so at least one scheduled backend supports pre-quantization."
         )
-    if not AITER_FP8_HAS_DESCALE:
+    if not getattr(ab, "AITER_FP8_HAS_DESCALE", False):
         raise ValueError(
             "--use_fp8_comms needs an AITER build whose flash_attn_fp8_pertensor_func "
-            "accepts q_descale/k_descale/v_descale; this build does not. Update AITER."
+            "accepts q_descale/k_descale/v_descale."
         )
     logger.info(
         "fp8 comms feeds pre-quantized Q/K/V to the dense FP8 attention kernel; "

--- a/xfuser/core/distributed/fp8_comms.py
+++ b/xfuser/core/distributed/fp8_comms.py
@@ -396,13 +396,14 @@ def fp8_observe_output(fp8_comms, attn, out, is_cross_attention) -> None:
 
 
 def _per_tensor_quant(x: torch.Tensor, scale_t: torch.Tensor):
-    """Quantize x to FP8 using a fixed pre-allocated scale tensor. Returns (x_fp8, descale)."""
+    """Quantize x to FP8 with a fixed pre-allocated scale. Returns (x_fp8, descale)."""
     import aiter
 
     fp8_dtype = aiter.dtypes.fp8
-    return aiter.per_tensor_quant(
-        x, scale=scale_t, quant_dtype=fp8_dtype, dtypeMax=torch.finfo(fp8_dtype).max
-    )
+    dtype_max = torch.finfo(fp8_dtype).max
+    # Clamp before the cast: fp8 has no saturation, so overflow would cast to NaN.
+    x_fp8 = (x.float() / scale_t).clamp(-dtype_max, dtype_max).to(fp8_dtype)
+    return x_fp8, scale_t
 
 
 def fp8_comms_input_all_to_all(query, key, value, q_scale, k_scale, v_scale, backend):

--- a/xfuser/core/distributed/fp8_comms.py
+++ b/xfuser/core/distributed/fp8_comms.py
@@ -75,8 +75,10 @@ class Fp8CommsState:
     ):
         if fixed_scale is not None and fixed_scale <= 0:
             raise ValueError(f"fp8_comms_scale must be positive, got {fixed_scale}.")
-        if safety_factor <= 0:
-            raise ValueError(f"fp8_comms_safety_factor must be positive, got {safety_factor}.")
+        if not 0 < safety_factor <= 1:
+            raise ValueError(
+                f"fp8_comms_safety_factor must be in (0, 1], got {safety_factor}."
+            )
         self.fixed_scale = fixed_scale
         # Calibrated per-layer scale = amax / (FP8_MAX * safety_factor). A smaller
         # safety_factor enlarges the scale, so the calibrated amax maps further below

--- a/xfuser/core/distributed/fp8_comms.py
+++ b/xfuser/core/distributed/fp8_comms.py
@@ -29,14 +29,6 @@ else:
 logger = init_logger(__name__)
 
 _FP8_LOG_SCALES = bool(os.environ.get("XFUSER_FP8_LOG_SCALES"))
-_FP8_DTYPES = (
-    torch.float8_e4m3fn,
-    torch.float8_e4m3fnuz,
-    torch.float8_e5m2,
-    torch.float8_e5m2fnuz,
-)
-
-
 class Fp8CommsCall(NamedTuple):
     """The per-layer fp8-comms scales for one attention call.
 
@@ -56,7 +48,6 @@ class Fp8CommsModelState:
     """Per-transformer FP8 comms calibration state (one entry per self-attn layer)."""
 
     def __init__(self, num_layers: int):
-        self.num_layers = num_layers
         self.q_running_max = torch.zeros(num_layers, dtype=torch.float32)
         self.k_running_max = torch.zeros(num_layers, dtype=torch.float32)
         self.v_running_max = torch.zeros(num_layers, dtype=torch.float32)
@@ -92,7 +83,6 @@ class Fp8CommsState:
         # FP8_MAX and live values above the calibrated peak no longer clip.
         self.safety_factor = safety_factor
         self._models: dict[int, Fp8CommsModelState] = {}
-        self.calibrated_model_ids: set = set()
 
     @classmethod
     def from_config(cls, config) -> "Optional[Fp8CommsState]":
@@ -125,7 +115,6 @@ class Fp8CommsState:
         if self.fixed_scale is not None:
             self.apply_fixed_scales_to_model(model)
             self._models[model_id].synced = True
-            self.calibrated_model_ids.add(model_id)
 
     def get_model_state(self, model) -> Optional[Fp8CommsModelState]:
         return self._models.get(id(model))
@@ -245,7 +234,6 @@ class Fp8CommsState:
         model_state.v_running_max.zero_()
         model_state.o_running_max.zero_()
         model_state.synced = True
-        self.calibrated_model_ids.add(id(model))
         if dist.get_rank() == 0:
             q_scales, k_scales, v_scales, o_scales = scales[0], scales[1], scales[2], scales[3]
             logger.info(
@@ -450,13 +438,8 @@ def fp8_comms_output_all_to_all(out: torch.Tensor, o_scale: torch.Tensor, qkv_am
             f"[fp8_scales rank{rank}] q_amax={q_amax:.4f} k_amax={k_amax:.4f} "
             f"v_amax={v_amax:.4f} out_amax={out_amax:.4f}"
         )
-    if o_scale is None:
-        raise RuntimeError("FP8 comms requires per-layer scale buffers fp8_o_scale")
-    restore_dtype = out.dtype if out.dtype not in _FP8_DTYPES else torch.bfloat16
-    if out.dtype not in _FP8_DTYPES:
-        out_fp8, out_descale = _per_tensor_quant(out, o_scale)
-    else:
-        out_fp8, out_descale = out, o_scale
+    restore_dtype = out.dtype
+    out_fp8, out_descale = _per_tensor_quant(out, o_scale)
     return (_ft_c_output_all_to_all(out_fp8).float() * out_descale).to(restore_dtype)
 
 
@@ -513,6 +496,14 @@ def validate_fp8_comms_config(config, capabilities, settings) -> None:
         raise ValueError(f"Model {settings.model_name} does not support --use_fp8_comms.")
     if (config.ulysses_degree or 1) <= 1:
         raise ValueError("--use_fp8_comms requires ulysses_degree > 1.")
+    if (
+        config.enable_sequential_cpu_offload
+        or config.enable_model_cpu_offload
+        or config.enable_group_cpu_offload
+    ):
+        # The per-layer scale and running-max buffers cannot be reliably co-located
+        # with the attention tensors when layers move on and off the GPU.
+        raise ValueError("--use_fp8_comms is not supported with CPU offload.")
     effective_backends = set()
     if config.attention_backend:
         effective_backends.add(_parse(config.attention_backend, "attention backend"))

--- a/xfuser/core/distributed/fp8_comms.py
+++ b/xfuser/core/distributed/fp8_comms.py
@@ -362,18 +362,19 @@ def install_fp8_comms_layer_state(transformer) -> None:
 def fp8_attention_kwargs(fp8_comms, attn, query, key, value, is_cross_attention, backend) -> dict:
     """Extras to splat into the attention call for fp8 comms, or ``{}`` when it does not apply.
 
-    Also accumulates calibration amaxes as a side effect (via observe_qkv), which happens on
-    every self-attn call regardless of the step's backend; fp8 comms is only *applied* once the
-    scales are synced and the current backend supports pre-quantization.
+    Also accumulates calibration amaxes as a side effect (via observe_qkv). Observation is
+    gated on the backend first: only pre-quantization backends rotate Q/K before quantizing,
+    and calibration must measure the rotated distribution. Observing on a hybrid step whose
+    backend does not rotate would record the (larger) unrotated amax and inflate the scale.
     """
     if is_cross_attention or fp8_comms is None:
-        return {}
-    synced = fp8_comms.observe_qkv(attn, query, key, value, backend)
-    if not synced:
         return {}
     from xfuser.core.distributed.attention_backend import SUPPORTS_PRE_QUANTIZATION_BACKENDS
 
     if backend not in SUPPORTS_PRE_QUANTIZATION_BACKENDS:
+        return {}
+    synced = fp8_comms.observe_qkv(attn, query, key, value, backend)
+    if not synced:
         return {}
     return {
         "fp8_comms": Fp8CommsCall(

--- a/xfuser/core/distributed/runtime_state.py
+++ b/xfuser/core/distributed/runtime_state.py
@@ -10,6 +10,7 @@ from torch.cuda import manual_seed as device_manual_seed
 from torch.cuda import manual_seed_all as device_manual_seed_all
 from diffusers import DiffusionPipeline
 import torch.distributed
+import torch.distributed as dist
 
 try:
     import torch_musa
@@ -20,6 +21,11 @@ except ModuleNotFoundError:
 
 import xfuser.envs as envs
 from xfuser.envs import PACKAGES_CHECKER
+
+if torch.cuda.is_available() or envs._is_npu():
+    from yunchang.globals import PROCESS_GROUP
+else:
+    PROCESS_GROUP = None
 if envs._is_npu():
     from torch.npu import manual_seed as device_manual_seed
     from torch.npu import manual_seed_all as device_manual_seed_all
@@ -33,6 +39,7 @@ from xfuser.core.distributed.attention_backend import (
     AttentionBackendType,
 )
 from xfuser.core.distributed.attention_schedule import AttentionSchedule, GemmPrecisionSchedule
+from xfuser.core.distributed.fp8_comms import Fp8CommsState
 from xfuser.config.config import (
     ParallelConfig,
     RuntimeConfig,
@@ -56,6 +63,7 @@ logger = init_logger(__name__)
 
 env_info = PACKAGES_CHECKER.get_packages_info()
 
+
 def set_random_seed(seed: int):
     random.seed(seed)
     np.random.seed(seed)
@@ -67,6 +75,7 @@ def set_random_seed(seed: int):
 class RuntimeState(metaclass=ABCMeta):
     attention_backend: AttentionBackendType = AttentionBackendType.SDPA_FLASH
     cross_attention_backend: Optional[AttentionBackendType] = None
+    fp8_comms: Optional[Fp8CommsState] = None
     parallel_config: ParallelConfig
     runtime_config: RuntimeConfig
     input_config: InputConfig
@@ -85,6 +94,7 @@ class RuntimeState(metaclass=ABCMeta):
         self.set_attention_backend(attention_backend)
         cross_attention_backend = self._select_cross_attention_backend(config)
         self.set_cross_attention_backend(cross_attention_backend)
+        self.fp8_comms = Fp8CommsState.from_config(config)
 
     def is_ready(self):
         return self.ready
@@ -555,6 +565,7 @@ class DiTRuntimeState(RuntimeState):
             self.use_high_precision_gemm = self.gemm_schedule.is_high_precision(current_step)
 
         self.step_counter = self.step_counter + 1
+
         if self.step_counter >= active_total_steps:
             self.step_counter = 0
 

--- a/xfuser/core/distributed/runtime_state.py
+++ b/xfuser/core/distributed/runtime_state.py
@@ -10,7 +10,6 @@ from torch.cuda import manual_seed as device_manual_seed
 from torch.cuda import manual_seed_all as device_manual_seed_all
 from diffusers import DiffusionPipeline
 import torch.distributed
-import torch.distributed as dist
 
 try:
     import torch_musa
@@ -22,10 +21,6 @@ except ModuleNotFoundError:
 import xfuser.envs as envs
 from xfuser.envs import PACKAGES_CHECKER
 
-if torch.cuda.is_available() or envs._is_npu():
-    from yunchang.globals import PROCESS_GROUP
-else:
-    PROCESS_GROUP = None
 if envs._is_npu():
     from torch.npu import manual_seed as device_manual_seed
     from torch.npu import manual_seed_all as device_manual_seed_all

--- a/xfuser/model_executor/layers/usp.py
+++ b/xfuser/model_executor/layers/usp.py
@@ -28,6 +28,11 @@ from xfuser.core.distributed.attention_backend import (
     ATTENTION_FUNCTION_REGISTRY,
     AttentionBackendType,
 )
+from xfuser.core.distributed.fp8_comms import (
+    Fp8CommsCall,
+    fp8_comms_input_all_to_all,
+    fp8_comms_output_all_to_all,
+)
 from xfuser.core.sparge_attention.head_balance import (
     apply_head_balance,
     revert_head_balance,
@@ -42,6 +47,9 @@ _HEAD_BALANCE_BACKENDS = frozenset({
     AttentionBackendType.AITER_SPARGE_V2,
     AttentionBackendType.FLEX_BLOCK_SPARGE,
 }) | AITER_MHA_V4_SPARGE_BACKEND_SET
+
+_FP8_NCCL_NEEDS_VIEW = not version_at_least(torch.__version__, "2.11.0")
+_FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e4m3fnuz, torch.float8_e5m2, torch.float8_e5m2fnuz)
 
 
 def ring_attn(attention_function, query, key, value, dropout_p=0.0, is_causal=False, joint_attn_kwargs=None, attention_kwargs=None):
@@ -87,10 +95,14 @@ def _maybe_wait(tensor: torch.Tensor) -> torch.Tensor:
 
 def _sdpa_all_to_all_single(x):
     x_shape = x.shape
+    x_dtype = x.dtype
     x = x.flatten()
+    # NCCL does not support FP8 collectives before PyTorch 2.11, view as uint8 (same width) for the transfer.
+    if _FP8_NCCL_NEEDS_VIEW and x_dtype in _FP8_DTYPES:
+        x = x.view(torch.uint8)
     x = ft_c.all_to_all_single(x, output_split_sizes=None, input_split_sizes=None, group=PROCESS_GROUP.ULYSSES_PG)
     x = _maybe_wait(x)
-    x = x.reshape(x_shape)
+    x = x.view(x_dtype).reshape(x_shape)
     return x
 
 
@@ -260,6 +272,7 @@ def USP(
         backend=None,
         attention_kwargs: dict | None = None,
         head_balance_layer=None,
+        fp8_comms: Fp8CommsCall | None = None,
     ):
     """
     Unified Sequence Parallelism (USP) attention call, supporting combinations of Ulysses and
@@ -303,8 +316,17 @@ def USP(
 
         }
 
+    qkv_amaxes = None
     if get_ulysses_parallel_world_size() > 1:
-        if combine_qkv_a2a and query.shape == key.shape == value.shape:
+        if fp8_comms is not None:
+            fp8_comms_backend = backend if backend is not None else get_runtime_state().attention_backend
+            query, key, value, attn_kwargs_update, qkv_amaxes = fp8_comms_input_all_to_all(
+                query, key, value,
+                fp8_comms.q_scale, fp8_comms.k_scale, fp8_comms.v_scale,
+                fp8_comms_backend,
+            )
+            attention_kwargs = (attention_kwargs or {}) | attn_kwargs_update
+        elif combine_qkv_a2a and query.shape == key.shape == value.shape:
             query, key, value = _combined_qkv_all_to_all(query, key, value)
         else:
             query = _ft_c_input_all_to_all(query)
@@ -351,7 +373,10 @@ def USP(
                             is_causal=is_causal,
                             joint_attn_kwargs=joint_attn_kwargs,
                             attention_kwargs=attention_kwargs)
-        out = _ft_c_output_all_to_all(out)
+        if fp8_comms is not None:
+            out = fp8_comms_output_all_to_all(out, fp8_comms.o_scale, qkv_amaxes)
+        else:
+            out = _ft_c_output_all_to_all(out)
         if hb_applied:
             # Restore global head order on the output, gather this step's per-head
             # costs across the Ulysses group, and plan next step's permutation.
@@ -371,6 +396,7 @@ def attention(
         backend=None,
         attention_kwargs=None,
         head_balance_layer=None,
+        fp8_comms: Fp8CommsCall | None = None,
     ):
     """
     Runs attention call without any parallelism.

--- a/xfuser/model_executor/layers/usp.py
+++ b/xfuser/model_executor/layers/usp.py
@@ -303,6 +303,10 @@ def USP(
         attention_kwargs=attention_kwargs,
     )
 
+    if fp8_comms is not None and joint_strategy:
+        # query is fp8-quantized before the all-to-all but joint_key/value stay bf16.
+        raise NotImplementedError("fp8 comms does not support joint attention.")
+
     joint_attn_kwargs = None
     if joint_strategy:
         query = _concat_joint_tensor(query, joint_query, joint_strategy, dim=2)

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -44,6 +44,7 @@ from xfuser.core.distributed.attention_backend import (
     AITER_MHA_V4_SPARGE_BACKEND_SET,
     AttentionBackendType,
 )
+from xfuser.core.distributed.fp8_comms import setup_fp8_comms, validate_fp8_comms_config
 from xfuser.core.distributed.attention_schedule import AttentionSchedule, create_hybrid_attn_schedule, create_hybrid_gemm_schedule
 from xfuser.model_executor.models.runner_models.loading.contracts import (
     LoadSupport,
@@ -136,6 +137,7 @@ class ModelCapabilities:
     use_fp8_text_encoder: bool = False
     use_fp4_gemms: bool = False
     supports_step_caching: bool = False
+    use_fp8_comms: bool = False
     use_hybrid_attn_schedule: bool = False
     use_hybrid_gemm_schedule: bool = False
     cross_attention_backend: bool = False
@@ -346,6 +348,14 @@ class xFuserModel(abc.ABC):
         if self.config.use_parallel_vae:
             self._vae_manager.setup_parallel_vae(self._decoding_vaes())
         self._enable_options()
+        setup_fp8_comms(
+            get_runtime_state().fp8_comms,
+            self.pipe,
+            input_args,
+            run_pipe_fn=self._run_timed_pipe,
+            split_prompts_fn=self._split_prompts_for_dp,
+            batch_size=self.config.batch_size,
+        )
 
         # Compile and warm the original blocks before cache adapters replace or
         # patch them, keeping stateful cross-step cache logic out of traced graphs.
@@ -550,6 +560,8 @@ class xFuserModel(abc.ABC):
             raise ValueError(f"Model {self.settings.model_name} requires a task to be specified. Supported tasks: {self.settings.valid_tasks}")
         if config.dataset_path and not config.batch_size:
             raise ValueError("Dataset path specified without batch size. Please specify batch size for dataset inference.")
+
+        validate_fp8_comms_config(config, self.capabilities, self.settings)
 
         if self.model_output_type == "video" and not self.fps:
             raise ValueError(f"Model {self.settings.model_name} produces video output but fps is not set.")

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -38,6 +38,7 @@ from xfuser.core.distributed import (
     get_pipeline_parallel_world_size,
     initialize_runtime_state,
     get_runtime_state,
+    runtime_state_is_initialized,
     init_distributed_environment,
 )
 from xfuser.core.distributed.attention_backend import (
@@ -348,8 +349,12 @@ class xFuserModel(abc.ABC):
         if self.config.use_parallel_vae:
             self._vae_manager.setup_parallel_vae(self._decoding_vaes())
         self._enable_options()
+        # Guard the singleton access: fp8 comms lives on the runtime state, so when
+        # it is not initialized (e.g. a lifecycle test that mocks it out) there is
+        # nothing to set up and the feature is simply off.
+        fp8_comms = get_runtime_state().fp8_comms if runtime_state_is_initialized() else None
         setup_fp8_comms(
-            get_runtime_state().fp8_comms,
+            fp8_comms,
             self.pipe,
             input_args,
             run_pipe_fn=self._run_timed_pipe,

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -349,9 +349,6 @@ class xFuserModel(abc.ABC):
         if self.config.use_parallel_vae:
             self._vae_manager.setup_parallel_vae(self._decoding_vaes())
         self._enable_options()
-        # Guard the singleton access: fp8 comms lives on the runtime state, so when
-        # it is not initialized (e.g. a lifecycle test that mocks it out) there is
-        # nothing to set up and the feature is simply off.
         fp8_comms = get_runtime_state().fp8_comms if runtime_state_is_initialized() else None
         setup_fp8_comms(
             fp8_comms,

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -350,14 +350,15 @@ class xFuserModel(abc.ABC):
             self._vae_manager.setup_parallel_vae(self._decoding_vaes())
         self._enable_options()
         fp8_comms = get_runtime_state().fp8_comms if runtime_state_is_initialized() else None
-        setup_fp8_comms(
-            fp8_comms,
-            self.pipe,
-            input_args,
-            run_pipe_fn=self._run_timed_pipe,
-            split_prompts_fn=self._split_prompts_for_dp,
-            batch_size=self.config.batch_size,
-        )
+        if fp8_comms is not None:
+            setup_fp8_comms(
+                fp8_comms,
+                self.pipe,
+                input_args,
+                run_pipe_fn=self._run_timed_pipe,
+                split_prompts_fn=self._split_prompts_for_dp,
+                batch_size=self.config.batch_size,
+            )
 
         # Compile and warm the original blocks before cache adapters replace or
         # patch them, keeping stateful cross-step cache logic out of traced graphs.

--- a/xfuser/model_executor/models/runner_models/wan.py
+++ b/xfuser/model_executor/models/runner_models/wan.py
@@ -1,5 +1,6 @@
 import re
 import torch
+from dataclasses import replace
 from typing import List, Optional
 from PIL import Image
 from diffusers import FlowMatchEulerDiscreteScheduler
@@ -306,6 +307,8 @@ class xFuserWan22I2VModel(xFuserWan21I2VModel):
     # WAN has no in-tree FBCache adapter (that path is FLUX.2-specific). FBCache is a
     # special case of DBCache (first-block cache), so expose "fbcache" as DBCache with
     # Fn_compute_blocks=1; base_model routes it through the cache-dit (dbcache) engine.
+    capabilities = replace(xFuserWan21I2VModel.capabilities, use_fp8_comms=True)
+
     def _customize_settings(self, config: xFuserArgs) -> None:
         super()._customize_settings(config)
         self.settings.model_name = "Wan-AI/Wan2.2-I2V-A14B-Diffusers"
@@ -672,6 +675,8 @@ class xFuserWan22T2VModel(xFuserWan21T2VModel):
     )
 
     # See xFuserWan22I2VModel: "fbcache" == DBCache first-block (Fn_compute_blocks=1).
+    capabilities = replace(xFuserWan21T2VModel.capabilities, use_fp8_comms=True)
+
     def _customize_settings(self, config: xFuserArgs) -> None:
         super()._customize_settings(config)
         self.settings.model_name = "Wan-AI/Wan2.2-T2V-A14B-Diffusers"
@@ -755,6 +760,7 @@ class xFuserWan22TI2VModel(xFuserWan21T2VModel):
         use_fp8_gemms=True,
         use_fp8_text_encoder=True,
         use_fp4_gemms=True,
+        use_fp8_comms=True,
         use_hybrid_attn_schedule=True,
         use_hybrid_gemm_schedule=True,
         use_parallel_vae=True,

--- a/xfuser/model_executor/models/transformers/transformer_wan.py
+++ b/xfuser/model_executor/models/transformers/transformer_wan.py
@@ -17,6 +17,11 @@ from xfuser.core.distributed import (
     get_sp_group,
     get_runtime_state,
 )
+from xfuser.core.distributed.fp8_comms import (
+    fp8_attention_kwargs,
+    fp8_observe_output,
+    install_fp8_comms_layer_state,
+)
 from xfuser.model_executor.layers.attention_processor import (
     xFuserAttentionProcessorRegister
 )
@@ -92,13 +97,14 @@ class xFuserWanAttnProcessor(WanAttnProcessor):
             # as some backends may have too much overhead for cross-attention.
             backend = get_runtime_state().get_cross_attention_backend()
 
+        activation_dtype = hidden_states.dtype
+
         encoder_hidden_states_img = None
         if attn.add_k_proj is not None:
             # 512 is the context length of the text encoder, hardcoded for now
             image_context_length = encoder_hidden_states.shape[1] - 512
             encoder_hidden_states_img = encoder_hidden_states[:, :image_context_length]
             encoder_hidden_states = encoder_hidden_states[:, image_context_length:]
-
         query, key, value = self._get_qkv_projections(attn, hidden_states, encoder_hidden_states)
 
         # Collapse norm_q -> norm_k -> apply_rotary_emb(q) -> apply_rotary_emb(k)
@@ -117,6 +123,12 @@ class xFuserWanAttnProcessor(WanAttnProcessor):
         else:
             query, key, value = self._qk_norm_rope_reference(attn, query, key, value, rotary_emb)
 
+        runtime_state = get_runtime_state()
+        fp8_kwargs = fp8_attention_kwargs(
+            runtime_state.fp8_comms, attn, query, key, value,
+            self.is_cross_attention, runtime_state.attention_backend,
+        )
+
         # I2V task
         hidden_states_img = None
         if encoder_hidden_states_img is not None:
@@ -126,15 +138,16 @@ class xFuserWanAttnProcessor(WanAttnProcessor):
             key_img = key_img.unflatten(2, (attn.heads, -1))
             value_img = value_img.unflatten(2, (attn.heads, -1))
 
-            hidden_states_img = self.attention_function(query.transpose(1, 2),
-                                                        key_img.transpose(1, 2),
-                                                        value_img.transpose(1, 2),
-                                                        backend=backend,
-                                                        attention_kwargs=self.attention_kwargs,
-                                                        ).transpose(1, 2)
+            hidden_states_img = self.attention_function(
+                query.transpose(1, 2),
+                key_img.transpose(1, 2),
+                value_img.transpose(1, 2),
+                backend=backend,
+                attention_kwargs=self.attention_kwargs,
+                **fp8_kwargs,
+            ).transpose(1, 2)
             hidden_states_img = hidden_states_img.flatten(2, 3)
-            hidden_states_img = hidden_states_img.type_as(query)
-
+            hidden_states_img = hidden_states_img.to(activation_dtype)
 
         hidden_states = self.attention_function(
             query.transpose(1, 2),
@@ -143,10 +156,15 @@ class xFuserWanAttnProcessor(WanAttnProcessor):
             backend=backend,
             attention_kwargs=self.attention_kwargs,
             head_balance_layer=attn,
+            **fp8_kwargs,
         ).transpose(1, 2)
 
+        fp8_observe_output(
+            runtime_state.fp8_comms, attn, hidden_states, self.is_cross_attention
+        )
+
         hidden_states = hidden_states.flatten(2, 3)
-        hidden_states = hidden_states.type_as(query)
+        hidden_states = hidden_states.to(activation_dtype)
 
         if hidden_states_img is not None:
             hidden_states = hidden_states + hidden_states_img
@@ -270,6 +288,14 @@ class xFuserWanTransformer3DWrapper(WanTransformer3DModel):
         )
         self.attention_kwargs["vsa_effective_drop_rate"] = effective_drop_rate
         self.attention_kwargs["vsa_use_dense"] = effective_drop_rate <= 0.25
+
+    def register_fp8_comms_state(self, fp8_comms) -> None:
+        """Install per-layer fp8 buffers and register running-max state (called only when fp8
+        comms is enabled, before compile). No buffers are added when fp8 comms is off."""
+        if fp8_comms is None:
+            return
+        install_fp8_comms_layer_state(self)
+        fp8_comms.register_model(self, len(self.blocks))
 
 
     def _chunk_and_pad_sequence(self, x: torch.Tensor, sp_world_rank: int, sp_world_size: int, pad_amount: int, dim: int) -> torch.Tensor:


### PR DESCRIPTION
Quantizes Ulysses all-to-all Q/K/V/O traffic to FP8 with per-layer calibrated scales, reducing communication volume by ~2x vs BF16.

The whole feature is encapsulated in `xfuser/core/distributed/fp8_comms.py`. The rest of the codebase (runtime_state, base_model, usp, transformer_wan) only makes thin calls into it.

Supported attention backends: `AITER_FP8`. Enabled models: `Wan2.2-I2V`, `Wan2.2-T2V`, `Wan2.2-TI2V`.

## Usage

Add `--use_fp8_comms` to an existing Wan2.2 run that already uses Ulysses.

Two optional args:

- `--fp8_comms_scale FLOAT` : use a fixed scale for every layer and skip   calibration entirely.
- `--fp8_comms_safety_factor FLOAT` : headroom applied to the calibrated scale (default 0.85). Lower value maps the calibrated amax further below the FP8 max, trading a little dynamic range for fewer overflows.


## How it works

The feature has three parts: a one-time calibration, a quantized all-to-all on each step, and an attention call that consumes the already-quantized tensors.

### 1. Calibration (once per run, before the timed steps)

FP8 has a small dynamic range, so each tensor needs a scale that maps its values into that range without clipping. Rather than compute a scale on every step, the feature measures it once:

- One throwaway BF16 forward pass runs before inference.
- During that pass, each self-attention layer records the maximum absolute value (amax) of the Q, K, V and output tensors it will later quantize.
- The per-layer amaxes are all-reduced with a max across the Ulysses ranks, so every rank agrees on the same scale for a given layer.
- Each per-layer scale is computed as `amax / (FP8_MAX * safety_factor)` and frozen into small buffers on the attention module.

Calibration finishes before `torch.compile` captures the graph, so the scales are constants in the compiled region. Nothing in the calibrated path runs inside the compiled graph, so there are no graph breaks on the hot path.

If `--fp8_comms_scale` is given, calibration is skipped and that fixed value is used for every layer.

### 2. Quantized all-to-all (every step)

Inside Ulysses, for each self-attention layer:

- Q and K are rotated by the existing Hadamard rotation (already merged) before   quantization. The rotation preserves the Q times K product but spreads outliers,  which lowers FP8 quantization error at no change to the attention result.
- Q, K and V are quantized to FP8 using the frozen per-layer scales.
- The all-to-all exchanges the FP8 tensors.
- After attention, the output is quantized to FP8 for the output all-to-all and   dequantized back to BF16 on the receiving side.

### 3. Attention on pre-quantized inputs

Because the tensors arrive already in FP8, the attention kernel does not quantize again. The AITER_FP8 path takes a `pre_quantized` flag: it feeds the FP8 Q/K/V and their descale factors straight into the dense FP8 attention kernel
(`flash_attn_fp8_pertensor_func`) and returns. One quantization for both transport and compute, no dequantize-and-requantize in between.

## Performance

Wan2.2, 8x GPU Ulysses, `AITER_FP8` hybrid backend, MI355X:

| Task  | Speedup |
|---|---|
| I2V | +2.88% |
| T2V | +3.13% |

## Example

```bash
--model Wan2.2-T2V --ulysses_degree 8 --use_hybrid_attn_schedule --hybrid_attn_low_precision_backend aiter_fp8 --hybrid_attn_high_precision_backend aiter --num_hybrid_attn_high_precision_steps 3 --use_fp8_gemms --use_fp8_comms
```