### PR TITLE
Fix broken "Performance" anchor in Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 - [🔥 Meet xDiT](#meet-xdit)
 - [📢 Open-source Community](#updates)
 - [🎯 Supported DiTs](#support-dits)
-- [📈 Performance](#perf)
+- [📈 Performance](#support-dits)
 - [🚀 QuickStart](#QuickStart)
 - [🖼️ ComfyUI with xDiT](#comfyui)
 - [✨ xDiT's Arsenal](#secrets)


### PR DESCRIPTION
Since commit `c539c6e` (PR #475) merged the standalone "Performance Reports"
section into the "Supported DiTs" table, the Table of Contents entry
`[📈 Performance](#perf)` pointed to a non-existent `#perf` anchor.

Point it at `#support-dits`, where the performance report links now live.