### PR TITLE
[Model] Add LTX-2.5 support (Distilled and Full)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ The following open-sourced DiT Models are released with xDiT in day 1.
 | [🎬 Wan2.2-Distilled (LightX2V 4-step)](https://huggingface.co/lightx2v/Wan2.2-Distill-Models) | ❎ | ✔️ | ❎ | ❎ | ✔️ | NA |
 | [🎬 CausalWan2.2](https://huggingface.co/FastVideo/CausalWan2.2-I2V-A14B-Preview-Diffusers) | ❎ | ❎ | ❎ | ❎ | ✔️ | NA |
 | [🎬 LTX-2](https://huggingface.co/Lightricks/LTX-2) | ❎ | ✔️ | ❎ | ❎ | ✔️ | NA |
+| [🎬 LTX-2.5](https://huggingface.co/Lightricks/LTX-2.5) | ❎ | ✔️ | ❎ | ❎ | ✔️ | NA |
 | [🔵 HunyuanDiT-v1.2-Diffusers](https://huggingface.co/Tencent-Hunyuan/HunyuanDiT-v1.2-Diffusers) | ✔️ | ✔️ | ✔️ | ❎ | ❎ | [Report](./docs/performance/hunyuandit.md) |
 | [🔴 Z-Image Turbo](https://huggingface.co/Tongyi-MAI/Z-Image-Turbo) | ❎ | ✔️ | ❎ | ❎ | ✔️ | NA |
 | [🟠 Flux 2 klein](https://huggingface.co/black-forest-labs/FLUX.2-klein-9B) | ❎ | ✔️ | ❎ | ❎ | ✔️ | NA |

--- a/docs/runner/runner.md
+++ b/docs/runner/runner.md
@@ -98,6 +98,7 @@ Individual model classes that inherit from `xFuserModel`:
 | Stable Diffusion 3 | `SD3.5`, `stabilityai/stable-diffusion-3.5-large` |
 | Z-Image-Turbo | `Z-Image-Turbo`, `Tongyi-MAI/Z-Image-Turbo` |
 | LTX-2 | `LTX-2`, `Lightricks/LTX-2` |
+| LTX-2.5 | `LTX-2.5`, `Lightricks/LTX-2.5-Diffusers` `LTX-2.5-distilled` `LTX-2.5` `LTX-2.5-full` |
 | Qwen-Image | `Qwen-Image`, `Qwen/Qwen-Image`, `Qwen-Image-2512`, `Qwen/Qwen-Image-2512` |
 | Qwen-Image-Edit | `Qwen-Image-Edit`, `Qwen/Qwen-Image-Edit`, `Qwen-Image-Edit-2509`, `Qwen/Qwen-Image-Edit-2509`, `Qwen-Image-Edit-2511`, `Qwen/Qwen-Image-Edit-2511` |
 | Krea2-Raw | `krea/krea-2-raw`, `krea/Krea-2-Raw`, `Krea-2-Raw` |

--- a/docs/runner/runner.md
+++ b/docs/runner/runner.md
@@ -98,7 +98,7 @@ Individual model classes that inherit from `xFuserModel`:
 | Stable Diffusion 3 | `SD3.5`, `stabilityai/stable-diffusion-3.5-large` |
 | Z-Image-Turbo | `Z-Image-Turbo`, `Tongyi-MAI/Z-Image-Turbo` |
 | LTX-2 | `LTX-2`, `Lightricks/LTX-2` |
-| LTX-2.5 | `LTX-2.5`, `Lightricks/LTX-2.5-Diffusers` `LTX-2.5-distilled` `LTX-2.5` `LTX-2.5-full` |
+| LTX-2.5 | `LTX-2.5`, `Lightricks/LTX-2.5-Diffusers`, `LTX-2.5-distilled`, `LTX-2.5`, `LTX-2.5-full` |
 | Qwen-Image | `Qwen-Image`, `Qwen/Qwen-Image`, `Qwen-Image-2512`, `Qwen/Qwen-Image-2512` |
 | Qwen-Image-Edit | `Qwen-Image-Edit`, `Qwen/Qwen-Image-Edit`, `Qwen-Image-Edit-2509`, `Qwen/Qwen-Image-Edit-2509`, `Qwen-Image-Edit-2511`, `Qwen/Qwen-Image-Edit-2511` |
 | Krea2-Raw | `krea/krea-2-raw`, `krea/Krea-2-Raw`, `Krea-2-Raw` |

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -597,6 +597,8 @@ def _sdpa_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs=No
     Allows Pytorch to decide which SDPA backend to use.
     """
     attn_mask = attention_kwargs.get("attn_mask") if attention_kwargs else None
+    if attn_mask is not None and attn_mask.dtype != query.dtype:
+        attn_mask = attn_mask.to(query.dtype)
     output = F.scaled_dot_product_attention(
         query, key, value, attn_mask=attn_mask, dropout_p=dropout_p, is_causal=is_causal
     )

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -382,18 +382,21 @@ if env_info["has_aiter"]:
     # sage_v2 relies on aiter's own matrix and has no Sylvester fallback (None
     # disables hadamard_rotation when create_hadamard_matrix is unavailable).
     HADAMARD_MATRIX = _aiter_hadamard_matrix(AITER_SAGE_V2_BLOCK_R, allow_sylvester_fallback=False)
-    # FP8 Hadamard matrices keyed by block_r, built lazily to support models
-    # with head_dim != 128 (e.g. LTX-2.5 audio head_dim=64). Seed with 128 for
-    # all existing models so first call is fast.
-    _FP8_HADAMARD_MATRICES: dict = {128: _aiter_hadamard_matrix(128)}
+    # 128-blocked FP8 Hadamard matrix (per-device), used by every model with
+    # head_dim a multiple of 128.
+    FP8_HADAMARD_MATRIX = _aiter_hadamard_matrix(128)
+    # Extra FP8 Hadamard matrices for smaller power-of-two head dims (e.g. LTX-2.5
+    # audio head_dim=64), built lazily and keyed by head_dim.
+    _FP8_HADAMARD_MATRICES: dict = {}
 
     def _get_fp8_hadamard_matrix(head_dim: int, device: torch.device) -> torch.Tensor:
-        # Use full-head 128-blocked rotation for head_dim that is a multiple of 128;
-        # fall back to a full-head rotation for smaller power-of-two dims (e.g. 64).
-        block_r = 128 if head_dim % 128 == 0 else head_dim
-        if block_r not in _FP8_HADAMARD_MATRICES:
-            _FP8_HADAMARD_MATRICES[block_r] = _aiter_hadamard_matrix(block_r)
-        return _FP8_HADAMARD_MATRICES[block_r][device]
+        # 128-blocked rotation for head_dim that is a multiple of 128 (all existing
+        # models); full-head rotation for smaller power-of-two dims (audio=64).
+        if head_dim % 128 == 0:
+            return FP8_HADAMARD_MATRIX[device]
+        if head_dim not in _FP8_HADAMARD_MATRICES:
+            _FP8_HADAMARD_MATRICES[head_dim] = _aiter_hadamard_matrix(head_dim)
+        return _FP8_HADAMARD_MATRICES[head_dim][device]
 
     _TRITON_SSTA_BLOCK_SIZE = 128
     
@@ -584,8 +587,9 @@ def _varlen_pack_keys(query_bshd, key_bshd, value_bshd, attention_kwargs):
     if indices_k is None:
         return None
     B, S, H, D = query_bshd.shape
-    k_flat = key_bshd.reshape(B * S, H, D)
-    v_flat = value_bshd.reshape(B * S, H, D)
+    Sk = key_bshd.shape[1]  # key seqlen may differ from query in cross-attention
+    k_flat = key_bshd.reshape(B * Sk, H, D)
+    v_flat = value_bshd.reshape(B * Sk, H, D)
     k_packed = torch.index_select(k_flat, 0, indices_k)
     v_packed = torch.index_select(v_flat, 0, indices_k)
     cu_seqlens_q = torch.arange(0, B + 1, dtype=torch.int32, device=query_bshd.device) * S
@@ -607,8 +611,6 @@ def _sdpa_attn_call(query, key, value, dropout_p, is_causal, attention_kwargs=No
     Allows Pytorch to decide which SDPA backend to use.
     """
     attn_mask = attention_kwargs.get("attn_mask") if attention_kwargs else None
-    if attn_mask is not None and attn_mask.dtype != query.dtype:
-        attn_mask = attn_mask.to(query.dtype)
     output = F.scaled_dot_product_attention(
         query, key, value, attn_mask=attn_mask, dropout_p=dropout_p, is_causal=is_causal
     )

--- a/xfuser/core/distributed/attention_backend.py
+++ b/xfuser/core/distributed/attention_backend.py
@@ -382,9 +382,19 @@ if env_info["has_aiter"]:
     # sage_v2 relies on aiter's own matrix and has no Sylvester fallback (None
     # disables hadamard_rotation when create_hadamard_matrix is unavailable).
     HADAMARD_MATRIX = _aiter_hadamard_matrix(AITER_SAGE_V2_BLOCK_R, allow_sylvester_fallback=False)
-    # Own Hadamard matrix for the fp8 paths (separate from sage_v2's);
-    # block_r = 128 = head_dim (full-head rotation). Sylvester fallback allowed.
-    FP8_HADAMARD_MATRIX = _aiter_hadamard_matrix(128)
+    # FP8 Hadamard matrices keyed by block_r, built lazily to support models
+    # with head_dim != 128 (e.g. LTX-2.5 audio head_dim=64). Seed with 128 for
+    # all existing models so first call is fast.
+    _FP8_HADAMARD_MATRICES: dict = {128: _aiter_hadamard_matrix(128)}
+
+    def _get_fp8_hadamard_matrix(head_dim: int, device: torch.device) -> torch.Tensor:
+        # Use full-head 128-blocked rotation for head_dim that is a multiple of 128;
+        # fall back to a full-head rotation for smaller power-of-two dims (e.g. 64).
+        block_r = 128 if head_dim % 128 == 0 else head_dim
+        if block_r not in _FP8_HADAMARD_MATRICES:
+            _FP8_HADAMARD_MATRICES[block_r] = _aiter_hadamard_matrix(block_r)
+        return _FP8_HADAMARD_MATRICES[block_r][device]
+
     _TRITON_SSTA_BLOCK_SIZE = 128
     
 
@@ -952,7 +962,7 @@ def _aiter_fp8_attn_call(query, key, value, dropout_p, is_causal, attention_kwar
     value = torch.permute(value, [0, 2, 1, 3]).contiguous()
 
     # Hadamard-rotate Q,K before quant: QK-preserving (kernel unchanged), cuts fp8 quant error.
-    R = FP8_HADAMARD_MATRIX[query.device]
+    R = _get_fp8_hadamard_matrix(query.shape[-1], query.device)
     query = _fp8_hadamard_rotate(query, R).contiguous()
     key = _fp8_hadamard_rotate(key, R).contiguous()
 

--- a/xfuser/model_executor/layers/attention_mask.py
+++ b/xfuser/model_executor/layers/attention_mask.py
@@ -16,7 +16,7 @@ class AttentionMaskWithMeta:
     produces indices_k is made once per forward pass rather than once per layer.
     """
 
-    attn_mask: torch.Tensor  # [B, 1, 1, S]  1 = valid key, 0 = padding
+    attn_mask: torch.Tensor  # [B, 1, 1, S]  bool: True = attend, False = pad
     indices_k: torch.Tensor  # [total_valid_k]  int64 flat valid positions
     cu_seqlens_k: torch.Tensor  # [B+1]  int32 cumulative valid-key counts
     max_seqlen_k: int
@@ -34,7 +34,7 @@ def make_attn_mask_with_meta(mask_2d: torch.Tensor) -> AttentionMaskWithMeta:
     indices_k = mask_2d.flatten().nonzero(as_tuple=False).flatten()
     max_seqlen_k = int(seqlens_k.max())
     return AttentionMaskWithMeta(
-        attn_mask=mask_2d[:, None, None, :],
+        attn_mask=mask_2d.to(torch.bool)[:, None, None, :],
         indices_k=indices_k,
         cu_seqlens_k=cu_seqlens_k,
         max_seqlen_k=max_seqlen_k,

--- a/xfuser/model_executor/layers/ltx2_na3d_eager_attn.py
+++ b/xfuser/model_executor/layers/ltx2_na3d_eager_attn.py
@@ -17,12 +17,14 @@ from torch.nn import functional
 
 # Element budget for one tile's [Nq, Nk] attention mask (bounds the mask
 # allocation and, on CPU, the math-backend score materialization).
-_NA_SCORE_BUDGET = 2 ** 25
+_NA_SCORE_BUDGET = 2**25
 # Element budget for the stacked K/V copies of one batched SDPA call on CUDA.
-_NA_KV_STACK_BUDGET = 2 ** 28
+_NA_KV_STACK_BUDGET = 2**28
 
 
-def _window_bounds(length: int, kernel: int, causal: bool) -> tuple[list[int], list[int]]:
+def _window_bounds(
+    length: int, kernel: int, causal: bool
+) -> tuple[list[int], list[int]]:
     """Per-index (start, end) of the attended window along one axis."""
     starts: list[int] = []
     ends: list[int] = []
@@ -47,7 +49,9 @@ def _pick_tiles(dims: tuple[int, int, int], kernels: list[int]) -> list[int]:
 
     def cost(ts: list[int]) -> int:
         nq = math.prod(ts)
-        nk = math.prod(min(d, t + k - 1) for t, k, d in zip(ts, kernels, dims, strict=True))
+        nk = math.prod(
+            min(d, t + k - 1) for t, k, d in zip(ts, kernels, dims, strict=True)
+        )
         return nq * nk
 
     while cost(tiles) > _NA_SCORE_BUDGET and max(tiles) > 1:
@@ -100,14 +104,19 @@ def _eager_na3d(
     batch, t, h, w, nh, hd = q.shape
     dims = (t, h, w)
     causal = [False, False, False] if is_causal is None else list(is_causal)
-    kernels = [k_ if c else min(k_, d) for k_, c, d in zip(kernel_size, causal, dims, strict=True)]
+    kernels = [
+        k_ if c else min(k_, d)
+        for k_, c, d in zip(kernel_size, causal, dims, strict=True)
+    ]
     if scale is None:
-        scale = hd ** -0.5
+        scale = hd**-0.5
     device = q.device
     if scale != 1.0:
         q = q * scale
 
-    bounds = [_window_bounds(d, k_, c) for d, k_, c in zip(dims, kernels, causal, strict=True)]
+    bounds = [
+        _window_bounds(d, k_, c) for d, k_, c in zip(dims, kernels, causal, strict=True)
+    ]
     tile_t, tile_h, tile_w = _pick_tiles(
         dims, [min(k_, d) for k_, d in zip(kernels, dims, strict=True)]
     )
@@ -163,7 +172,9 @@ def _eager_na3d(
             q_s = q_s.permute(0, 1, 5, 2, 3, 4, 6).reshape(g * batch, nh, nq, hd)
             k_s = k_s.permute(0, 1, 5, 2, 3, 4, 6).reshape(g * batch, nh, nk, hd)
             v_s = v_s.permute(0, 1, 5, 2, 3, 4, 6).reshape(g * batch, nh, nk, hd)
-            o = functional.scaled_dot_product_attention(q_s, k_s, v_s, attn_mask=mask, scale=1.0)
+            o = functional.scaled_dot_product_attention(
+                q_s, k_s, v_s, attn_mask=mask, scale=1.0
+            )
             o = o.view(g, batch, nh, tq, th, tw, hd).permute(0, 1, 3, 4, 5, 2, 6)
             for i, (qs, _) in enumerate(chunk):
                 out[:, qs[0], qs[1], qs[2]] = o[i]
@@ -182,24 +193,38 @@ class LTX2VideoVaeEagerSdpaAttnProcessor:
     comfy-kitchen / ltx-core).
     """
 
-    def __call__(self, attn: object, hidden_states: torch.Tensor, block_mask=None) -> torch.Tensor:
+    def __call__(
+        self, attn: object, hidden_states: torch.Tensor, block_mask=None
+    ) -> torch.Tensor:
         batch_size, num_frames, height, width, _ = hidden_states.shape
         query, key, value = attn.project_qkv(hidden_states)  # type: ignore[union-attr]
 
         # Reshape from (B, T*H*W, NH*HD) to (B, T, H, W, NH, HD) for _eager_na3d.
-        query = query.reshape(batch_size, num_frames, height, width, attn.heads, attn.head_dim)  # type: ignore[union-attr]
-        key = key.reshape(batch_size, num_frames, height, width, attn.heads, attn.head_dim)  # type: ignore[union-attr]
-        value = value.reshape(batch_size, num_frames, height, width, attn.heads, attn.head_dim)  # type: ignore[union-attr]
+        query = query.reshape(
+            batch_size, num_frames, height, width, attn.heads, attn.head_dim
+        )  # type: ignore[union-attr]
+        key = key.reshape(
+            batch_size, num_frames, height, width, attn.heads, attn.head_dim
+        )  # type: ignore[union-attr]
+        value = value.reshape(
+            batch_size, num_frames, height, width, attn.heads, attn.head_dim
+        )  # type: ignore[union-attr]
 
         # Q is already scaled in project_qkv (same convention as the NATTEN and
         # FlexAttention processors), so pass scale=1.0 to avoid double-scaling.
         hidden_states = _eager_na3d(
-            query, key, value,
+            query,
+            key,
+            value,
             kernel_size=list(attn.kernel_size),  # type: ignore[union-attr]
             scale=1.0,
         )
 
         hidden_states = hidden_states.reshape(
-            batch_size, num_frames, height, width, attn.heads * attn.head_dim  # type: ignore[union-attr]
+            batch_size,
+            num_frames,
+            height,
+            width,
+            attn.heads * attn.head_dim,  # type: ignore[union-attr]
         )
         return attn.to_out[0](hidden_states)  # type: ignore[union-attr]

--- a/xfuser/model_executor/layers/ltx2_na3d_eager_attn.py
+++ b/xfuser/model_executor/layers/ltx2_na3d_eager_attn.py
@@ -1,0 +1,205 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tiled SDPA neighborhood attention processor for LTX2VideoDiffusionDecoderModel.
+
+Provides a fallback when NATTEN kernels are unavailable.
+The core `_eager_na3d` function is ported from the LTX-2 reference codebase
+(comfy-kitchen, Apache-2.0), implementing 3D neighborhood attention via tiled
+`torch.nn.functional.scaled_dot_product_attention` calls with additive masks.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+from torch.nn import functional
+
+# Element budget for one tile's [Nq, Nk] attention mask (bounds the mask
+# allocation and, on CPU, the math-backend score materialization).
+_NA_SCORE_BUDGET = 2 ** 25
+# Element budget for the stacked K/V copies of one batched SDPA call on CUDA.
+_NA_KV_STACK_BUDGET = 2 ** 28
+
+
+def _window_bounds(length: int, kernel: int, causal: bool) -> tuple[list[int], list[int]]:
+    """Per-index (start, end) of the attended window along one axis."""
+    starts: list[int] = []
+    ends: list[int] = []
+    if causal:
+        for i in range(length):
+            starts.append(max(0, i - kernel + 1))
+            ends.append(i + 1)
+    else:
+        kernel = min(kernel, length)
+        lo = length - kernel
+        half = kernel // 2
+        for i in range(length):
+            start = min(max(i - half, 0), lo)
+            starts.append(start)
+            ends.append(start + kernel)
+    return starts, ends
+
+
+def _pick_tiles(dims: tuple[int, int, int], kernels: list[int]) -> list[int]:
+    """Per-axis query-tile lengths keeping one tile's [Nq, Nk] under budget."""
+    tiles = list(dims)
+
+    def cost(ts: list[int]) -> int:
+        nq = math.prod(ts)
+        nk = math.prod(min(d, t + k - 1) for t, k, d in zip(ts, kernels, dims, strict=True))
+        return nq * nk
+
+    while cost(tiles) > _NA_SCORE_BUDGET and max(tiles) > 1:
+        i = max(range(3), key=lambda a: tiles[a] / kernels[a])
+        if tiles[i] <= 1:
+            break
+        tiles[i] = max(1, (tiles[i] + 1) // 2)
+    return tiles
+
+
+def _group_mask(
+    rel_bounds: tuple[tuple[tuple[int, ...], tuple[int, ...]], ...],
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    """Additive ``[1, 1, Nq, Nk]`` mask for one tile-geometry group."""
+    bools = []
+    for starts, ends in rel_bounds:
+        st = torch.tensor(starts, device=device)
+        en = torch.tensor(ends, device=device)
+        kj = torch.arange(int(en.max()), device=device)
+        bools.append((kj[None, :] >= st[:, None]) & (kj[None, :] < en[:, None]))
+    visible = (
+        bools[0][:, None, None, :, None, None]
+        & bools[1][None, :, None, None, :, None]
+        & bools[2][None, None, :, None, None, :]
+    )
+    nq = visible.shape[0] * visible.shape[1] * visible.shape[2]
+    nk = visible.shape[3] * visible.shape[4] * visible.shape[5]
+    mask = torch.zeros((nq, nk), dtype=dtype, device=device)
+    mask.masked_fill_(~visible.reshape(nq, nk), torch.finfo(dtype).min)
+    return mask.reshape(1, 1, nq, nk)
+
+
+def _eager_na3d(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    kernel_size: list[int] | tuple[int, ...],
+    is_causal: list[bool] | None = None,
+    scale: float | None = None,
+) -> torch.Tensor:
+    """3D neighborhood attention over ``(B, T, H, W, NH, HD)`` tensors.
+
+    ``scale`` defaults to ``head_dim**-0.5``. Pass ``scale=1.0`` when Q is
+    already scaled.
+
+    Ported from LTX-2 reference (comfy-kitchen, Apache-2.0).
+    """
+    batch, t, h, w, nh, hd = q.shape
+    dims = (t, h, w)
+    causal = [False, False, False] if is_causal is None else list(is_causal)
+    kernels = [k_ if c else min(k_, d) for k_, c, d in zip(kernel_size, causal, dims, strict=True)]
+    if scale is None:
+        scale = hd ** -0.5
+    device = q.device
+    if scale != 1.0:
+        q = q * scale
+
+    bounds = [_window_bounds(d, k_, c) for d, k_, c in zip(dims, kernels, causal, strict=True)]
+    tile_t, tile_h, tile_w = _pick_tiles(
+        dims, [min(k_, d) for k_, d in zip(kernels, dims, strict=True)]
+    )
+
+    groups: dict = {}
+    for t0 in range(0, t, tile_t):
+        t1 = min(t0 + tile_t, t)
+        rt0, rt1 = bounds[0][0][t0], bounds[0][1][t1 - 1]
+        rel_t = (
+            tuple(s - rt0 for s in bounds[0][0][t0:t1]),
+            tuple(e - rt0 for e in bounds[0][1][t0:t1]),
+        )
+        for h0 in range(0, h, tile_h):
+            h1 = min(h0 + tile_h, h)
+            rh0, rh1 = bounds[1][0][h0], bounds[1][1][h1 - 1]
+            rel_h = (
+                tuple(s - rh0 for s in bounds[1][0][h0:h1]),
+                tuple(e - rh0 for e in bounds[1][1][h0:h1]),
+            )
+            for w0 in range(0, w, tile_w):
+                w1 = min(w0 + tile_w, w)
+                rw0, rw1 = bounds[2][0][w0], bounds[2][1][w1 - 1]
+                rel_w = (
+                    tuple(s - rw0 for s in bounds[2][0][w0:w1]),
+                    tuple(e - rw0 for e in bounds[2][1][w0:w1]),
+                )
+                groups.setdefault((rel_t, rel_h, rel_w), []).append(
+                    (
+                        (slice(t0, t1), slice(h0, h1), slice(w0, w1)),
+                        (slice(rt0, rt1), slice(rh0, rh1), slice(rw0, rw1)),
+                    )
+                )
+
+    out = torch.empty((batch, t, h, w, nh, hd), device=device, dtype=v.dtype)
+    for rel, tiles in groups.items():
+        mask = _group_mask(rel, q.dtype, device)
+        nq, nk = mask.shape[2], mask.shape[3]
+        g_max = (
+            max(1, _NA_KV_STACK_BUDGET // max(1, batch * nh * nk * hd * 2))
+            if device.type == "cuda"
+            else 1
+        )
+        qs0, _ = tiles[0]
+        tq = qs0[0].stop - qs0[0].start
+        th = qs0[1].stop - qs0[1].start
+        tw = qs0[2].stop - qs0[2].start
+        for c0 in range(0, len(tiles), g_max):
+            chunk = tiles[c0 : c0 + g_max]
+            g = len(chunk)
+            q_s = torch.stack([q[:, qs[0], qs[1], qs[2]] for qs, _ in chunk])
+            k_s = torch.stack([k[:, rs[0], rs[1], rs[2]] for _, rs in chunk])
+            v_s = torch.stack([v[:, rs[0], rs[1], rs[2]] for _, rs in chunk])
+            q_s = q_s.permute(0, 1, 5, 2, 3, 4, 6).reshape(g * batch, nh, nq, hd)
+            k_s = k_s.permute(0, 1, 5, 2, 3, 4, 6).reshape(g * batch, nh, nk, hd)
+            v_s = v_s.permute(0, 1, 5, 2, 3, 4, 6).reshape(g * batch, nh, nk, hd)
+            o = functional.scaled_dot_product_attention(q_s, k_s, v_s, attn_mask=mask, scale=1.0)
+            o = o.view(g, batch, nh, tq, th, tw, hd).permute(0, 1, 3, 4, 5, 2, 6)
+            for i, (qs, _) in enumerate(chunk):
+                out[:, qs[0], qs[1], qs[2]] = o[i]
+
+    return out
+
+
+class LTX2VideoVaeEagerSdpaAttnProcessor:
+    """CUDA/ROCm/CPU-compatible neighborhood attention via tiled PyTorch SDPA.
+
+    Drop-in replacement for ``LTX2VideoVaeNeighborhoodNattenProcessor`` that
+    requires no NATTEN or FlexAttention. Compatible with any device that supports
+    ``torch.nn.functional.scaled_dot_product_attention``.
+
+    Ported from the LTX-2 reference ``EagerSdpaAttention`` (Apache-2.0,
+    comfy-kitchen / ltx-core).
+    """
+
+    def __call__(self, attn: object, hidden_states: torch.Tensor, block_mask=None) -> torch.Tensor:
+        batch_size, num_frames, height, width, _ = hidden_states.shape
+        query, key, value = attn.project_qkv(hidden_states)  # type: ignore[union-attr]
+
+        # Reshape from (B, T*H*W, NH*HD) to (B, T, H, W, NH, HD) for _eager_na3d.
+        query = query.reshape(batch_size, num_frames, height, width, attn.heads, attn.head_dim)  # type: ignore[union-attr]
+        key = key.reshape(batch_size, num_frames, height, width, attn.heads, attn.head_dim)  # type: ignore[union-attr]
+        value = value.reshape(batch_size, num_frames, height, width, attn.heads, attn.head_dim)  # type: ignore[union-attr]
+
+        # Q is already scaled in project_qkv (same convention as the NATTEN and
+        # FlexAttention processors), so pass scale=1.0 to avoid double-scaling.
+        hidden_states = _eager_na3d(
+            query, key, value,
+            kernel_size=list(attn.kernel_size),  # type: ignore[union-attr]
+            scale=1.0,
+        )
+
+        hidden_states = hidden_states.reshape(
+            batch_size, num_frames, height, width, attn.heads * attn.head_dim  # type: ignore[union-attr]
+        )
+        return attn.to_out[0](hidden_states)  # type: ignore[union-attr]

--- a/xfuser/model_executor/models/runner_models/ltx.py
+++ b/xfuser/model_executor/models/runner_models/ltx.py
@@ -625,11 +625,6 @@ class _xFuserLTX25VideoModelBase(xFuserModel):
                 **stage2_shared,
             )
         else:
-            from diffusers.pipelines.ltx2.utils import DEFAULT_NEGATIVE_PROMPT
-
-            shared["negative_prompt"] = input_args.get(
-                "negative_prompt", DEFAULT_NEGATIVE_PROMPT
-            )
             # Full model: single-stage with full guidance (STG, modality, CFG).
             shared["guidance_scale"] = input_args["guidance_scale"]
             shared["guidance_rescale"] = self._GUIDANCE_RESCALE

--- a/xfuser/model_executor/models/runner_models/ltx.py
+++ b/xfuser/model_executor/models/runner_models/ltx.py
@@ -545,7 +545,7 @@ class _xFuserLTX25VideoModelBase(xFuserModel):
             guidance_scale = input_args.get("guidance_scale")
             if guidance_scale != 1.0:
                 log(
-                    "Using guidance_scale=1.0. Other guindance scale values are not supported with this model."
+                    "Using guidance_scale=1.0. Other guidance scale values are not supported with this model."
                 )
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:

--- a/xfuser/model_executor/models/runner_models/ltx.py
+++ b/xfuser/model_executor/models/runner_models/ltx.py
@@ -439,19 +439,10 @@ class _xFuserLTX25VideoModelBase(xFuserModel):
         )
         from diffusers.pipelines.ltx2.latent_upsampler import LTX2LatentUpsamplerModel
 
-        use_sp = self.config.ulysses_degree > 1 or self.config.ring_degree > 1
-        if use_sp:
-            from xfuser.model_executor.models.transformers.transformer_ltx2 import (
-                xFuserLTX2VideoTransformer3DWrapper,
-            )
-
-            transformer_cls = xFuserLTX2VideoTransformer3DWrapper
-        else:
-            from diffusers.models.transformers.transformer_ltx2 import (
-                LTX2VideoTransformer3DModel,
-            )
-
-            transformer_cls = LTX2VideoTransformer3DModel
+        from xfuser.model_executor.models.transformers.transformer_ltx2 import (
+            xFuserLTX2VideoTransformer3DWrapper,
+        )
+        transformer_cls = xFuserLTX2VideoTransformer3DWrapper
 
         transformer = transformer_cls.from_pretrained(
             self.settings.model_name,

--- a/xfuser/model_executor/models/runner_models/ltx.py
+++ b/xfuser/model_executor/models/runner_models/ltx.py
@@ -1,41 +1,43 @@
-import torch
 import copy
+from types import SimpleNamespace
+from typing import ClassVar
+
+import torch
 from diffusers import FlowMatchEulerDiscreteScheduler
 from diffusers.pipelines.pipeline_utils import DiffusionPipeline
-from types import SimpleNamespace
+
+from xfuser.core.utils.runner_utils import log
+from xfuser.core.utils.video_utils import encode_video_with_audio
 from xfuser.envs import PACKAGES_CHECKER
 from xfuser.model_executor.models.runner_models.base_model import (
-    xFuserModel,
-    register_model,
+    DIFFUSERS_FROM_SOURCE,
     DefaultInputValues,
     DiffusionOutput,
-    ModelSettings,
     ModelCapabilities,
-    DIFFUSERS_FROM_SOURCE,
+    ModelSettings,
+    register_model,
+    xFuserModel,
 )
 
-from xfuser.core.utils.runner_utils import (
-    log,
+DEFAULT_NEGATIVE_PROMPT = (
+    ""
+    "blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, "
+    "grainy texture, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, "
+    "deformed facial features, asymmetrical face, missing facial features, extra limbs, disfigured hands, "
+    "wrong hand count, artifacts around text, inconsistent perspective, camera shake, incorrect depth of "
+    "field, background too sharp, background clutter, distracting reflections, harsh shadows, inconsistent "
+    "lighting direction, color banding, cartoonish rendering, 3D CGI look, unrealistic materials, uncanny "
+    "valley effect, incorrect ethnicity, wrong gender, exaggerated expressions, wrong gaze direction, "
+    "mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, background noise, "
+    "off-sync audio, incorrect dialogue, added dialogue, repetitive speech, jittery movement, awkward "
+    "pauses, incorrect timing, unnatural transitions, inconsistent framing, tilted camera, flat lighting, "
+    "inconsistent tone, cinematic oversaturation, stylized filters, or AI artifacts."
 )
-from xfuser.core.utils.video_utils import encode_video_with_audio
 
-DEFAULT_NEGATIVE_PROMPT = "" \
-"blurry, out of focus, overexposed, underexposed, low contrast, washed out colors, excessive noise, " \
-"grainy texture, poor lighting, flickering, motion blur, distorted proportions, unnatural skin tones, " \
-"deformed facial features, asymmetrical face, missing facial features, extra limbs, disfigured hands, " \
-"wrong hand count, artifacts around text, inconsistent perspective, camera shake, incorrect depth of " \
-"field, background too sharp, background clutter, distracting reflections, harsh shadows, inconsistent " \
-"lighting direction, color banding, cartoonish rendering, 3D CGI look, unrealistic materials, uncanny " \
-"valley effect, incorrect ethnicity, wrong gender, exaggerated expressions, wrong gaze direction, " \
-"mismatched lip sync, silent or muted audio, distorted voice, robotic voice, echo, background noise, " \
-"off-sync audio, incorrect dialogue, added dialogue, repetitive speech, jittery movement, awkward " \
-"pauses, incorrect timing, unnatural transitions, inconsistent framing, tilted camera, flat lighting, " \
-"inconsistent tone, cinematic oversaturation, stylized filters, or AI artifacts."
 
 @register_model("dg845/LTX-2.3-Diffusers")
 @register_model("LTX-2.3")
 class xFuserLTX23VideoModel(xFuserModel):
-
     min_diffusers_version = "0.37.0"
 
     default_input_values = DefaultInputValues(
@@ -63,7 +65,7 @@ class xFuserLTX23VideoModel(xFuserModel):
     )
 
     _STG_SCALE = 1.0
-    _SPATIO_TEMPORAL_GUIDANCE_BLOCKS = [28]
+    _SPATIO_TEMPORAL_GUIDANCE_BLOCKS: ClassVar[list[int]] = [28]
     _MODALITY_SCALE = 3.0
     _GUIDANCE_RESCALE = 0.7
     _AUDIO_GUIDANCE_SCALE = 7.0
@@ -72,11 +74,13 @@ class xFuserLTX23VideoModel(xFuserModel):
     _AUDIO_GUIDANCE_RESCALE = 0.7
 
     def _load_model(self) -> DiffusionPipeline:
-        from diffusers import LTX2Pipeline, LTX2LatentUpsamplePipeline
+        from diffusers import LTX2LatentUpsamplePipeline, LTX2Pipeline
         from diffusers.pipelines.ltx2.latent_upsampler import LTX2LatentUpsamplerModel
+
         from xfuser.model_executor.models.transformers.transformer_ltx2 import (
             xFuserLTX2VideoTransformer3DWrapper,
         )
+
         transformer = xFuserLTX2VideoTransformer3DWrapper.from_pretrained(
             self.settings.model_name,
             torch_dtype=torch.bfloat16,
@@ -108,7 +112,9 @@ class xFuserLTX23VideoModel(xFuserModel):
             subfolder="latent_upsampler",
             torch_dtype=torch.bfloat16,
         )
-        upsample_pipe = LTX2LatentUpsamplePipeline(vae=pipe.vae, latent_upsampler=latent_upsampler)
+        upsample_pipe = LTX2LatentUpsamplePipeline(
+            vae=pipe.vae, latent_upsampler=latent_upsampler
+        )
 
         second_pipe.vae.enable_tiling()
 
@@ -124,6 +130,7 @@ class xFuserLTX23VideoModel(xFuserModel):
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
         from diffusers.pipelines.ltx2.utils import STAGE_2_DISTILLED_SIGMA_VALUES
+
         generator = torch.Generator(device="cuda").manual_seed(input_args["seed"])
 
         # self.pipe and self.second_pipe share the same transformer object, so the
@@ -154,7 +161,9 @@ class xFuserLTX23VideoModel(xFuserModel):
             return_dict=False,
         )
 
-        video_latent = self.upsample_pipe(latents=video_latent, output_type="latent", return_dict=False)[0]
+        video_latent = self.upsample_pipe(
+            latents=video_latent, output_type="latent", return_dict=False
+        )[0]
 
         self.second_pipe.transformer.enable_adapters()
 
@@ -197,7 +206,9 @@ class xFuserLTX23VideoModel(xFuserModel):
 
         # two steps to warmup the torch compiler
         compile_args = copy.deepcopy(input_args)
-        compile_args["num_inference_steps"] = 2  # Reduce steps for warmup # TODO: make this more generic
+        compile_args["num_inference_steps"] = (
+            2  # Reduce steps for warmup # TODO: make this more generic
+        )
         self._run_timed_pipe(compile_args)
 
     def save_output(self, output: DiffusionOutput) -> None:
@@ -228,7 +239,6 @@ class xFuserLTX23VideoModel(xFuserModel):
 @register_model("Lightricks/LTX-2")
 @register_model("LTX-2")
 class xFuserLTX2VideoModel(xFuserModel):
-
     min_diffusers_version = "0.37.0"
 
     default_input_values = DefaultInputValues(
@@ -256,11 +266,13 @@ class xFuserLTX2VideoModel(xFuserModel):
     )
 
     def _load_model(self) -> DiffusionPipeline:
-        from diffusers import LTX2Pipeline, LTX2LatentUpsamplePipeline
+        from diffusers import LTX2LatentUpsamplePipeline, LTX2Pipeline
         from diffusers.pipelines.ltx2.latent_upsampler import LTX2LatentUpsamplerModel
+
         from xfuser.model_executor.models.transformers.transformer_ltx2 import (
             xFuserLTX2VideoTransformer3DWrapper,
         )
+
         transformer = xFuserLTX2VideoTransformer3DWrapper.from_pretrained(
             self.settings.model_name,
             torch_dtype=torch.bfloat16,
@@ -277,17 +289,23 @@ class xFuserLTX2VideoModel(xFuserModel):
             torch_dtype=torch.bfloat16,
         )
         second_pipe.load_lora_weights(
-            self.settings.model_name, adapter_name="stage_2_distilled", weight_name="ltx-2-19b-distilled-lora-384.safetensors"
+            self.settings.model_name,
+            adapter_name="stage_2_distilled",
+            weight_name="ltx-2-19b-distilled-lora-384.safetensors",
         )
         latent_upsampler = LTX2LatentUpsamplerModel.from_pretrained(
             self.settings.model_name,
             subfolder="latent_upsampler",
             torch_dtype=torch.bfloat16,
         )
-        upsample_pipe = LTX2LatentUpsamplePipeline(vae=pipe.vae, latent_upsampler=latent_upsampler)
+        upsample_pipe = LTX2LatentUpsamplePipeline(
+            vae=pipe.vae, latent_upsampler=latent_upsampler
+        )
 
-        second_pipe.scheduler = FlowMatchEulerDiscreteScheduler.from_config( # Scheduler for the 2nd stage
-            pipe.scheduler.config, use_dynamic_shifting=False, shift_terminal=None
+        second_pipe.scheduler = (
+            FlowMatchEulerDiscreteScheduler.from_config(  # Scheduler for the 2nd stage
+                pipe.scheduler.config, use_dynamic_shifting=False, shift_terminal=None
+            )
         )
         self.second_pipe = second_pipe
         self.upsample_pipe = upsample_pipe
@@ -303,6 +321,7 @@ class xFuserLTX2VideoModel(xFuserModel):
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
         from diffusers.pipelines.ltx2.utils import STAGE_2_DISTILLED_SIGMA_VALUES
+
         video_latent, audio_latent = self.pipe(
             prompt=input_args["prompt"],
             negative_prompt=input_args["negative_prompt"],
@@ -318,7 +337,9 @@ class xFuserLTX2VideoModel(xFuserModel):
             generator=torch.Generator(device="cuda").manual_seed(input_args["seed"]),
         )
 
-        video_latent = self.upsample_pipe(latents=video_latent, output_type="latent", return_dict=False)[0]
+        video_latent = self.upsample_pipe(
+            latents=video_latent, output_type="latent", return_dict=False
+        )[0]
 
         output = self.second_pipe(
             latents=video_latent,
@@ -345,7 +366,9 @@ class xFuserLTX2VideoModel(xFuserModel):
 
         # two steps to warmup the torch compiler
         compile_args = copy.deepcopy(input_args)
-        compile_args["num_inference_steps"] = 2  # Reduce steps for warmup # TODO: make this more generic
+        compile_args["num_inference_steps"] = (
+            2  # Reduce steps for warmup # TODO: make this more generic
+        )
         self._run_timed_pipe(compile_args)
 
     def save_output(self, output: DiffusionOutput) -> None:
@@ -390,7 +413,7 @@ class _xFuserLTX25VideoModelBase(xFuserModel):
     # Guidance defaults for the distilled path (no CFG / STG / modality boost).
     # xFuserLTX25FullVideoModel overrides these with LTX-2.4/2.5 params.
     _STG_SCALE: float = 0.0
-    _SPATIO_TEMPORAL_GUIDANCE_BLOCKS = None
+    _SPATIO_TEMPORAL_GUIDANCE_BLOCKS: ClassVar[list[int] | None] = None
     _MODALITY_SCALE: float = 1.0
     _GUIDANCE_RESCALE: float = 0.0
     _AUDIO_GUIDANCE_SCALE: float = 1.0
@@ -410,9 +433,9 @@ class _xFuserLTX25VideoModelBase(xFuserModel):
 
     def _load_model(self) -> DiffusionPipeline:
         from diffusers import (
-            LTX2Pipeline,
             LTX2ImageToVideoPipeline,
             LTX2LatentUpsamplePipeline,
+            LTX2Pipeline,
         )
         from diffusers.pipelines.ltx2.latent_upsampler import LTX2LatentUpsamplerModel
 
@@ -421,9 +444,13 @@ class _xFuserLTX25VideoModelBase(xFuserModel):
             from xfuser.model_executor.models.transformers.transformer_ltx2 import (
                 xFuserLTX2VideoTransformer3DWrapper,
             )
+
             transformer_cls = xFuserLTX2VideoTransformer3DWrapper
         else:
-            from diffusers.models.transformers.transformer_ltx2 import LTX2VideoTransformer3DModel
+            from diffusers.models.transformers.transformer_ltx2 import (
+                LTX2VideoTransformer3DModel,
+            )
+
             transformer_cls = LTX2VideoTransformer3DModel
 
         transformer = transformer_cls.from_pretrained(
@@ -432,7 +459,9 @@ class _xFuserLTX25VideoModelBase(xFuserModel):
             subfolder=self._TRANSFORMER_SUBFOLDER,
         )
 
-        pipe_cls = LTX2ImageToVideoPipeline if self.config.task == "i2v" else LTX2Pipeline
+        pipe_cls = (
+            LTX2ImageToVideoPipeline if self.config.task == "i2v" else LTX2Pipeline
+        )
         pipe = pipe_cls.from_pretrained(
             self.settings.model_name,
             transformer=transformer,
@@ -456,9 +485,6 @@ class _xFuserLTX25VideoModelBase(xFuserModel):
             self.upsample_pipe = LTX2LatentUpsamplePipeline(
                 vae=pipe.vae, latent_upsampler=latent_upsampler
             )
-            # Stage 2 always decodes at 2× spatial/temporal scale; tiling is
-            # required for correct results at normal output resolutions.
-            #pipe.vae.enable_tiling()
 
         # Diffusion decoder — replaces convolutional VAE decode for both distilled
         # and full model pipelines.
@@ -476,17 +502,21 @@ class _xFuserLTX25VideoModelBase(xFuserModel):
             from diffusers.models.autoencoders.ltx2_diffusion_decoder import (
                 LTX2VideoVaeNeighborhoodNattenProcessor,
             )
+
             diff_decoder.set_attn_processor(LTX2VideoVaeNeighborhoodNattenProcessor())
             log("Diffusion decoder: using NATTEN attention processor.")
-        except Exception:
+        except (ImportError, RuntimeError):
             # NATTEN is not available
             # Fall back to tiled PyTorch SDPA
             # Works on CUDA, ROCm and CPU. Ported from LTX-2 EagerSdpaAttention.
             from xfuser.model_executor.layers.ltx2_na3d_eager_attn import (
                 LTX2VideoVaeEagerSdpaAttnProcessor,
             )
+
             diff_decoder.set_attn_processor(LTX2VideoVaeEagerSdpaAttnProcessor())
-            log("Diffusion decoder: NATTEN unavailable; using Triton na3d attention fallback.")
+            log(
+                "Diffusion decoder: NATTEN unavailable; using Triton na3d attention fallback."
+            )
         self.decode_pipe = LTX2VideoDiffusionDecodePipeline(
             diffusion_decoder=diff_decoder,
             scheduler=pipe.scheduler,
@@ -526,7 +556,9 @@ class _xFuserLTX25VideoModelBase(xFuserModel):
                 )
             guidance_scale = input_args.get("guidance_scale")
             if guidance_scale != 1.0:
-                log(f"Using guidance_scale=1.0. Other guindance scale values are not supported with this model.")
+                log(
+                    "Using guidance_scale=1.0. Other guindance scale values are not supported with this model."
+                )
 
     def _run_pipe(self, input_args: dict) -> DiffusionOutput:
         from diffusers.pipelines.ltx2.utils import (
@@ -537,16 +569,16 @@ class _xFuserLTX25VideoModelBase(xFuserModel):
         is_i2v = self.config.task == "i2v"
         generator = torch.Generator(device="cuda").manual_seed(input_args["seed"])
 
-        shared = dict(
-            prompt=input_args["prompt"],
-            frame_rate=self.settings.fps,
-            stg_scale=self._STG_SCALE,
-            modality_scale=self._MODALITY_SCALE,
-            audio_guidance_scale=self._AUDIO_GUIDANCE_SCALE,
-            audio_stg_scale=self._AUDIO_STG_SCALE,
-            audio_modality_scale=self._AUDIO_MODALITY_SCALE,
-            generator=generator,
-        )
+        shared = {
+            "prompt": input_args["prompt"],
+            "frame_rate": self.settings.fps,
+            "stg_scale": self._STG_SCALE,
+            "modality_scale": self._MODALITY_SCALE,
+            "audio_guidance_scale": self._AUDIO_GUIDANCE_SCALE,
+            "audio_stg_scale": self._AUDIO_STG_SCALE,
+            "audio_modality_scale": self._AUDIO_MODALITY_SCALE,
+            "generator": generator,
+        }
         if is_i2v:
             shared["image"] = input_args["image"]
 
@@ -568,20 +600,20 @@ class _xFuserLTX25VideoModelBase(xFuserModel):
             )[0]
 
             # Stage-2: guidance disabled.
-            stage2_shared = dict(
-                prompt=input_args["prompt"],
-                frame_rate=self.settings.fps,
-                guidance_scale=1.0,
-                stg_scale=0.0,
-                modality_scale=1.0,
-                audio_guidance_scale=1.0,
-                audio_stg_scale=0.0,
-                audio_modality_scale=1.0,
-                generator=generator,
-            )
+            stage2_shared = {
+                "prompt": input_args["prompt"],
+                "frame_rate": self.settings.fps,
+                "guidance_scale": 1.0,
+                "stg_scale": 0.0,
+                "modality_scale": 1.0,
+                "audio_guidance_scale": 1.0,
+                "audio_stg_scale": 0.0,
+                "audio_modality_scale": 1.0,
+                "generator": generator,
+            }
             if is_i2v:
                 stage2_shared["image"] = input_args["image"]
-            
+
             video_latents, audio_latents = self.pipe(
                 num_frames=input_args["num_frames"],
                 sigmas=STAGE_2_DISTILLED_SIGMA_VALUES,
@@ -594,14 +626,19 @@ class _xFuserLTX25VideoModelBase(xFuserModel):
             )
         else:
             from diffusers.pipelines.ltx2.utils import DEFAULT_NEGATIVE_PROMPT
-            shared["negative_prompt"] = input_args.get("negative_prompt", DEFAULT_NEGATIVE_PROMPT)
+
+            shared["negative_prompt"] = input_args.get(
+                "negative_prompt", DEFAULT_NEGATIVE_PROMPT
+            )
             # Full model: single-stage with full guidance (STG, modality, CFG).
             shared["guidance_scale"] = input_args["guidance_scale"]
             shared["guidance_rescale"] = self._GUIDANCE_RESCALE
             shared["audio_guidance_rescale"] = self._AUDIO_GUIDANCE_RESCALE
             shared["use_cross_timestep"] = True
             if self._SPATIO_TEMPORAL_GUIDANCE_BLOCKS is not None:
-                shared["spatio_temporal_guidance_blocks"] = self._SPATIO_TEMPORAL_GUIDANCE_BLOCKS
+                shared["spatio_temporal_guidance_blocks"] = (
+                    self._SPATIO_TEMPORAL_GUIDANCE_BLOCKS
+                )
             video_latents, audio_latents = self.pipe(
                 height=input_args["height"],
                 width=input_args["width"],
@@ -650,8 +687,10 @@ class _xFuserLTX25VideoModelBase(xFuserModel):
             # with guidance), so the hook must fire per-invocation.
             # Mirrors diffusers_adapters/flux2.py
             if hasattr(torch.compiler, "cudagraph_mark_step_begin"):
+
                 def _mark_cudagraph_step(module, args, kwargs):
                     torch.compiler.cudagraph_mark_step_begin()
+
                 self.pipe.transformer.register_forward_pre_hook(
                     _mark_cudagraph_step, with_kwargs=True, prepend=True
                 )
@@ -729,13 +768,13 @@ class xFuserLTX25FullVideoModel(_xFuserLTX25VideoModelBase):
     """
 
     _TRANSFORMER_SUBFOLDER = "transformer_full"
-    _DISTILLED = False   # single-stage, no upsampler
+    _DISTILLED = False  # single-stage, no upsampler
 
     # Full-model guidance parameters - LTX-2.4/2.5 params:
     # video:  cfg_scale=3.0, stg_scale=1.0, rescale_scale=0.7, modality_scale=3.0, stg_blocks=[28]
     # audio:  cfg_scale=7.0, stg_scale=1.0, rescale_scale=0.7, modality_scale=3.0, stg_blocks=[28]
     _STG_SCALE = 1.0
-    _SPATIO_TEMPORAL_GUIDANCE_BLOCKS = [28]
+    _SPATIO_TEMPORAL_GUIDANCE_BLOCKS: ClassVar[list[int]] = [28]
     _MODALITY_SCALE = 3.0
     _GUIDANCE_RESCALE = 0.7
     _AUDIO_GUIDANCE_SCALE = 7.0

--- a/xfuser/model_executor/models/runner_models/ltx.py
+++ b/xfuser/model_executor/models/runner_models/ltx.py
@@ -633,6 +633,7 @@ class _xFuserLTX25VideoModelBase(xFuserModel):
             shared["guidance_rescale"] = self._GUIDANCE_RESCALE
             shared["audio_guidance_rescale"] = self._AUDIO_GUIDANCE_RESCALE
             shared["use_cross_timestep"] = True
+            shared["negative_prompt"] = input_args["negative_prompt"]
             if self._SPATIO_TEMPORAL_GUIDANCE_BLOCKS is not None:
                 shared["spatio_temporal_guidance_blocks"] = (
                     self._SPATIO_TEMPORAL_GUIDANCE_BLOCKS

--- a/xfuser/model_executor/models/runner_models/ltx.py
+++ b/xfuser/model_executor/models/runner_models/ltx.py
@@ -2,6 +2,7 @@ import torch
 import copy
 from diffusers import FlowMatchEulerDiscreteScheduler
 from diffusers.pipelines.pipeline_utils import DiffusionPipeline
+from types import SimpleNamespace
 from xfuser.envs import PACKAGES_CHECKER
 from xfuser.model_executor.models.runner_models.base_model import (
     xFuserModel,
@@ -10,6 +11,7 @@ from xfuser.model_executor.models.runner_models.base_model import (
     DiffusionOutput,
     ModelSettings,
     ModelCapabilities,
+    DIFFUSERS_FROM_SOURCE,
 )
 
 from xfuser.core.utils.runner_utils import (
@@ -368,3 +370,394 @@ class xFuserLTX2VideoModel(xFuserModel):
         super()._post_load_and_state_initialization(input_args)
         self.upsample_pipe.to(self.pipe.device)
         self.second_pipe.to(self.pipe.device)
+
+
+class _xFuserLTX25VideoModelBase(xFuserModel):
+    """Shared lifecycle logic for LTX-2.5 distilled and full runner variants.
+
+    Subclasses set:
+        _TRANSFORMER_SUBFOLDER : str   – "transformer" or "transformer_full"
+        _DISTILLED             : bool  – selects the two-stage vs single-stage
+                                         inference recipe
+
+    Guidance knobs default to distilled (no-guidance) values here.
+    xFuserLTX25FullVideoModel overrides them with the full-model reference
+    parameters from LTX-2 package constants.py.
+    """
+
+    _TRANSFORMER_SUBFOLDER: str = "transformer"
+    _DISTILLED: bool = True
+    # Guidance defaults for the distilled path (no CFG / STG / modality boost).
+    # xFuserLTX25FullVideoModel overrides these with LTX-2.4/2.5 params.
+    _STG_SCALE: float = 0.0
+    _SPATIO_TEMPORAL_GUIDANCE_BLOCKS = None
+    _MODALITY_SCALE: float = 1.0
+    _GUIDANCE_RESCALE: float = 0.0
+    _AUDIO_GUIDANCE_SCALE: float = 1.0
+    _AUDIO_STG_SCALE: float = 0.0
+    _AUDIO_MODALITY_SCALE: float = 1.0
+    _AUDIO_GUIDANCE_RESCALE: float = 0.0
+
+    min_diffusers_version = DIFFUSERS_FROM_SOURCE
+
+    capabilities = ModelCapabilities(
+        ulysses_degree=True,
+        ring_degree=True,
+        enable_tiling=True,
+        enable_slicing=True,
+        use_fp8_gemms=True,
+    )
+
+    def _load_model(self) -> DiffusionPipeline:
+        from diffusers import (
+            LTX2Pipeline,
+            LTX2ImageToVideoPipeline,
+            LTX2LatentUpsamplePipeline,
+        )
+        from diffusers.pipelines.ltx2.latent_upsampler import LTX2LatentUpsamplerModel
+
+        use_sp = self.config.ulysses_degree > 1 or self.config.ring_degree > 1
+        if use_sp:
+            from xfuser.model_executor.models.transformers.transformer_ltx2 import (
+                xFuserLTX2VideoTransformer3DWrapper,
+            )
+            transformer_cls = xFuserLTX2VideoTransformer3DWrapper
+        else:
+            from diffusers.models.transformers.transformer_ltx2 import LTX2VideoTransformer3DModel
+            transformer_cls = LTX2VideoTransformer3DModel
+
+        transformer = transformer_cls.from_pretrained(
+            self.settings.model_name,
+            torch_dtype=torch.bfloat16,
+            subfolder=self._TRANSFORMER_SUBFOLDER,
+        )
+
+        pipe_cls = LTX2ImageToVideoPipeline if self.config.task == "i2v" else LTX2Pipeline
+        pipe = pipe_cls.from_pretrained(
+            self.settings.model_name,
+            transformer=transformer,
+            torch_dtype=torch.bfloat16,
+        )
+
+        if not self._DISTILLED:
+            # Full model uses a dynamic-shifting schedule
+            pipe.scheduler = FlowMatchEulerDiscreteScheduler.from_config(
+                pipe.scheduler.config,
+                use_dynamic_shifting=True,
+                shift_terminal=0.1,
+            )
+
+        if self._DISTILLED:
+            latent_upsampler = LTX2LatentUpsamplerModel.from_pretrained(
+                self.settings.model_name,
+                subfolder="latent_upsampler",
+                torch_dtype=torch.bfloat16,
+            )
+            self.upsample_pipe = LTX2LatentUpsamplePipeline(
+                vae=pipe.vae, latent_upsampler=latent_upsampler
+            )
+            # Stage 2 always decodes at 2× spatial/temporal scale; tiling is
+            # required for correct results at normal output resolutions.
+            #pipe.vae.enable_tiling()
+
+        # Diffusion decoder — replaces convolutional VAE decode for both distilled
+        # and full model pipelines.
+        from diffusers import LTX2VideoDiffusionDecoderModel
+        from diffusers.pipelines.ltx2.pipeline_ltx2_diffusion_decode import (
+            LTX2VideoDiffusionDecodePipeline,
+        )
+
+        diff_decoder = LTX2VideoDiffusionDecoderModel.from_pretrained(
+            self.settings.model_name,
+            subfolder="diffusion_decoder",
+            torch_dtype=torch.bfloat16,
+        )
+        try:
+            from diffusers.models.autoencoders.ltx2_diffusion_decoder import (
+                LTX2VideoVaeNeighborhoodNattenProcessor,
+            )
+            diff_decoder.set_attn_processor(LTX2VideoVaeNeighborhoodNattenProcessor())
+            log("Diffusion decoder: using NATTEN attention processor.")
+        except Exception:
+            # NATTEN is not available
+            # Fall back to tiled PyTorch SDPA
+            # Works on CUDA, ROCm and CPU. Ported from LTX-2 EagerSdpaAttention.
+            from xfuser.model_executor.layers.ltx2_na3d_eager_attn import (
+                LTX2VideoVaeEagerSdpaAttnProcessor,
+            )
+            diff_decoder.set_attn_processor(LTX2VideoVaeEagerSdpaAttnProcessor())
+            log("Diffusion decoder: NATTEN unavailable; using Triton na3d attention fallback.")
+        self.decode_pipe = LTX2VideoDiffusionDecodePipeline(
+            diffusion_decoder=diff_decoder,
+            scheduler=pipe.scheduler,
+        )
+
+        return pipe
+
+    def _enable_options(self) -> None:
+        super()._enable_options()
+        if self.config.enable_tiling:
+            self.pipe.vae.enable_tiling()
+            self.decode_pipe.diffusion_decoder.enable_tiling()
+        if self.config.enable_slicing:
+            self.pipe.vae.enable_slicing()
+            self.decode_pipe.diffusion_decoder.enable_slicing()
+
+    def _preprocess_args_images(self, input_args: dict) -> dict:
+        input_args = super()._preprocess_args_images(input_args)
+        if self.config.task == "i2v":
+            input_args["image"] = input_args["input_images"][0]
+        return input_args
+
+    def _validate_args(self, input_args: dict) -> None:
+        super()._validate_args(input_args)
+        if self.config.task == "i2v":
+            images = input_args.get("input_images") or []
+            if len(images) != 1:
+                raise ValueError(
+                    f"LTX-2.5 I2V requires exactly one input image, got {len(images)}."
+                )
+        if self._DISTILLED:
+            steps = input_args.get("num_inference_steps")
+            if steps != 8:
+                raise ValueError(
+                    f"LTX-2.5 distilled uses a fixed 8-step schedule; "
+                    f"num_inference_steps must be 8, got {steps}."
+                )
+            guidance_scale = input_args.get("guidance_scale")
+            if guidance_scale != 1.0:
+                log(f"Using guidance_scale=1.0. Other guindance scale values are not supported with this model.")
+
+    def _run_pipe(self, input_args: dict) -> DiffusionOutput:
+        from diffusers.pipelines.ltx2.utils import (
+            DISTILLED_SIGMA_VALUES,
+            STAGE_2_DISTILLED_SIGMA_VALUES,
+        )
+
+        is_i2v = self.config.task == "i2v"
+        generator = torch.Generator(device="cuda").manual_seed(input_args["seed"])
+
+        shared = dict(
+            prompt=input_args["prompt"],
+            frame_rate=self.settings.fps,
+            stg_scale=self._STG_SCALE,
+            modality_scale=self._MODALITY_SCALE,
+            audio_guidance_scale=self._AUDIO_GUIDANCE_SCALE,
+            audio_stg_scale=self._AUDIO_STG_SCALE,
+            audio_modality_scale=self._AUDIO_MODALITY_SCALE,
+            generator=generator,
+        )
+        if is_i2v:
+            shared["image"] = input_args["image"]
+
+        if self._DISTILLED:
+            # Distilled model: no guidance, fixed 8-step sigma schedule.
+            shared["guidance_scale"] = 1.0
+            video_latent, audio_latent = self.pipe(
+                height=input_args["height"] // 2,
+                width=input_args["width"] // 2,
+                num_frames=input_args["num_frames"],
+                sigmas=DISTILLED_SIGMA_VALUES,
+                output_type="latent",
+                return_dict=False,
+                **shared,
+            )
+
+            video_latent = self.upsample_pipe(
+                latents=video_latent, output_type="latent", return_dict=False
+            )[0]
+
+            # Stage-2: guidance disabled.
+            stage2_shared = dict(
+                prompt=input_args["prompt"],
+                frame_rate=self.settings.fps,
+                guidance_scale=1.0,
+                stg_scale=0.0,
+                modality_scale=1.0,
+                audio_guidance_scale=1.0,
+                audio_stg_scale=0.0,
+                audio_modality_scale=1.0,
+                generator=generator,
+            )
+            if is_i2v:
+                stage2_shared["image"] = input_args["image"]
+            
+            video_latents, audio_latents = self.pipe(
+                num_frames=input_args["num_frames"],
+                sigmas=STAGE_2_DISTILLED_SIGMA_VALUES,
+                latents=video_latent,
+                audio_latents=audio_latent,
+                noise_scale=STAGE_2_DISTILLED_SIGMA_VALUES[0],
+                output_type="latent",
+                return_dict=False,
+                **stage2_shared,
+            )
+        else:
+            from diffusers.pipelines.ltx2.utils import DEFAULT_NEGATIVE_PROMPT
+            shared["negative_prompt"] = input_args.get("negative_prompt", DEFAULT_NEGATIVE_PROMPT)
+            # Full model: single-stage with full guidance (STG, modality, CFG).
+            shared["guidance_scale"] = input_args["guidance_scale"]
+            shared["guidance_rescale"] = self._GUIDANCE_RESCALE
+            shared["audio_guidance_rescale"] = self._AUDIO_GUIDANCE_RESCALE
+            shared["use_cross_timestep"] = True
+            if self._SPATIO_TEMPORAL_GUIDANCE_BLOCKS is not None:
+                shared["spatio_temporal_guidance_blocks"] = self._SPATIO_TEMPORAL_GUIDANCE_BLOCKS
+            video_latents, audio_latents = self.pipe(
+                height=input_args["height"],
+                width=input_args["width"],
+                num_frames=input_args["num_frames"],
+                num_inference_steps=input_args["num_inference_steps"],
+                output_type="latent",
+                return_dict=False,
+                **shared,
+            )
+
+        # Diffusion decode (replaces convolutional VAE decode)
+        video_np = self.decode_pipe(
+            video_latents,
+            generator=generator,
+            output_type="np",
+            denormalize=False,
+            return_dict=False,
+        )[0]  # (B, T, H, W, C) float32 in [0, 1]
+
+        # Audio: pipeline returned raw audio latents when output_type="latent".
+        # Decode via audio_vae -> mel -> vocoder -> waveform.
+        mel = self.pipe.audio_vae.decode(
+            audio_latents.to(self.pipe.audio_vae.dtype), return_dict=False
+        )[0]
+        audio_waveform = self.pipe.vocoder(mel)
+
+        output = SimpleNamespace(frames=video_np, audio=audio_waveform)
+        return DiffusionOutput(videos=output, pipe_args=input_args)
+
+    def _get_compile_mode(self) -> str:
+        if PACKAGES_CHECKER._on_rdna4():
+            return "default"
+        return "reduce-overhead"
+
+    def _compile_model(self, input_args: dict) -> None:
+        super()._enable_compute_comm_overlap()
+
+        if hasattr(self.pipe.transformer, "compile_repeated_blocks"):
+            # xFuser wrapper: compiles each block; the wrapper forward adds
+            # .clone() between calls to prevent pytorch#152887 CUDAGraph aliasing.
+            self.pipe.transformer.compile_repeated_blocks(mode=self._get_compile_mode())
+            # Register a pre-hook so the CUDAGraph system gets a step-boundary
+            # signal before EVERY transformer forward (not just before the pipe
+            # call).  The denoising loop calls the transformer once per step
+            # (×8 for distilled stage-1, ×3 for stage-2, ×3× for full model
+            # with guidance), so the hook must fire per-invocation.
+            # Mirrors diffusers_adapters/flux2.py
+            if hasattr(torch.compiler, "cudagraph_mark_step_begin"):
+                def _mark_cudagraph_step(module, args, kwargs):
+                    torch.compiler.cudagraph_mark_step_begin()
+                self.pipe.transformer.register_forward_pre_hook(
+                    _mark_cudagraph_step, with_kwargs=True, prepend=True
+                )
+
+        compile_args = copy.deepcopy(input_args)
+        compile_args["num_inference_steps"] = 2
+        self._run_timed_pipe(compile_args)
+
+    def save_output(self, output: DiffusionOutput) -> None:
+        pipe_args = output.pipe_args
+        output = output.videos
+        audio_sample_rate = self.pipe.vocoder.config.output_sampling_rate
+        for i, video_object in enumerate(output):
+            video, audio = video_object.frames, video_object.audio
+            video = (video * 255).round().astype("uint8")
+            video = torch.from_numpy(video)
+            output_name = self.get_output_name(pipe_args[i])
+            output_path = f"{self.config.output_directory}/{output_name}_{i}.mp4"
+            encode_video_with_audio(
+                video[0],
+                audio=audio[0].float().cpu(),
+                audio_sample_rate=audio_sample_rate,
+                fps=self.settings.fps,
+                output_path=output_path,
+            )
+            log(f"Output video saved to {output_path}")
+
+    def _post_load_and_state_initialization(self, input_args: dict) -> None:
+        super()._post_load_and_state_initialization(input_args)
+        if self._DISTILLED:
+            self.upsample_pipe.to(self.pipe.device)
+        self.decode_pipe.diffusion_decoder.to(self.pipe.device)
+
+
+@register_model("Lightricks/LTX-2.5-Diffusers")
+@register_model("LTX-2.5-distilled")
+@register_model("LTX-2.5")
+class xFuserLTX25DistilledVideoModel(_xFuserLTX25VideoModelBase):
+    """LTX-2.5 distilled (default) T2V / I2V runner.
+
+    Uses the two-stage flow: stage-1 at half resolution with
+    DISTILLED_SIGMA_VALUES, spatial latent upsample, then stage-2 refine at
+    full resolution with STAGE_2_DISTILLED_SIGMA_VALUES.
+    """
+
+    _TRANSFORMER_SUBFOLDER = "transformer"
+    _DISTILLED = True
+
+    default_input_values = DefaultInputValues(
+        height=1024,
+        width=1536,
+        num_frames=121,
+        num_inference_steps=8,
+        guidance_scale=1.0,
+        negative_prompt=DEFAULT_NEGATIVE_PROMPT,
+    )
+
+    settings = ModelSettings(
+        model_name="Lightricks/LTX-2.5-Diffusers",
+        output_name="ltx_2_5_distilled_video",
+        model_output_type="video",
+        fps=24,
+        resolution_divisor=64,
+        valid_tasks=["t2v", "i2v"],
+        fp8_gemm_module_list=["transformer.transformer_blocks"],
+    )
+
+
+@register_model("LTX-2.5-full")
+class xFuserLTX25FullVideoModel(_xFuserLTX25VideoModelBase):
+    """LTX-2.5 full/SFT T2V / I2V runner.
+
+    Single-stage inference: full transformer, dynamic-shifting schedule,
+    full guidance (cfg=3.0, stg=1.0, modality=3.0).
+    """
+
+    _TRANSFORMER_SUBFOLDER = "transformer_full"
+    _DISTILLED = False   # single-stage, no upsampler
+
+    # Full-model guidance parameters - LTX-2.4/2.5 params:
+    # video:  cfg_scale=3.0, stg_scale=1.0, rescale_scale=0.7, modality_scale=3.0, stg_blocks=[28]
+    # audio:  cfg_scale=7.0, stg_scale=1.0, rescale_scale=0.7, modality_scale=3.0, stg_blocks=[28]
+    _STG_SCALE = 1.0
+    _SPATIO_TEMPORAL_GUIDANCE_BLOCKS = [28]
+    _MODALITY_SCALE = 3.0
+    _GUIDANCE_RESCALE = 0.7
+    _AUDIO_GUIDANCE_SCALE = 7.0
+    _AUDIO_STG_SCALE = 1.0
+    _AUDIO_MODALITY_SCALE = 3.0
+    _AUDIO_GUIDANCE_RESCALE = 0.7
+
+    default_input_values = DefaultInputValues(
+        height=1024,
+        width=1536,
+        num_frames=121,
+        num_inference_steps=30,
+        guidance_scale=3.0,
+        negative_prompt=DEFAULT_NEGATIVE_PROMPT,
+    )
+
+    settings = ModelSettings(
+        model_name="Lightricks/LTX-2.5-Diffusers",
+        output_name="ltx_2_5_full_video",
+        model_output_type="video",
+        fps=24,
+        resolution_divisor=64,
+        valid_tasks=["t2v", "i2v"],
+        fp8_gemm_module_list=["transformer.transformer_blocks"],
+    )

--- a/xfuser/model_executor/models/runner_models/ltx.py
+++ b/xfuser/model_executor/models/runner_models/ltx.py
@@ -429,6 +429,9 @@ class _xFuserLTX25VideoModelBase(xFuserModel):
         enable_tiling=True,
         enable_slicing=True,
         use_fp8_gemms=True,
+        use_fp4_gemms=True,
+        use_hybrid_attn_schedule=True,
+        use_hybrid_gemm_schedule=True,
     )
 
     def _load_model(self) -> DiffusionPipeline:
@@ -505,7 +508,7 @@ class _xFuserLTX25VideoModelBase(xFuserModel):
 
             diff_decoder.set_attn_processor(LTX2VideoVaeNeighborhoodNattenProcessor())
             log("Diffusion decoder: using NATTEN attention processor.")
-        except (ImportError, RuntimeError):
+        except (ImportError, RuntimeError, FileNotFoundError):
             # NATTEN is not available
             # Fall back to tiled PyTorch SDPA
             # Works on CUDA, ROCm and CPU. Ported from LTX-2 EagerSdpaAttention.
@@ -751,6 +754,7 @@ class xFuserLTX25DistilledVideoModel(_xFuserLTX25VideoModelBase):
         resolution_divisor=64,
         valid_tasks=["t2v", "i2v"],
         fp8_gemm_module_list=["transformer.transformer_blocks"],
+        fp4_gemm_module_list=["transformer.transformer_blocks"],
     )
 
 
@@ -794,4 +798,5 @@ class xFuserLTX25FullVideoModel(_xFuserLTX25VideoModelBase):
         resolution_divisor=64,
         valid_tasks=["t2v", "i2v"],
         fp8_gemm_module_list=["transformer.transformer_blocks"],
+        fp4_gemm_module_list=["transformer.transformer_blocks"],
     )

--- a/xfuser/model_executor/models/runner_models/ltx.py
+++ b/xfuser/model_executor/models/runner_models/ltx.py
@@ -427,11 +427,8 @@ class _xFuserLTX25VideoModelBase(xFuserModel):
         ulysses_degree=True,
         ring_degree=True,
         enable_tiling=True,
-        enable_slicing=True,
         use_fp8_gemms=True,
         use_fp4_gemms=True,
-        use_hybrid_attn_schedule=True,
-        use_hybrid_gemm_schedule=True,
     )
 
     def _load_model(self) -> DiffusionPipeline:
@@ -532,9 +529,6 @@ class _xFuserLTX25VideoModelBase(xFuserModel):
         if self.config.enable_tiling:
             self.pipe.vae.enable_tiling()
             self.decode_pipe.diffusion_decoder.enable_tiling()
-        if self.config.enable_slicing:
-            self.pipe.vae.enable_slicing()
-            self.decode_pipe.diffusion_decoder.enable_slicing()
 
     def _preprocess_args_images(self, input_args: dict) -> dict:
         input_args = super()._preprocess_args_images(input_args)

--- a/xfuser/model_executor/models/transformers/transformer_ltx2.py
+++ b/xfuser/model_executor/models/transformers/transformer_ltx2.py
@@ -65,13 +65,11 @@ class xFuserLTX2PerturbedAttnProcessor:
             ]
 
         if isinstance(attention_mask, AttentionMaskWithMeta):
+            # Only forward attn_mask. The varlen fields (indices_k etc.) are for
+            # self-attention where Q and K share the same sequence length; here the
+            # mask covers text encoder tokens (K) while Q is video tokens, so the
+            # varlen pack path in _varlen_pack_keys would mis-reshape the key tensor.
             attn_kw = {"attn_mask": attention_mask.attn_mask}
-            if attention_mask.indices_k is not None:
-                attn_kw.update(
-                    indices_k=attention_mask.indices_k,
-                    cu_seqlens_k=attention_mask.cu_seqlens_k,
-                    max_seqlen_k=attention_mask.max_seqlen_k,
-                )
         elif attention_mask is not None:
             attention_mask = attn.prepare_attention_mask(
                 attention_mask, sequence_length, batch_size
@@ -186,13 +184,11 @@ class xFuserLTX2AudioVideoAttnProcessor:
             ]
 
         if isinstance(attention_mask, AttentionMaskWithMeta):
+            # Only forward attn_mask. The varlen fields (indices_k etc.) are for
+            # self-attention where Q and K share the same sequence length; here the
+            # mask covers text encoder tokens (K) while Q is video tokens, so the
+            # varlen pack path in _varlen_pack_keys would mis-reshape the key tensor.
             attn_kw = {"attn_mask": attention_mask.attn_mask}
-            if attention_mask.indices_k is not None:
-                attn_kw.update(
-                    indices_k=attention_mask.indices_k,
-                    cu_seqlens_k=attention_mask.cu_seqlens_k,
-                    max_seqlen_k=attention_mask.max_seqlen_k,
-                )
         elif attention_mask is not None:
             attention_mask = attn.prepare_attention_mask(
                 attention_mask, sequence_length, batch_size

--- a/xfuser/model_executor/models/transformers/transformer_ltx2.py
+++ b/xfuser/model_executor/models/transformers/transformer_ltx2.py
@@ -1,26 +1,27 @@
+from typing import Any
+
 import torch
-from typing import Any, Dict, List, Optional, Tuple
 from diffusers.models.transformers.transformer_ltx2 import (
+    AudioVisualModelOutput,
     LTX2VideoTransformer3DModel,
     apply_interleaved_rotary_emb,
     apply_split_rotary_emb,
-    AudioVisualModelOutput,
 )
 from diffusers.utils import USE_PEFT_BACKEND, scale_lora_layers, unscale_lora_layers
 
+from xfuser.core.distributed import (
+    get_sequence_parallel_rank,
+    get_sequence_parallel_world_size,
+    get_sp_group,
+)
 from xfuser.model_executor.layers.attention_mask import (
     AttentionMaskWithMeta,
     make_attn_mask_with_meta,
 )
 from xfuser.model_executor.layers.usp import USP, attention
-from xfuser.core.distributed import (
-    get_sequence_parallel_world_size,
-    get_sequence_parallel_rank,
-    get_sp_group,
-)
 
 
-def _get_mask_meta(cache: dict, mask: Optional[torch.Tensor]) -> Optional[object]:
+def _get_mask_meta(cache: dict, mask: torch.Tensor | None) -> object | None:
     """Convert a 2-D boolean attention mask to AttentionMaskWithMeta, cached per tensor."""
     if mask is None or mask.ndim != 2:
         return mask
@@ -31,7 +32,6 @@ def _get_mask_meta(cache: dict, mask: Optional[torch.Tensor]) -> Optional[object
 
 
 class xFuserLTX2PerturbedAttnProcessor:
-
     def __init__(self, use_parallel_attention: bool = True, gather_kv=False):
         if use_parallel_attention:
             self.attention_method = USP
@@ -41,22 +41,28 @@ class xFuserLTX2PerturbedAttnProcessor:
 
     def __call__(
         self,
-        attn: "LTX2Attention",
+        attn: Any,
         hidden_states: torch.Tensor,
-        encoder_hidden_states: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        query_rotary_emb: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
-        key_rotary_emb: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
-        perturbation_mask: Optional[torch.Tensor] = None,
-        all_perturbed: Optional[bool] = None,
+        encoder_hidden_states: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        query_rotary_emb: tuple[torch.Tensor, torch.Tensor] | None = None,
+        key_rotary_emb: tuple[torch.Tensor, torch.Tensor] | None = None,
+        perturbation_mask: torch.Tensor | None = None,
+        all_perturbed: bool | None = None,
     ) -> torch.Tensor:
         batch_size, sequence_length, _ = (
-            hidden_states.shape if encoder_hidden_states is None else encoder_hidden_states.shape
+            hidden_states.shape
+            if encoder_hidden_states is None
+            else encoder_hidden_states.shape
         )
         if self.gather_kv:
-            encoder_hidden_states = get_sp_group().all_gather(encoder_hidden_states, dim=1)
+            encoder_hidden_states = get_sp_group().all_gather(
+                encoder_hidden_states, dim=1
+            )
             key_rotary_emb = [x.contiguous() for x in key_rotary_emb]
-            key_rotary_emb = [get_sp_group().all_gather(x, dim=2) for x in key_rotary_emb]
+            key_rotary_emb = [
+                get_sp_group().all_gather(x, dim=2) for x in key_rotary_emb
+            ]
 
         if isinstance(attention_mask, AttentionMaskWithMeta):
             attn_kw = {"attn_mask": attention_mask.attn_mask}
@@ -67,8 +73,12 @@ class xFuserLTX2PerturbedAttnProcessor:
                     max_seqlen_k=attention_mask.max_seqlen_k,
                 )
         elif attention_mask is not None:
-            attention_mask = attn.prepare_attention_mask(attention_mask, sequence_length, batch_size)
-            attention_mask = attention_mask.view(batch_size, attn.heads, -1, attention_mask.shape[-1])
+            attention_mask = attn.prepare_attention_mask(
+                attention_mask, sequence_length, batch_size
+            )
+            attention_mask = attention_mask.view(
+                batch_size, attn.heads, -1, attention_mask.shape[-1]
+            )
             attn_kw = {"attn_mask": attention_mask}
         else:
             attn_kw = None
@@ -80,7 +90,11 @@ class xFuserLTX2PerturbedAttnProcessor:
             gate_logits = attn.to_gate_logits(hidden_states)
         value = attn.to_v(encoder_hidden_states)
         if all_perturbed is None:
-            all_perturbed = torch.all(perturbation_mask == 0) if perturbation_mask is not None else False
+            all_perturbed = (
+                torch.all(perturbation_mask == 0)
+                if perturbation_mask is not None
+                else False
+            )
 
         if all_perturbed:
             hidden_states = value
@@ -95,18 +109,32 @@ class xFuserLTX2PerturbedAttnProcessor:
                 if attn.rope_type == "interleaved":
                     query = apply_interleaved_rotary_emb(query, query_rotary_emb)
                     key = apply_interleaved_rotary_emb(
-                        key, key_rotary_emb if key_rotary_emb is not None else query_rotary_emb
+                        key,
+                        key_rotary_emb
+                        if key_rotary_emb is not None
+                        else query_rotary_emb,
                     )
                 elif attn.rope_type == "split":
                     query = apply_split_rotary_emb(query, query_rotary_emb)
-                    key = apply_split_rotary_emb(key, key_rotary_emb if key_rotary_emb is not None else query_rotary_emb)
+                    key = apply_split_rotary_emb(
+                        key,
+                        key_rotary_emb
+                        if key_rotary_emb is not None
+                        else query_rotary_emb,
+                    )
 
             query = query.unflatten(2, (attn.heads, -1)).transpose(1, 2)
             key = key.unflatten(2, (attn.heads, -1)).transpose(1, 2)
             value = value.unflatten(2, (attn.heads, -1)).transpose(1, 2)
 
-            hidden_states = self.attention_method(query, key, value, dropout_p=0.0, is_causal=False,
-                                                  attention_kwargs=attn_kw)
+            hidden_states = self.attention_method(
+                query,
+                key,
+                value,
+                dropout_p=0.0,
+                is_causal=False,
+                attention_kwargs=attn_kw,
+            )
             hidden_states = hidden_states.transpose(1, 2).flatten(2, 3)
             hidden_states = hidden_states.to(query.dtype)
 
@@ -126,7 +154,6 @@ class xFuserLTX2PerturbedAttnProcessor:
 
 
 class xFuserLTX2AudioVideoAttnProcessor:
-
     def __init__(self, use_parallel_attention: bool = True, gather_kv=False):
         if use_parallel_attention:
             self.attention_method = USP
@@ -136,21 +163,27 @@ class xFuserLTX2AudioVideoAttnProcessor:
 
     def __call__(
         self,
-        attn: "LTX2Attention",
+        attn: Any,
         hidden_states: torch.Tensor,
-        encoder_hidden_states: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        query_rotary_emb: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
-        key_rotary_emb: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        encoder_hidden_states: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        query_rotary_emb: tuple[torch.Tensor, torch.Tensor] | None = None,
+        key_rotary_emb: tuple[torch.Tensor, torch.Tensor] | None = None,
     ) -> torch.Tensor:
         batch_size, sequence_length, _ = (
-            hidden_states.shape if encoder_hidden_states is None else encoder_hidden_states.shape
+            hidden_states.shape
+            if encoder_hidden_states is None
+            else encoder_hidden_states.shape
         )
 
         if self.gather_kv:
-            encoder_hidden_states = get_sp_group().all_gather(encoder_hidden_states, dim=1)
+            encoder_hidden_states = get_sp_group().all_gather(
+                encoder_hidden_states, dim=1
+            )
             key_rotary_emb = [x.contiguous() for x in key_rotary_emb]
-            key_rotary_emb = [get_sp_group().all_gather(x, dim=2) for x in key_rotary_emb]
+            key_rotary_emb = [
+                get_sp_group().all_gather(x, dim=2) for x in key_rotary_emb
+            ]
 
         if isinstance(attention_mask, AttentionMaskWithMeta):
             attn_kw = {"attn_mask": attention_mask.attn_mask}
@@ -161,8 +194,12 @@ class xFuserLTX2AudioVideoAttnProcessor:
                     max_seqlen_k=attention_mask.max_seqlen_k,
                 )
         elif attention_mask is not None:
-            attention_mask = attn.prepare_attention_mask(attention_mask, sequence_length, batch_size)
-            attention_mask = attention_mask.view(batch_size, attn.heads, -1, attention_mask.shape[-1])
+            attention_mask = attn.prepare_attention_mask(
+                attention_mask, sequence_length, batch_size
+            )
+            attention_mask = attention_mask.view(
+                batch_size, attn.heads, -1, attention_mask.shape[-1]
+            )
             attn_kw = {"attn_mask": attention_mask}
         else:
             attn_kw = None
@@ -184,18 +221,23 @@ class xFuserLTX2AudioVideoAttnProcessor:
             if attn.rope_type == "interleaved":
                 query = apply_interleaved_rotary_emb(query, query_rotary_emb)
                 key = apply_interleaved_rotary_emb(
-                    key, key_rotary_emb if key_rotary_emb is not None else query_rotary_emb
+                    key,
+                    key_rotary_emb if key_rotary_emb is not None else query_rotary_emb,
                 )
             elif attn.rope_type == "split":
                 query = apply_split_rotary_emb(query, query_rotary_emb)
-                key = apply_split_rotary_emb(key, key_rotary_emb if key_rotary_emb is not None else query_rotary_emb)
+                key = apply_split_rotary_emb(
+                    key,
+                    key_rotary_emb if key_rotary_emb is not None else query_rotary_emb,
+                )
 
         query = query.unflatten(2, (attn.heads, -1)).transpose(1, 2)
         key = key.unflatten(2, (attn.heads, -1)).transpose(1, 2)
         value = value.unflatten(2, (attn.heads, -1)).transpose(1, 2)
 
-        hidden_states = self.attention_method(query, key, value, dropout_p=0.0, is_causal=False,
-                                              attention_kwargs=attn_kw)
+        hidden_states = self.attention_method(
+            query, key, value, dropout_p=0.0, is_causal=False, attention_kwargs=attn_kw
+        )
         hidden_states = hidden_states.transpose(1, 2).flatten(2, 3)
         hidden_states = hidden_states.to(query.dtype)
 
@@ -211,24 +253,23 @@ class xFuserLTX2AudioVideoAttnProcessor:
 
 
 class xFuserLTX2VideoTransformer3DWrapper(LTX2VideoTransformer3DModel):
-
     def __init__(
         self,
         in_channels: int = 128,  # Video Arguments
-        out_channels: Optional[int] = 128,
+        out_channels: int | None = 128,
         patch_size: int = 1,
         patch_size_t: int = 1,
         num_attention_heads: int = 32,
         attention_head_dim: int = 128,
         cross_attention_dim: int = 4096,
-        vae_scale_factors: Tuple[int, int, int] = (8, 32, 32),
+        vae_scale_factors: tuple[int, int, int] = (8, 32, 32),
         pos_embed_max_pos: int = 20,
         base_height: int = 2048,
         base_width: int = 2048,
         gated_attn: bool = False,
         cross_attn_mod: bool = False,
         audio_in_channels: int = 128,  # Audio Arguments
-        audio_out_channels: Optional[int] = 128,
+        audio_out_channels: int | None = 128,
         audio_patch_size: int = 1,
         audio_patch_size_t: int = 1,
         audio_num_attention_heads: int = 32,
@@ -321,30 +362,49 @@ class xFuserLTX2VideoTransformer3DWrapper(LTX2VideoTransformer3DModel):
         for block in self.transformer_blocks:
             block.attn1.processor = attn_processor_cls()
             block.attn2.processor = attn_processor_cls(use_parallel_attention=False)
-            block.audio_attn1.processor = attn_processor_cls(use_parallel_attention=False)
-            block.audio_attn2.processor = attn_processor_cls(use_parallel_attention=False)
-            block.audio_to_video_attn.processor = attn_processor_cls(use_parallel_attention=False)
-            block.video_to_audio_attn.processor = attn_processor_cls(use_parallel_attention=False, gather_kv=True)
+            block.audio_attn1.processor = attn_processor_cls(
+                use_parallel_attention=False
+            )
+            block.audio_attn2.processor = attn_processor_cls(
+                use_parallel_attention=False
+            )
+            block.audio_to_video_attn.processor = attn_processor_cls(
+                use_parallel_attention=False
+            )
+            block.video_to_audio_attn.processor = attn_processor_cls(
+                use_parallel_attention=False, gather_kv=True
+            )
 
-
-    def _chunk_and_pad_sequence(self, x: torch.Tensor, sp_world_rank: int, sp_world_size: int, pad_amount: int, dim: int) -> torch.Tensor:
+    def _chunk_and_pad_sequence(
+        self,
+        x: torch.Tensor,
+        sp_world_rank: int,
+        sp_world_size: int,
+        pad_amount: int,
+        dim: int,
+    ) -> torch.Tensor:
         if pad_amount > 0:
             if dim < 0:
                 dim = x.ndim + dim
             pad_shape = list(x.shape)
             pad_shape[dim] = pad_amount
-            x = torch.cat([x,
-                        torch.zeros(
-                            pad_shape,
-                            dtype=x.dtype,
-                            device=x.device,
-                        )], dim=dim)
-        x = torch.chunk(x,
-                        sp_world_size,
-                        dim=dim)[sp_world_rank]
+            x = torch.cat(
+                [
+                    x,
+                    torch.zeros(
+                        pad_shape,
+                        dtype=x.dtype,
+                        device=x.device,
+                    ),
+                ],
+                dim=dim,
+            )
+        x = torch.chunk(x, sp_world_size, dim=dim)[sp_world_rank]
         return x
 
-    def _gather_and_unpad(self, x: torch.Tensor, pad_amount: int, dim: int) -> torch.Tensor:
+    def _gather_and_unpad(
+        self, x: torch.Tensor, pad_amount: int, dim: int
+    ) -> torch.Tensor:
         x = get_sp_group().all_gather(x, dim=dim)
         size = x.size(dim)
         return x.narrow(dim=dim, start=0, length=size - pad_amount)
@@ -356,23 +416,23 @@ class xFuserLTX2VideoTransformer3DWrapper(LTX2VideoTransformer3DModel):
         encoder_hidden_states: torch.Tensor,
         audio_encoder_hidden_states: torch.Tensor,
         timestep: torch.LongTensor,
-        audio_timestep: Optional[torch.LongTensor] = None,
-        sigma: Optional[torch.Tensor] = None,
-        audio_sigma: Optional[torch.Tensor] = None,
-        encoder_attention_mask: Optional[torch.Tensor] = None,
-        audio_encoder_attention_mask: Optional[torch.Tensor] = None,
-        num_frames: Optional[int] = None,
-        height: Optional[int] = None,
-        width: Optional[int] = None,
+        audio_timestep: torch.LongTensor | None = None,
+        sigma: torch.Tensor | None = None,
+        audio_sigma: torch.Tensor | None = None,
+        encoder_attention_mask: torch.Tensor | None = None,
+        audio_encoder_attention_mask: torch.Tensor | None = None,
+        num_frames: int | None = None,
+        height: int | None = None,
+        width: int | None = None,
         fps: float = 24.0,
-        audio_num_frames: Optional[int] = None,
-        video_coords: Optional[torch.Tensor] = None,
-        audio_coords: Optional[torch.Tensor] = None,
+        audio_num_frames: int | None = None,
+        video_coords: torch.Tensor | None = None,
+        audio_coords: torch.Tensor | None = None,
         isolate_modalities: bool = False,
-        spatio_temporal_guidance_blocks: Optional[List[int]] = None,
-        perturbation_mask: Optional[torch.Tensor] = None,
+        spatio_temporal_guidance_blocks: list[int] | None = None,
+        perturbation_mask: torch.Tensor | None = None,
         use_cross_timestep: bool = False,
-        attention_kwargs: Optional[Dict[str, Any]] = None,
+        attention_kwargs: dict[str, Any] | None = None,
         return_dict: bool = True,
     ) -> torch.Tensor:
         if attention_kwargs is not None:
@@ -384,14 +444,14 @@ class xFuserLTX2VideoTransformer3DWrapper(LTX2VideoTransformer3DModel):
         if USE_PEFT_BACKEND:
             scale_lora_layers(self, lora_scale)
 
-
-
         sp_world_rank = get_sequence_parallel_rank()
         sp_world_size = get_sequence_parallel_world_size()
 
         full_seq_len = hidden_states.shape[1]
         pad_amount = (sp_world_size - (full_seq_len % sp_world_size)) % sp_world_size
-        hidden_states = self._chunk_and_pad_sequence(hidden_states, sp_world_rank, sp_world_size, pad_amount, dim=1)
+        hidden_states = self._chunk_and_pad_sequence(
+            hidden_states, sp_world_rank, sp_world_size, pad_amount, dim=1
+        )
 
         # Determine timestep for audio before chunking the video-side timestep.
         # The pipeline passes audio_timestep as a separate per-sample tensor, so
@@ -404,10 +464,16 @@ class xFuserLTX2VideoTransformer3DWrapper(LTX2VideoTransformer3DModel):
         # the broadcast mismatch between chunked hidden_states [batch, local_seq, dim]
         # and embedded_timestep [batch, full_seq, dim] in the output scale/shift layer.
         if timestep.ndim == 2 and timestep.shape[1] == full_seq_len:
-            timestep = self._chunk_and_pad_sequence(timestep, sp_world_rank, sp_world_size, pad_amount, dim=1)
+            timestep = self._chunk_and_pad_sequence(
+                timestep, sp_world_rank, sp_world_size, pad_amount, dim=1
+            )
 
-        encoder_attention_mask = _get_mask_meta(self._enc_mask_cache, encoder_attention_mask)
-        audio_encoder_attention_mask = _get_mask_meta(self._audio_enc_mask_cache, audio_encoder_attention_mask)
+        encoder_attention_mask = _get_mask_meta(
+            self._enc_mask_cache, encoder_attention_mask
+        )
+        audio_encoder_attention_mask = _get_mask_meta(
+            self._audio_enc_mask_cache, audio_encoder_attention_mask
+        )
 
         batch_size = hidden_states.size(0)
 
@@ -421,14 +487,19 @@ class xFuserLTX2VideoTransformer3DWrapper(LTX2VideoTransformer3DModel):
                 batch_size, audio_num_frames, audio_hidden_states.device
             )
 
-
-        video_coords = self._chunk_and_pad_sequence(video_coords, sp_world_rank, sp_world_size, pad_amount, dim=2)
+        video_coords = self._chunk_and_pad_sequence(
+            video_coords, sp_world_rank, sp_world_size, pad_amount, dim=2
+        )
 
         video_rotary_emb = self.rope(video_coords, device=hidden_states.device)
 
-        audio_rotary_emb = self.audio_rope(audio_coords, device=audio_hidden_states.device)
+        audio_rotary_emb = self.audio_rope(
+            audio_coords, device=audio_hidden_states.device
+        )
 
-        video_cross_attn_rotary_emb = self.cross_attn_rope(video_coords[:, 0:1, :], device=hidden_states.device)
+        video_cross_attn_rotary_emb = self.cross_attn_rope(
+            video_coords[:, 0:1, :], device=hidden_states.device
+        )
         audio_cross_attn_rotary_emb = self.cross_attn_audio_rope(
             audio_coords[:, 0:1, :], device=audio_hidden_states.device
         )
@@ -439,7 +510,8 @@ class xFuserLTX2VideoTransformer3DWrapper(LTX2VideoTransformer3DModel):
 
         # 3. Prepare timestep embeddings and modulation parameters
         timestep_cross_attn_gate_scale_factor = (
-            self.config.cross_attn_timestep_scale_multiplier / self.config.timestep_scale_multiplier
+            self.config.cross_attn_timestep_scale_multiplier
+            / self.config.timestep_scale_multiplier
         )
 
         # 3.1. Prepare global modality (video and audio) timestep embedding and modulation parameters
@@ -452,7 +524,9 @@ class xFuserLTX2VideoTransformer3DWrapper(LTX2VideoTransformer3DModel):
         )
 
         temb = temb.view(batch_size, -1, temb.size(-1))
-        embedded_timestep = embedded_timestep.view(batch_size, -1, embedded_timestep.size(-1))
+        embedded_timestep = embedded_timestep.view(
+            batch_size, -1, embedded_timestep.size(-1)
+        )
 
         temb_audio, audio_embedded_timestep = self.audio_time_embed(
             audio_timestep.flatten(),
@@ -462,24 +536,34 @@ class xFuserLTX2VideoTransformer3DWrapper(LTX2VideoTransformer3DModel):
 
         temb_audio = temb_audio.view(batch_size, -1, temb_audio.size(-1))
 
-        audio_embedded_timestep = audio_embedded_timestep.view(batch_size, -1, audio_embedded_timestep.size(-1))
+        audio_embedded_timestep = audio_embedded_timestep.view(
+            batch_size, -1, audio_embedded_timestep.size(-1)
+        )
 
         if self.prompt_modulation and self.config.use_prompt_adaln_single:
             temb_prompt, _ = self.prompt_adaln(
                 sigma.flatten(), batch_size=batch_size, hidden_dtype=hidden_states.dtype
             )
             temb_prompt_audio, _ = self.audio_prompt_adaln(
-                audio_sigma.flatten(), batch_size=batch_size, hidden_dtype=audio_hidden_states.dtype
+                audio_sigma.flatten(),
+                batch_size=batch_size,
+                hidden_dtype=audio_hidden_states.dtype,
             )
             temb_prompt = temb_prompt.view(batch_size, -1, temb_prompt.size(-1))
-            temb_prompt_audio = temb_prompt_audio.view(batch_size, -1, temb_prompt_audio.size(-1))
+            temb_prompt_audio = temb_prompt_audio.view(
+                batch_size, -1, temb_prompt_audio.size(-1)
+            )
         else:
             temb_prompt = temb_prompt_audio = None
 
         # 3.2. Prepare global modality cross attention modulation parameters
         # LTX-2.3: use the cross-modality sigma (audio sigma for video CA, video sigma for audio CA)
-        video_ca_timestep = audio_sigma.flatten() if use_cross_timestep else timestep.flatten()
-        audio_ca_timestep = sigma.flatten() if use_cross_timestep else audio_timestep.flatten()
+        video_ca_timestep = (
+            audio_sigma.flatten() if use_cross_timestep else timestep.flatten()
+        )
+        audio_ca_timestep = (
+            sigma.flatten() if use_cross_timestep else audio_timestep.flatten()
+        )
 
         video_cross_attn_scale_shift, _ = self.av_cross_attn_video_scale_shift(
             video_ca_timestep,
@@ -495,7 +579,9 @@ class xFuserLTX2VideoTransformer3DWrapper(LTX2VideoTransformer3DModel):
         video_cross_attn_scale_shift = video_cross_attn_scale_shift.view(
             batch_size, -1, video_cross_attn_scale_shift.shape[-1]
         )
-        video_cross_attn_a2v_gate = video_cross_attn_a2v_gate.view(batch_size, -1, video_cross_attn_a2v_gate.shape[-1])
+        video_cross_attn_a2v_gate = video_cross_attn_a2v_gate.view(
+            batch_size, -1, video_cross_attn_a2v_gate.shape[-1]
+        )
 
         audio_cross_attn_scale_shift, _ = self.av_cross_attn_audio_scale_shift(
             audio_ca_timestep,
@@ -510,15 +596,23 @@ class xFuserLTX2VideoTransformer3DWrapper(LTX2VideoTransformer3DModel):
         audio_cross_attn_scale_shift = audio_cross_attn_scale_shift.view(
             batch_size, -1, audio_cross_attn_scale_shift.shape[-1]
         )
-        audio_cross_attn_v2a_gate = audio_cross_attn_v2a_gate.view(batch_size, -1, audio_cross_attn_v2a_gate.shape[-1])
+        audio_cross_attn_v2a_gate = audio_cross_attn_v2a_gate.view(
+            batch_size, -1, audio_cross_attn_v2a_gate.shape[-1]
+        )
 
         # 4. Prepare prompt embeddings (LTX-2.0)
         if self.config.use_prompt_embeddings:
             encoder_hidden_states = self.caption_projection(encoder_hidden_states)
-            encoder_hidden_states = encoder_hidden_states.view(batch_size, -1, hidden_states.size(-1))
+            encoder_hidden_states = encoder_hidden_states.view(
+                batch_size, -1, hidden_states.size(-1)
+            )
 
-            audio_encoder_hidden_states = self.audio_caption_projection(audio_encoder_hidden_states)
-            audio_encoder_hidden_states = audio_encoder_hidden_states.view(batch_size, -1, audio_hidden_states.size(-1))
+            audio_encoder_hidden_states = self.audio_caption_projection(
+                audio_encoder_hidden_states
+            )
+            audio_encoder_hidden_states = audio_encoder_hidden_states.view(
+                batch_size, -1, audio_hidden_states.size(-1)
+            )
 
         # 5. Run transformer blocks
         stg_blocks = set(spatio_temporal_guidance_blocks or [])
@@ -533,9 +627,11 @@ class xFuserLTX2VideoTransformer3DWrapper(LTX2VideoTransformer3DModel):
             is_stg_block = block_i in stg_blocks
             block_all_perturbed = default_all_perturbed if is_stg_block else False
             block_perturbation_mask = (
-                perturbation_mask if (is_stg_block and not default_all_perturbed) else None
+                perturbation_mask
+                if (is_stg_block and not default_all_perturbed)
+                else None
             )
-            
+
             if torch.is_grad_enabled() and self.gradient_checkpointing:
                 hidden_states, audio_hidden_states = self._gradient_checkpointing_func(
                     block,
@@ -600,7 +696,9 @@ class xFuserLTX2VideoTransformer3DWrapper(LTX2VideoTransformer3DModel):
                 audio_hidden_states = audio_hidden_states.clone()
 
         # 6. Output layers (including unpatchification)
-        scale_shift_values = self.scale_shift_table[None, None] + embedded_timestep[:, :, None]
+        scale_shift_values = (
+            self.scale_shift_table[None, None] + embedded_timestep[:, :, None]
+        )
         shift, scale = scale_shift_values[:, :, 0], scale_shift_values[:, :, 1]
 
         hidden_states = self.norm_out(hidden_states)
@@ -609,8 +707,14 @@ class xFuserLTX2VideoTransformer3DWrapper(LTX2VideoTransformer3DModel):
 
         output = self._gather_and_unpad(output, pad_amount, dim=1)
 
-        audio_scale_shift_values = self.audio_scale_shift_table[None, None] + audio_embedded_timestep[:, :, None]
-        audio_shift, audio_scale = audio_scale_shift_values[:, :, 0], audio_scale_shift_values[:, :, 1]
+        audio_scale_shift_values = (
+            self.audio_scale_shift_table[None, None]
+            + audio_embedded_timestep[:, :, None]
+        )
+        audio_shift, audio_scale = (
+            audio_scale_shift_values[:, :, 0],
+            audio_scale_shift_values[:, :, 1],
+        )
 
         audio_hidden_states = self.audio_norm_out(audio_hidden_states)
         audio_hidden_states = audio_hidden_states * (1 + audio_scale) + audio_shift

--- a/xfuser/model_executor/models/transformers/transformer_ltx2.py
+++ b/xfuser/model_executor/models/transformers/transformer_ltx2.py
@@ -6,25 +6,28 @@ from diffusers.models.transformers.transformer_ltx2 import (
     apply_split_rotary_emb,
     AudioVisualModelOutput,
 )
+from diffusers.utils import USE_PEFT_BACKEND, scale_lora_layers, unscale_lora_layers
 
-from diffusers.utils import (
-    USE_PEFT_BACKEND,
-    scale_lora_layers,
-    unscale_lora_layers,
+from xfuser.model_executor.layers.attention_mask import (
+    AttentionMaskWithMeta,
+    make_attn_mask_with_meta,
 )
-
-
-
-from xfuser.model_executor.layers.usp import (
-    USP,
-    attention,
-)
-
+from xfuser.model_executor.layers.usp import USP, attention
 from xfuser.core.distributed import (
     get_sequence_parallel_world_size,
     get_sequence_parallel_rank,
     get_sp_group,
 )
+
+
+def _get_mask_meta(cache: dict, mask: Optional[torch.Tensor]) -> Optional[object]:
+    """Convert a 2-D boolean attention mask to AttentionMaskWithMeta, cached per tensor."""
+    if mask is None or mask.ndim != 2:
+        return mask
+    key = (mask.data_ptr(), tuple(mask.shape))
+    if key not in cache:
+        cache[key] = make_attn_mask_with_meta(mask)
+    return cache[key]
 
 
 class xFuserLTX2PerturbedAttnProcessor:
@@ -55,9 +58,20 @@ class xFuserLTX2PerturbedAttnProcessor:
             key_rotary_emb = [x.contiguous() for x in key_rotary_emb]
             key_rotary_emb = [get_sp_group().all_gather(x, dim=2) for x in key_rotary_emb]
 
-        if attention_mask is not None:
+        if isinstance(attention_mask, AttentionMaskWithMeta):
+            attn_kw = {"attn_mask": attention_mask.attn_mask}
+            if attention_mask.indices_k is not None:
+                attn_kw.update(
+                    indices_k=attention_mask.indices_k,
+                    cu_seqlens_k=attention_mask.cu_seqlens_k,
+                    max_seqlen_k=attention_mask.max_seqlen_k,
+                )
+        elif attention_mask is not None:
             attention_mask = attn.prepare_attention_mask(attention_mask, sequence_length, batch_size)
             attention_mask = attention_mask.view(batch_size, attn.heads, -1, attention_mask.shape[-1])
+            attn_kw = {"attn_mask": attention_mask}
+        else:
+            attn_kw = None
 
         if encoder_hidden_states is None:
             encoder_hidden_states = hidden_states
@@ -69,7 +83,6 @@ class xFuserLTX2PerturbedAttnProcessor:
             all_perturbed = torch.all(perturbation_mask == 0) if perturbation_mask is not None else False
 
         if all_perturbed:
-            # Skip attention, use the value projection value
             hidden_states = value
         else:
             query = attn.to_q(hidden_states)
@@ -92,13 +105,8 @@ class xFuserLTX2PerturbedAttnProcessor:
             key = key.unflatten(2, (attn.heads, -1)).transpose(1, 2)
             value = value.unflatten(2, (attn.heads, -1)).transpose(1, 2)
 
-            hidden_states = self.attention_method(
-                query,
-                key,
-                value,
-                dropout_p=0.0,
-                is_causal=False,
-            )
+            hidden_states = self.attention_method(query, key, value, dropout_p=0.0, is_causal=False,
+                                                  attention_kwargs=attn_kw)
             hidden_states = hidden_states.transpose(1, 2).flatten(2, 3)
             hidden_states = hidden_states.to(query.dtype)
 
@@ -144,9 +152,20 @@ class xFuserLTX2AudioVideoAttnProcessor:
             key_rotary_emb = [x.contiguous() for x in key_rotary_emb]
             key_rotary_emb = [get_sp_group().all_gather(x, dim=2) for x in key_rotary_emb]
 
-        if attention_mask is not None:
+        if isinstance(attention_mask, AttentionMaskWithMeta):
+            attn_kw = {"attn_mask": attention_mask.attn_mask}
+            if attention_mask.indices_k is not None:
+                attn_kw.update(
+                    indices_k=attention_mask.indices_k,
+                    cu_seqlens_k=attention_mask.cu_seqlens_k,
+                    max_seqlen_k=attention_mask.max_seqlen_k,
+                )
+        elif attention_mask is not None:
             attention_mask = attn.prepare_attention_mask(attention_mask, sequence_length, batch_size)
             attention_mask = attention_mask.view(batch_size, attn.heads, -1, attention_mask.shape[-1])
+            attn_kw = {"attn_mask": attention_mask}
+        else:
+            attn_kw = None
 
         if encoder_hidden_states is None:
             encoder_hidden_states = hidden_states
@@ -175,13 +194,8 @@ class xFuserLTX2AudioVideoAttnProcessor:
         key = key.unflatten(2, (attn.heads, -1)).transpose(1, 2)
         value = value.unflatten(2, (attn.heads, -1)).transpose(1, 2)
 
-        hidden_states = self.attention_method(
-            query,
-            key,
-            value,
-            dropout_p=0.0,
-            is_causal=False,
-        )
+        hidden_states = self.attention_method(query, key, value, dropout_p=0.0, is_causal=False,
+                                              attention_kwargs=attn_kw)
         hidden_states = hidden_states.transpose(1, 2).flatten(2, 3)
         hidden_states = hidden_states.to(query.dtype)
 
@@ -242,6 +256,10 @@ class xFuserLTX2VideoTransformer3DWrapper(LTX2VideoTransformer3DModel):
         rope_type: str = "interleaved",
         use_prompt_embeddings: bool = True,
         perturbed_attn: bool = False,
+        ff_bias: bool = False,
+        audio_ff_bias: bool = False,
+        use_prompt_adaln_single: bool = False,
+        use_keyframes_abs_pos_embedding: bool = False,
     ):
         super().__init__(
             in_channels=in_channels,
@@ -286,7 +304,14 @@ class xFuserLTX2VideoTransformer3DWrapper(LTX2VideoTransformer3DModel):
             rope_type=rope_type,
             use_prompt_embeddings=use_prompt_embeddings,
             perturbed_attn=perturbed_attn,
+            ff_bias=ff_bias,
+            audio_ff_bias=audio_ff_bias,
+            use_prompt_adaln_single=use_prompt_adaln_single,
+            use_keyframes_abs_pos_embedding=use_keyframes_abs_pos_embedding,
         )
+
+        self._enc_mask_cache: dict = {}
+        self._audio_enc_mask_cache: dict = {}
 
         if perturbed_attn:
             attn_processor_cls = xFuserLTX2PerturbedAttnProcessor
@@ -350,76 +375,6 @@ class xFuserLTX2VideoTransformer3DWrapper(LTX2VideoTransformer3DModel):
         attention_kwargs: Optional[Dict[str, Any]] = None,
         return_dict: bool = True,
     ) -> torch.Tensor:
-        """
-        Forward pass for LTX-2.0 audiovisual video transformer.
-
-        Args:
-            hidden_states (`torch.Tensor`):
-                Input patchified video latents of shape `(batch_size, num_video_tokens, in_channels)`.
-            audio_hidden_states (`torch.Tensor`):
-                Input patchified audio latents of shape `(batch_size, num_audio_tokens, audio_in_channels)`.
-            encoder_hidden_states (`torch.Tensor`):
-                Input video text embeddings of shape `(batch_size, text_seq_len, self.config.caption_channels)`.
-            audio_encoder_hidden_states (`torch.Tensor`):
-                Input audio text embeddings of shape `(batch_size, text_seq_len, self.config.caption_channels)`.
-            timestep (`torch.Tensor`):
-                Input timestep of shape `(batch_size, num_video_tokens)`. These should already be scaled by
-                `self.config.timestep_scale_multiplier`.
-            audio_timestep (`torch.Tensor`, *optional*):
-                Input timestep of shape `(batch_size,)` or `(batch_size, num_audio_tokens)` for audio modulation
-                params. This is only used by certain pipelines such as the I2V pipeline.
-            encoder_attention_mask (`torch.Tensor`, *optional*):
-                Optional multiplicative text attention mask of shape `(batch_size, text_seq_len)`.
-            audio_encoder_attention_mask (`torch.Tensor`, *optional*):
-                Optional multiplicative text attention mask of shape `(batch_size, text_seq_len)` for audio modeling.
-            num_frames (`int`, *optional*):
-                The number of latent video frames. Used if calculating the video coordinates for RoPE.
-            height (`int`, *optional*):
-                The latent video height. Used if calculating the video coordinates for RoPE.
-            width (`int`, *optional*):
-                The latent video width. Used if calculating the video coordinates for RoPE.
-            fps: (`float`, *optional*, defaults to `24.0`):
-                The desired frames per second of the generated video. Used if calculating the video coordinates for
-                RoPE.
-            audio_num_frames: (`int`, *optional*):
-                The number of latent audio frames. Used if calculating the audio coordinates for RoPE.
-            video_coords (`torch.Tensor`, *optional*):
-                The video coordinates to be used when calculating the rotary positional embeddings (RoPE) of shape
-                `(batch_size, 3, num_video_tokens, 2)`. If not supplied, this will be calculated inside `forward`.
-            audio_coords (`torch.Tensor`, *optional*):
-                The audio coordinates to be used when calculating the rotary positional embeddings (RoPE) of shape
-                `(batch_size, 1, num_audio_tokens, 2)`. If not supplied, this will be calculated inside `forward`.
-            attention_kwargs (`Dict[str, Any]`, *optional*):
-                Optional dict of keyword args to be passed to the attention processor.
-            return_dict (`bool`, *optional*, defaults to `True`):
-                Whether to return a dict-like structured output of type `AudioVisualModelOutput` or a tuple.
-
-        Returns:
-            `AudioVisualModelOutput` or `tuple`:
-                If `return_dict` is `True`, returns a structured output of type `AudioVisualModelOutput`, otherwise a
-                `tuple` is returned where the first element is the denoised video latent patch sequence and the second
-                element is the denoised audio latent patch sequence.
-        """
-
-        """
-            _cp_plan = {
-        "": {
-            "hidden_states": ContextParallelInput(split_dim=1, expected_dims=3, split_output=False),
-            "encoder_hidden_states": ContextParallelInput(split_dim=1, expected_dims=3, split_output=False),
-            "encoder_attention_mask": ContextParallelInput(split_dim=1, expected_dims=2, split_output=False),
-        },
-        "rope": {
-            0: ContextParallelInput(split_dim=1, expected_dims=3, split_output=True),
-            1: ContextParallelInput(split_dim=1, expected_dims=3, split_output=True),
-        },
-        "proj_out": ContextParallelOutput(gather_dim=1, expected_dims=3),
-    }
-
-        """
-
-        # Newer diffusers passes sigma / STG / modality kwargs; accepted above for API compatibility.
-        # When all are omitted (older pipelines), behavior matches the pre-update path.
-
         if attention_kwargs is not None:
             attention_kwargs = attention_kwargs.copy()
             lora_scale = attention_kwargs.pop("scale", 1.0)
@@ -427,34 +382,32 @@ class xFuserLTX2VideoTransformer3DWrapper(LTX2VideoTransformer3DModel):
             lora_scale = 1.0
 
         if USE_PEFT_BACKEND:
-            # weight the lora layers by setting `lora_scale` for each PEFT layer
             scale_lora_layers(self, lora_scale)
-        else:
-            if attention_kwargs is not None and attention_kwargs.get("scale", None) is not None:
-                logger.warning(
-                    "Passing `scale` via `attention_kwargs` when not using the PEFT backend is ineffective."
-                )
 
 
 
         sp_world_rank = get_sequence_parallel_rank()
         sp_world_size = get_sequence_parallel_world_size()
 
-        pad_amount = (sp_world_size - (hidden_states.shape[1] % sp_world_size)) % sp_world_size
+        full_seq_len = hidden_states.shape[1]
+        pad_amount = (sp_world_size - (full_seq_len % sp_world_size)) % sp_world_size
         hidden_states = self._chunk_and_pad_sequence(hidden_states, sp_world_rank, sp_world_size, pad_amount, dim=1)
 
-        # Determine timestep for audio.
+        # Determine timestep for audio before chunking the video-side timestep.
+        # The pipeline passes audio_timestep as a separate per-sample tensor, so
+        # it must not inherit the (to-be-chunked) per-token video timestep.
         audio_timestep = audio_timestep if audio_timestep is not None else timestep
         audio_sigma = audio_sigma if audio_sigma is not None else sigma
 
-        # convert encoder_attention_mask to a bias the same way we do for attention_mask
-        if encoder_attention_mask is not None and encoder_attention_mask.ndim == 2:
-            encoder_attention_mask = (1 - encoder_attention_mask.to(hidden_states.dtype)) * -10000.0
-            encoder_attention_mask = encoder_attention_mask.unsqueeze(1)
+        # If the video timestep is per-token [batch, num_video_tokens] rather than
+        # per-sample, chunk it to match the local hidden_states shard.  This avoids
+        # the broadcast mismatch between chunked hidden_states [batch, local_seq, dim]
+        # and embedded_timestep [batch, full_seq, dim] in the output scale/shift layer.
+        if timestep.ndim == 2 and timestep.shape[1] == full_seq_len:
+            timestep = self._chunk_and_pad_sequence(timestep, sp_world_rank, sp_world_size, pad_amount, dim=1)
 
-        if audio_encoder_attention_mask is not None and audio_encoder_attention_mask.ndim == 2:
-            audio_encoder_attention_mask = (1 - audio_encoder_attention_mask.to(audio_hidden_states.dtype)) * -10000.0
-            audio_encoder_attention_mask = audio_encoder_attention_mask.unsqueeze(1)
+        encoder_attention_mask = _get_mask_meta(self._enc_mask_cache, encoder_attention_mask)
+        audio_encoder_attention_mask = _get_mask_meta(self._audio_enc_mask_cache, audio_encoder_attention_mask)
 
         batch_size = hidden_states.size(0)
 
@@ -511,8 +464,7 @@ class xFuserLTX2VideoTransformer3DWrapper(LTX2VideoTransformer3DModel):
 
         audio_embedded_timestep = audio_embedded_timestep.view(batch_size, -1, audio_embedded_timestep.size(-1))
 
-        if self.prompt_modulation:
-            # LTX-2.3
+        if self.prompt_modulation and self.config.use_prompt_adaln_single:
             temb_prompt, _ = self.prompt_adaln(
                 sigma.flatten(), batch_size=batch_size, hidden_dtype=hidden_states.dtype
             )

--- a/xfuser/model_executor/models/transformers/transformer_ltx2.py
+++ b/xfuser/model_executor/models/transformers/transformer_ltx2.py
@@ -293,9 +293,9 @@ class xFuserLTX2VideoTransformer3DWrapper(LTX2VideoTransformer3DModel):
         rope_type: str = "interleaved",
         use_prompt_embeddings: bool = True,
         perturbed_attn: bool = False,
-        ff_bias: bool = False,
-        audio_ff_bias: bool = False,
-        use_prompt_adaln_single: bool = False,
+        ff_bias: bool = True,
+        audio_ff_bias: bool = True,
+        use_prompt_adaln_single: bool = True,
         use_keyframes_abs_pos_embedding: bool = False,
     ):
         super().__init__(

--- a/xfuser/model_executor/models/transformers/transformer_ltx2.py
+++ b/xfuser/model_executor/models/transformers/transformer_ltx2.py
@@ -22,7 +22,7 @@ from xfuser.model_executor.layers.usp import USP, attention
 
 
 def _get_mask_meta(cache: dict, mask: torch.Tensor | None) -> object | None:
-    """Convert a 2-D boolean attention mask to AttentionMaskWithMeta, cached per tensor."""
+    """Convert a 2-D key-padding mask (1=valid, 0=pad) to AttentionMaskWithMeta, cached per tensor."""
     if mask is None or mask.ndim != 2:
         return mask
     key = (mask.data_ptr(), tuple(mask.shape))
@@ -65,11 +65,12 @@ class xFuserLTX2PerturbedAttnProcessor:
             ]
 
         if isinstance(attention_mask, AttentionMaskWithMeta):
-            # Only forward attn_mask. The varlen fields (indices_k etc.) are for
-            # self-attention where Q and K share the same sequence length; here the
-            # mask covers text encoder tokens (K) while Q is video tokens, so the
-            # varlen pack path in _varlen_pack_keys would mis-reshape the key tensor.
-            attn_kw = {"attn_mask": attention_mask.attn_mask}
+            attn_kw = {
+                "attn_mask": attention_mask.attn_mask,
+                "indices_k": attention_mask.indices_k,
+                "cu_seqlens_k": attention_mask.cu_seqlens_k,
+                "max_seqlen_k": attention_mask.max_seqlen_k,
+            }
         elif attention_mask is not None:
             attention_mask = attn.prepare_attention_mask(
                 attention_mask, sequence_length, batch_size
@@ -184,11 +185,12 @@ class xFuserLTX2AudioVideoAttnProcessor:
             ]
 
         if isinstance(attention_mask, AttentionMaskWithMeta):
-            # Only forward attn_mask. The varlen fields (indices_k etc.) are for
-            # self-attention where Q and K share the same sequence length; here the
-            # mask covers text encoder tokens (K) while Q is video tokens, so the
-            # varlen pack path in _varlen_pack_keys would mis-reshape the key tensor.
-            attn_kw = {"attn_mask": attention_mask.attn_mask}
+            attn_kw = {
+                "attn_mask": attention_mask.attn_mask,
+                "indices_k": attention_mask.indices_k,
+                "cu_seqlens_k": attention_mask.cu_seqlens_k,
+                "max_seqlen_k": attention_mask.max_seqlen_k,
+            }
         elif attention_mask is not None:
             attention_mask = attn.prepare_attention_mask(
                 attention_mask, sequence_length, batch_size


### PR DESCRIPTION
## Summary
Adds runner models for the [LTX-2.5-Diffusers](https://huggingface.co/Lightricks/LTX-2.5-Diffusers) checkpoints with both distilled and full-model variants, and T2V/I2V tasks.

## Features
- Parallelism: USP (Ulysses) u=2/4/8
- Quantization: FP8/FP4 GEMMs (torchao), quantized attention backends
- torch.compile: only DiT compiled (denoising part, not diffusion decoder)
- Modes: --task t2v / i2v (for I2V, --input_images is required and should have a single input image)

## Changes:
- `xFuserLTX25DistilledVideoModel`: two-stage distilled pipeline for LTX-2.5: stage-1 at half resolution with a fixed 8-step sigma schedule, spatial upsampling, then stage-2 refinement (3 steps, guidance disabled)
- `xFuserLTX25FullVideoModel`: single-stage LTX-2.5 full-model pipeline with CFG, STG, and modality guidance
Both variants decode via `LTX2VideoDiffusionDecoderModel` (diffusion decoder) with a NATTEN neighborhood-attention processor; falls back to a tiled SDPA implementation (`ltx2_na3d_eager_attn.py`) if NATTEN is not available.
- Attention masks (padding masks) are forwarded with `AttentionMaskWithMeta`, so the runtime-selected backend (SDPA, AITER varlen, etc.) can use them if masks or varlen is supported for the specific backend.
- `attention_backends.py` changes: SDPA attn_mask casted to query's dtype if needed. Hadamart matrix generated also for head dims that aren't divisible by 128 (ltx-2.5 audio attn head head_dim=64). Original Hadamart matrix selection logic is kept intact for head_dims that are multiple of 128.

**New model IDs**: `Lightricks/LTX-2.5-Diffusers`, `LTX-2.5`, `LTX-2.5-distilled`, `LTX-2.5-full`

## Tests
- LTX-2.5 distill and full variants tested to work on MI350 and B200
- Code changes affect also previous model version LTX-2.3 transformer wrapper. LTX-2.3 was tested to still work and remains as performant as before changes.

## Examples

```bash
OUT_DIR=/output/xdit_ltx2.5-distill_i2v_8gpu
PROMPT="Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside."
mkdir $OUT_DIR
xdit \
  --task i2v \
  --model Lightricks/LTX-2.5-Diffusers \
  --prompt "$PROMPT" \
  --input_images /app/data/wan_input.jpg \
  --height 1536 --width 1024 --num_frames 121 \
  --num_inference_steps 8 \
  --num_iterations 1 \
  --ulysses_degree 8 \
  --attention_backend AITER \
  --use_torch_compile \
  --resize_input_images \
  --output_directory $OUT_DIR &>> $OUT_DIR/out.log
```
https://github.com/user-attachments/assets/5fc35e61-fe9c-4e17-af20-6e770aa7db57

```bash
OUT_DIR=/output/xdit_ltx2.5-distill_i2v_1gpu
PROMPT="Summer beach vacation style, a white cat wearing sunglasses sits on a surfboard. The fluffy-furred feline gazes directly at the camera with a relaxed expression. Blurred beach scenery forms the background featuring crystal-clear waters, distant green hills, and a blue sky dotted with white clouds. The cat assumes a naturally relaxed posture, as if savoring the sea breeze and warm sunlight. A close-up shot highlights the feline's intricate details and the refreshing atmosphere of the seaside."
mkdir $OUT_DIR
xdit \
  --task i2v \
  --model Lightricks/LTX-2.5-Diffusers \
  --prompt "$PROMPT" \
  --input_images /app/data/wan_input.jpg \
  --height 1536 --width 1024 --num_frames 121 \
  --num_inference_steps 8 \
  --num_iterations 1 \
  --ulysses_degree 1 \
  --attention_backend AITER_FP8 \
  --use_torch_compile \
  --resize_input_images \
  --output_directory $OUT_DIR &>> $OUT_DIR/out.log
```
https://github.com/user-attachments/assets/88bffcb9-cf55-4c80-87a9-059fbc2c5449


```bash
OUT_DIR=/output/xdit_ltx2.5-distill_t2v_1gpu
PROMPT="A tight medium close-up opens on a man in his mid-thirties pressed flat against a cracked concrete wall in a narrow alley at blue dusk, his dark hair matted with sweat against his forehead, a torn olive utility jacket smudged with grit and ash, and a fresh cut along his temple bleeding down into his stubble. Sodium streetlights spill amber rim light across one side of his face while the other half stays buried in deep chiaroscuro shadow, volumetric haze drifting through the cold air behind him and dust motes catching the practical glow. He leans an inch toward the lens, his eyes darting once off-frame, and says in a strained, breathless whisper barely louder than the wind, \"We need to run.\" His chest rises and falls in shallow, rapid pulls as the camera executes an aggressive snap zoom directly to his mouth, holding one beat on the tremor of his cracked lower lip and the flash of clenched teeth. He erupts in a raw, throat-tearing scream, \"NOW\", a fleck of spittle catching the amber light as the camera snaps back out in a violent rack-out pull, restoring the wide framing in a single jolt. He pivots sharply on his heel, his boots scraping wet asphalt, and bolts away from the lens in a low-shouldered sprint, his jacket whipping behind him as the camera transitions into a handheld tracking shot that surges after him with jittery momentum, dust and damp debris kicking up in his wake. The audio bed layers distant sirens, a low pulsing sub-drone, crisp foley of pounding footsteps and ragged breathing, the wet scrape of pivoting boots, and a faint metallic clang receding far behind."
mkdir $OUT_DIR
xdit \
  --task t2v \
  --model Lightricks/LTX-2.5-Diffusers \
  --prompt "$PROMPT" \
  --height 1024 --width 1536--num_frames 121 \
  --num_inference_steps 8 \
  --num_iterations 1 \
  --ulysses_degree 1 \
  --attention_backend AITER \
  --use_torch_compile \
  --output_directory $OUT_DIR &>> $OUT_DIR/out.log
```

https://github.com/user-attachments/assets/f114caa0-6ae6-4df7-9aca-57a7183beebd

