### PR TITLE
fix(flydsl): use device wave size for WAN QK RoPE fusion

### DIFF
--- a/xfuser/model_executor/layers/flydsl_utils.py
+++ b/xfuser/model_executor/layers/flydsl_utils.py
@@ -1,0 +1,11 @@
+from typing import Optional
+
+import torch
+
+
+def get_device_wave_size(tensor: torch.Tensor) -> Optional[int]:
+    properties = torch.cuda.get_device_properties(tensor.device)
+    wave_size = getattr(properties, "warp_size", None)
+    if not isinstance(wave_size, int) or wave_size < 2 or wave_size & (wave_size - 1):
+        return None
+    return wave_size

--- a/xfuser/model_executor/layers/fused_qk_norm_rope_wan_flydsl.py
+++ b/xfuser/model_executor/layers/fused_qk_norm_rope_wan_flydsl.py
@@ -29,6 +29,8 @@ from typing import Optional, Tuple
 
 import torch
 
+from xfuser.model_executor.layers.flydsl_utils import get_device_wave_size
+
 # The FlyDSL + aiter stack is optional; importing this module must never hard
 # fail on a box without them (CPU-only CI, non-ROCm).  ``_HAS_FLYDSL`` gates the
 # fast path; the wrapper / enabled() check fall back to the reference when False.
@@ -47,7 +49,7 @@ except Exception:  # pragma: no cover - only exercised where flydsl is absent
     _HAS_FLYDSL = False
 
 
-def _pick_tiling(H: int, D: int) -> Optional[Tuple[int, int, int]]:
+def _pick_tiling(H: int, D: int, wave_size: int) -> Optional[Tuple[int, int, int]]:
     """Return ``(BLOCK_THREADS, VEC, N_TILES)`` for ``[H, D]`` or None.
 
     ``VEC`` is the q/k/out vectorization -- q/k/out are bf16, so a single 128-bit
@@ -56,7 +58,8 @@ def _pick_tiling(H: int, D: int) -> Optional[Tuple[int, int, int]]:
     the bf16 q/k path keeps its full 128-bit VEC even when cos/sin are fp32.
 
     Constraints (see module docstring):
-      * BLOCK_THREADS a power of two <= 64 (single wave -> shuffle_xor butterfly);
+      * BLOCK_THREADS no larger than the hardware wave (single wave ->
+        shuffle_xor butterfly);
       * VEC even and ``VEC | D`` (GPT-J pairs stay lane-local, lane block inside
         one head);
       * ``(BLOCK_THREADS * VEC) | (H*D)`` (whole tiles) and
@@ -66,8 +69,10 @@ def _pick_tiling(H: int, D: int) -> Optional[Tuple[int, int, int]]:
     Prefer the widest wave, then the widest VEC (fewer, wider 128-bit loads).
     """
     HD = H * D
-    for bt in (64, 32, 16):
+    bt = wave_size
+    while bt >= 16:
         if HD % bt:
+            bt //= 2
             continue
         for vec in (8, 4, 2):
             if D % vec or vec % 2:
@@ -76,6 +81,7 @@ def _pick_tiling(H: int, D: int) -> Optional[Tuple[int, int, int]]:
             if HD % tile or tile % D:
                 continue
             return bt, vec, HD // tile
+        bt //= 2
     return None
 
 
@@ -289,7 +295,11 @@ if _HAS_FLYDSL:
         """
         S, HD = q.shape
         D = HD // heads
-        bt, vec, n_tiles = _pick_tiling(heads, D)  # guaranteed non-None by caller
+        wave_size = get_device_wave_size(q)
+        tiling = _pick_tiling(heads, D, wave_size) if wave_size is not None else None
+        if tiling is None:
+            raise RuntimeError("unsupported WAN FlyDSL QK norm/RoPE tiling")
+        bt, vec, n_tiles = tiling
 
         launcher = _build_kernel(
             HD=HD,
@@ -429,7 +439,8 @@ def fused_qk_norm_rope(
     eps_q, eps_k = norm_q.eps, norm_k.eps
     if eps_q is None or eps_k is None or eps_q != eps_k:
         return _ref()
-    if _pick_tiling(heads, D) is None:
+    wave_size = get_device_wave_size(query)
+    if wave_size is None or _pick_tiling(heads, D, wave_size) is None:
         return _ref()
 
     # freqs: [1, S, 1, D], last dim contiguous (diffusers WanRotaryPosEmbed).

--- a/xfuser/model_executor/layers/fused_qk_rope_flydsl.py
+++ b/xfuser/model_executor/layers/fused_qk_rope_flydsl.py
@@ -42,6 +42,7 @@ import torch
 from diffusers.models.embeddings import apply_rotary_emb
 
 from xfuser.logger import init_logger
+from xfuser.model_executor.layers.flydsl_utils import get_device_wave_size
 
 logger = init_logger(__name__)
 
@@ -87,13 +88,6 @@ def _pick_block(d: int, wave_size: int) -> Optional[Tuple[int, int]]:
         bt //= 2
     return None
 
-
-def _device_wave_size(query: torch.Tensor) -> Optional[int]:
-    properties = torch.cuda.get_device_properties(query.device)
-    wave_size = getattr(properties, "warp_size", None)
-    if not isinstance(wave_size, int) or wave_size < 2 or wave_size & (wave_size - 1):
-        return None
-    return wave_size
 
 
 if _HAS_FLYDSL:
@@ -366,7 +360,7 @@ def _supported(query, key, cos) -> bool:
     if query.dim() != 4:  # [B, S, H, D]
         return False
     d = query.shape[-1]
-    wave_size = _device_wave_size(query)
+    wave_size = get_device_wave_size(query)
     if wave_size is None or _pick_block(d, wave_size) is None:
         return False
     if not isinstance(cos, torch.Tensor) or cos.shape[-1] != d:
@@ -447,7 +441,7 @@ def flydsl_fused_qk_norm_rope(
     if cos2.dtype not in (torch.float32, torch.bfloat16):
         return _reference(query, key, norm_q, norm_k, rotary_emb)
 
-    wave_size = _device_wave_size(query)
+    wave_size = get_device_wave_size(query)
     if wave_size is None:
         return _reference(query, key, norm_q, norm_k, rotary_emb)
     block_vec = _pick_block(d, wave_size)


### PR DESCRIPTION
Extract device wave-size detection into a shared FlyDSL utility and use it across the FLUX, Qwen, and WAN fused QK normalization/RoPE kernels.

Select WAN block geometry from the hardware-reported wave size, preventing wave64 shuffle reductions on wave32 RDNA4 devices. Fall back to the reference implementation when the wave size or tensor geometry is unsupported.