### PR TITLE
Add MiniMax-H3 hybrid attention schedule support

### DIFF
--- a/tests/test_minimax_h3.py
+++ b/tests/test_minimax_h3.py
@@ -100,6 +100,32 @@ def _tiny_inputs(device):
     }
 
 
+def _patch_minimax_runtime_state(monkeypatch, *, track_steps=False):
+    from xfuser.core.distributed.attention_backend import AttentionBackendType
+    from xfuser.model_executor.models.runner_models import minimax_h3 as minimax_h3_runner
+    from xfuser.model_executor.models.transformers import transformer_minimax_h3
+
+    calls = []
+
+    class _RuntimeState:
+        attention_backend = AttentionBackendType.SDPA
+
+        def has_attention_schedule(self):
+            return False
+
+        def increment_step_counter(self):
+            if track_steps:
+                calls.append(True)
+
+    runtime_state = _RuntimeState()
+    getter = lambda: runtime_state
+    monkeypatch.setattr(transformer_minimax_h3, "get_runtime_state", getter)
+    monkeypatch.setattr(minimax_h3_runner, "get_runtime_state", getter)
+    monkeypatch.setattr("xfuser.core.distributed.get_runtime_state", getter)
+    monkeypatch.setattr("xfuser.model_executor.layers.usp.get_runtime_state", getter)
+    return calls
+
+
 def test_minimax_h3_wrapper_matches_diffusers_u1(monkeypatch):
     from diffusers import MiniMaxH3Transformer3DModel
 
@@ -119,6 +145,7 @@ def test_minimax_h3_wrapper_matches_diffusers_u1(monkeypatch):
         "get_ulysses_parallel_rank",
         lambda: 0,
     )
+    _patch_minimax_runtime_state(monkeypatch)
 
     config = _tiny_config()
     base = MiniMaxH3Transformer3DModel(**config).eval()
@@ -444,7 +471,7 @@ def test_minimax_h3_ref2va_runtime_state_uses_ref_transformer():
     assert not hasattr(model.pipe, "transformer")
 
 
-def test_minimax_h3_compile_preserves_forward_signature():
+def test_minimax_h3_compile_preserves_forward_signature(monkeypatch):
     from xfuser.model_executor.models.runner_models.minimax_h3 import (
         xFuserMiniMaxH3Model,
     )
@@ -452,6 +479,7 @@ def test_minimax_h3_compile_preserves_forward_signature():
         xFuserMiniMaxH3Transformer3DWrapper,
     )
 
+    _patch_minimax_runtime_state(monkeypatch)
     transformer = xFuserMiniMaxH3Transformer3DWrapper(**_tiny_config()).eval()
     model = object.__new__(xFuserMiniMaxH3Model)
     model.config = SimpleNamespace(fully_shard_degree=1)
@@ -503,3 +531,81 @@ def test_minimax_h3_ref2va_uses_typed_image_references():
     assert len(captured["references"]) == 1
     assert isinstance(captured["references"][0], MiniMaxH3ImageReference)
     assert captured["references"][0].image is image
+
+
+def test_minimax_h3_supports_hybrid_attention_capability():
+    from xfuser.model_executor.models.runner_models.minimax_h3 import (
+        xFuserMiniMaxH3Model,
+        xFuserMiniMaxH3Ref2VAModel,
+    )
+
+    assert xFuserMiniMaxH3Model.capabilities.use_hybrid_attn_schedule
+    assert xFuserMiniMaxH3Ref2VAModel.capabilities.use_hybrid_attn_schedule
+    assert (
+        xFuserMiniMaxH3Model.default_input_values.num_hybrid_attn_high_precision_steps
+        == 5
+    )
+
+
+def test_minimax_h3_accepts_hybrid_attention_backends():
+    from xfuser.config import xFuserArgs
+    from xfuser.model_executor.models.runner_models.minimax_h3 import (
+        xFuserMiniMaxH3Model,
+    )
+
+    config = xFuserArgs(
+        model="MiniMax-H3",
+        task="t2va",
+        use_hybrid_attn_schedule=True,
+        hybrid_attn_high_precision_backend="cudnn",
+        hybrid_attn_low_precision_backend="nvte_fp8",
+        num_hybrid_attn_high_precision_steps=5,
+    )
+
+    xFuserMiniMaxH3Model(config)
+
+
+def test_minimax_h3_rejects_unsupported_hybrid_backend():
+    from xfuser.config import xFuserArgs
+    from xfuser.model_executor.models.runner_models.minimax_h3 import (
+        xFuserMiniMaxH3Model,
+    )
+
+    config = xFuserArgs(
+        model="MiniMax-H3",
+        task="t2va",
+        use_hybrid_attn_schedule=True,
+        hybrid_attn_high_precision_backend="cudnn",
+        hybrid_attn_low_precision_backend="flash_3_fp8",
+        num_hybrid_attn_high_precision_steps=5,
+    )
+
+    with pytest.raises(ValueError, match="does not support attention backend"):
+        xFuserMiniMaxH3Model(config)
+
+
+def test_minimax_h3_forward_increments_hybrid_step_counter(monkeypatch):
+    from xfuser.model_executor.models.transformers import transformer_minimax_h3
+    from xfuser.model_executor.models.transformers.transformer_minimax_h3 import (
+        xFuserMiniMaxH3Transformer3DWrapper,
+    )
+
+    monkeypatch.setattr(
+        transformer_minimax_h3,
+        "get_ulysses_parallel_world_size",
+        lambda: 1,
+    )
+    monkeypatch.setattr(
+        transformer_minimax_h3,
+        "get_ulysses_parallel_rank",
+        lambda: 0,
+    )
+    calls = _patch_minimax_runtime_state(monkeypatch, track_steps=True)
+
+    wrapper = xFuserMiniMaxH3Transformer3DWrapper(**_tiny_config()).eval()
+    inputs = _tiny_inputs(torch.device("cpu"))
+
+    with torch.no_grad():
+        wrapper(**inputs)
+
+    assert len(calls) == 1

--- a/xfuser/model_executor/models/runner_models/minimax_h3.py
+++ b/xfuser/model_executor/models/runner_models/minimax_h3.py
@@ -7,7 +7,7 @@ import numpy as np
 import torch
 
 from xfuser.core.distributed.attention_backend import AttentionBackendType
-from xfuser.core.distributed import get_world_group
+from xfuser.core.distributed import get_runtime_state, get_world_group
 from xfuser.core.utils.runner_utils import log
 from xfuser.core.utils.video_utils import encode_video_with_audio
 from xfuser.model_executor.models.runner_models.base_model import (
@@ -130,6 +130,7 @@ class xFuserMiniMaxH3Model(xFuserModel):
         width=1344,
         num_frames=124,
         num_inference_steps=50,
+        num_hybrid_attn_high_precision_steps=5,
     )
 
     settings = ModelSettings(
@@ -172,6 +173,7 @@ class xFuserMiniMaxH3Model(xFuserModel):
         fully_shard_degree=True,
         use_fp8_gemms=True,
         use_fp4_gemms=True,
+        use_hybrid_attn_schedule=True,
         enable_slicing=False,
         enable_tiling=False,
     )
@@ -195,23 +197,41 @@ class xFuserMiniMaxH3Model(xFuserModel):
             else:
                 config.task = "fl2va"
         super()._validate_config(config)
-        backend = _parse_attention_backend(
-            config.attention_backend,
-            "attention backend",
-        )
-        if backend is not None and backend not in _SUPPORTED_ATTN_BACKENDS:
-            supported = ", ".join(sorted(item.name for item in _SUPPORTED_ATTN_BACKENDS))
-            raise ValueError(
-                f"MiniMax-H3 does not support attention backend {backend.name}. "
-                f"Supported backends: {supported}."
-            )
-        if backend == AttentionBackendType.AITER_FP8:
-            try:
-                from aiter import flash_attn_varlen_fp8_pertensor_func  # noqa: F401
-            except ImportError:
-                raise RuntimeError(
-                    "MiniMax-H3 FP8 attention requires AITER varlen FP8 flash attention."
-                ) from None
+        if config.use_hybrid_attn_schedule:
+            backend_specs = [
+                (
+                    config.hybrid_attn_high_precision_backend,
+                    "hybrid attention high precision backend",
+                ),
+                (
+                    config.hybrid_attn_low_precision_backend,
+                    "hybrid attention low precision backend",
+                ),
+            ]
+        else:
+            backend_specs = [(config.attention_backend, "attention backend")]
+
+        backends = [
+            backend
+            for value, label in backend_specs
+            if (backend := _parse_attention_backend(value, label)) is not None
+        ]
+        for backend in backends:
+            if backend not in _SUPPORTED_ATTN_BACKENDS:
+                supported = ", ".join(
+                    sorted(item.name for item in _SUPPORTED_ATTN_BACKENDS)
+                )
+                raise ValueError(
+                    f"MiniMax-H3 does not support attention backend {backend.name}. "
+                    f"Supported backends: {supported}."
+                )
+            if backend == AttentionBackendType.AITER_FP8:
+                try:
+                    from aiter import flash_attn_varlen_fp8_pertensor_func  # noqa: F401
+                except ImportError:
+                    raise RuntimeError(
+                        "MiniMax-H3 FP8 attention requires AITER varlen FP8 flash attention."
+                    ) from None
 
         ulysses_degree = config.ulysses_degree or 1
         if ulysses_degree not in _SUPPORTED_ULYSSES_DEGREES:
@@ -400,13 +420,15 @@ class xFuserMiniMaxH3Model(xFuserModel):
             return
         self._enable_compute_comm_overlap()
         transformer = getattr(self.pipe, self._transformer_component_name)
+        use_hybrid = get_runtime_state().has_attention_schedule()
         transformer.forward = torch.compile(
             transformer.forward,
             mode=self._get_compile_mode(),
-            fullgraph=True,
+            fullgraph=not use_hybrid,
         )
         compile_args = copy.deepcopy(input_args)
-        compile_args["num_inference_steps"] = 3
+        if not get_runtime_state().has_attention_schedule():
+            compile_args["num_inference_steps"] = 3
         self._run_timed_pipe(compile_args)
 
     def _run_warmup_calls(self, input_args: dict) -> None:

--- a/xfuser/model_executor/models/runner_models/minimax_h3.py
+++ b/xfuser/model_executor/models/runner_models/minimax_h3.py
@@ -29,6 +29,9 @@ from xfuser.model_executor.models.runner_models.loading.contracts import (
 _SUPPORTED_ATTN_BACKENDS = frozenset({
     AttentionBackendType.AITER,
     AttentionBackendType.AITER_FP8,
+    AttentionBackendType.CUDNN,
+    AttentionBackendType.SDPA,
+    AttentionBackendType.NVTE_FP8,
 })
 _SUPPORTED_ULYSSES_DEGREES = frozenset({1, 2, 4, 8})
 _SUPPORTED_TASKS = frozenset({"t2va", "i2va", "l2va", "fl2va", "ref2va"})
@@ -199,7 +202,7 @@ class xFuserMiniMaxH3Model(xFuserModel):
         if backend is not None and backend not in _SUPPORTED_ATTN_BACKENDS:
             supported = ", ".join(sorted(item.name for item in _SUPPORTED_ATTN_BACKENDS))
             raise ValueError(
-                f"MiniMax-H3 currently supports only packed varlen AITER attention. "
+                f"MiniMax-H3 does not support attention backend {backend.name}. "
                 f"Supported backends: {supported}."
             )
         if backend == AttentionBackendType.AITER_FP8:

--- a/xfuser/model_executor/models/transformers/transformer_minimax_h3.py
+++ b/xfuser/model_executor/models/transformers/transformer_minimax_h3.py
@@ -14,6 +14,7 @@ from diffusers.models.transformers.transformer_minimax_h3 import (
 from diffusers.utils import apply_lora_scale
 
 from xfuser.core.distributed import (
+    get_runtime_state,
     get_sp_group,
     get_ulysses_parallel_rank,
     get_ulysses_parallel_world_size,
@@ -115,6 +116,10 @@ class xFuserMiniMaxH3Transformer3DWrapper(MiniMaxH3Transformer3DModel):
                     backend=attention_backend,
                 )
             )
+
+        self.register_forward_pre_hook(
+            lambda module, args: get_runtime_state().increment_step_counter()
+        )
 
     @staticmethod
     def _pad_rows(


### PR DESCRIPTION
# Add MiniMax-H3 hybrid attention schedule support
## Summary

Enable per-step hybrid attention scheduling for **MiniMax-H3** (T2VA and Ref2VA), following the same pattern already used by Krea2 and Wan2.2. The default schedule runs high-precision attention on the first and last *N* denoising steps and a low-precision backend on the remaining steps.

**Default schedule (50 steps, N=5):**

```
5× AITER  →  40× AITER_FP8  →  5× AITER
```

Also expands MiniMax-H3's supported attention backends to include `CUDNN`, `SDPA`, and `NVTE_FP8` (in addition to existing AITER backends). On AMD, the validated hybrid path uses `AITER` / `aiter_fp8`; on NVIDIA, `cudnn` / `nvte_fp8` is supported as well.

# Changes

**1. Runner model (`xfuser/model_executor/models/runner_models/minimax_h3.py`)**

- Advertise `use_hybrid_attn_schedule=True` in `ModelCapabilities`.
- Set default `num_hybrid_attn_high_precision_steps=5`.
- Expand `_SUPPORTED_ATTN_BACKENDS` to include `CUDNN`, `SDPA`, and `NVTE_FP8`.
- Validate hybrid high/low precision backends when `--use_hybrid_attn_schedule` is set (Krea2-style).
- Compile path adjustments for hybrid:
  - Use `fullgraph=False` when a per-step attention schedule is active.
  - Run full `num_inference_steps` during compile warmup (not truncated to 3) so all backend phases are exercised.

**2. Transformer wrapper (`xfuser/model_executor/models/transformers/transformer_minimax_h3.py`)**

- Register a **forward pre-hook** that calls `get_runtime_state().increment_step_counter()` before each transformer forward. This keeps step counting outside the compiled forward graph and avoids Dynamo graph-break issues from in-body step mutation.

**3. Tests (`tests/test_minimax_h3.py`)**

- Add hybrid capability, backend validation, and step-counter tests.
- Patch runtime state in existing tests that instantiate the transformer wrapper.

No changes to shared hybrid infrastructure (`runtime_state.py`, CLI args) — those already support hybrid scheduling from Krea2/Wan.

# Sample commands

All examples below use **544×960**, **124 frames**, **50 steps**, **8 GPUs** (`--ulysses_degree 8`), and **`--use_torch_compile`**.

### Hybrid attention — T2VA (8-GPU)

```bash
xdit --model MiniMaxAI/MiniMax-H3 \
  --prompt "A red fox trots through a snowy pine forest." \
  --height 544 --width 960 \
  --num_frames 124 \
  --num_inference_steps 50 \
  --seed 42 \
  --task t2va \
  --ulysses_degree 8 \
  --use_fp8_gemms \
  --use_torch_compile \
  --use_hybrid_attn_schedule \
  --hybrid_attn_high_precision_backend aiter \
  --hybrid_attn_low_precision_backend aiter_fp8 \
  --num_hybrid_attn_high_precision_steps 5 \
  --output_directory ./output
```

### Hybrid attention — I2VA (8-GPU)

```bash
xdit --model MiniMaxAI/MiniMax-H3 \
  --prompt "A red fox trots through a snowy pine forest." \
  --height 544 --width 960 \
  --num_frames 124 \
  --num_inference_steps 50 \
  --seed 42 \
  --task i2va \
  --input_images /path/to/first_frame.png \
  --resize_input_images \
  --ulysses_degree 8 \
  --use_fp8_gemms \
  --use_torch_compile \
  --use_hybrid_attn_schedule \
  --hybrid_attn_high_precision_backend aiter \
  --hybrid_attn_low_precision_backend aiter_fp8 \
  --num_hybrid_attn_high_precision_steps 5 \
  --output_directory ./output
```

### Hybrid attention with text-encoder TP (8-GPU)

```bash
xdit --model MiniMaxAI/MiniMax-H3 \
  --prompt "A red fox trots through a snowy pine forest." \
  --height 544 --width 960 \
  --num_frames 124 \
  --num_inference_steps 50 \
  --seed 42 \
  --task t2va \
  --ulysses_degree 8 \
  --text_encoder_tp_degree 8 \
  --use_fp8_gemms \
  --use_torch_compile \
  --use_hybrid_attn_schedule \
  --hybrid_attn_high_precision_backend aiter \
  --hybrid_attn_low_precision_backend aiter_fp8 \
  --num_hybrid_attn_high_precision_steps 5 \
  --output_directory ./output
```

### Baseline — AITER backend (no hybrid)

```bash
xdit --model MiniMaxAI/MiniMax-H3 \
  --prompt "A red fox trots through a snowy pine forest." \
  --height 544 --width 960 \
  --num_frames 124 \
  --num_inference_steps 50 \
  --seed 42 \
  --task t2va \
  --ulysses_degree 8 \
  --use_fp8_gemms \
  --use_torch_compile \
  --attention_backend aiter \
  --output_directory ./output
```

# Tests

```bash
python -m pytest tests/test_minimax_h3.py -q
```

- [x] `tests/test_minimax_h3.py` — 22 passed
- [x] Hybrid T2VA inference with `torch.compile` completes and produces video output
- [x] Hybrid I2VA inference with `torch.compile` completes and produces video output

# Benchmark notes (8× MI355X, 544×960, 124 frames, 50 steps, `torch.compile`)

Measured from `/app/minimax_h3_bench` runs. Inference time is the denoising step reported in `timings.json` (seconds).

| Configuration | Task | FP8 GEMMs | Hybrid attn | Inference (s) |
|---|---|---|---|---|
| Ulysses-8 | T2VA | yes | no (`aiter`) | 16.98 |
| Ulysses-8 | T2VA | yes | yes (`aiter` / `aiter_fp8`) | **16.01** |
| Ulysses-8 | I2VA | yes | no (`aiter`) | 11.49 |
| Ulysses-8 | I2VA | yes | yes (`aiter` / `aiter_fp8`) | **11.24** |
| Ulysses-8 + text-encoder TP-8 | T2VA | yes | no (`aiter`) | 17.16 |
| Ulysses-8 + text-encoder TP-8 | T2VA | yes | yes (`aiter` / `aiter_fp8`) | **16.99** |
| Ulysses-8 + text-encoder TP-8 | I2VA | yes | no (`aiter`) | 11.68 |
| Ulysses-8 + text-encoder TP-8 | I2VA | yes | yes (`aiter` / `aiter_fp8`) | **11.67** |

Hybrid scheduling (`5× AITER → 40× AITER_FP8 → 5× AITER`) improves T2VA inference by ~5.7% vs fixed `aiter` at this resolution, with similar or slightly better latency on I2VA and text-encoder-TP configs.
