### PR TITLE
Add fused QK Norm + RoPE to FLUX.2 with strided QKV support

### DIFF
--- a/xfuser/model_executor/layers/fused_qk_rope_flydsl.py
+++ b/xfuser/model_executor/layers/fused_qk_rope_flydsl.py
@@ -15,11 +15,19 @@ diffusers ``apply_rotary_emb``; this fuses the whole chain):
     and k.
 
 Numerics: the kernel reproduces the reference *rounding schedule*, not just the
-formula.  ``diffusers`` RMSNorm rounds to the (bf16) weight dtype after the
-rstd-multiply and again after the affine-multiply, then ``apply_rotary_emb``
-upcasts to fp32 for the rotate and rounds once at the end.  ``ROUND_AFTER_NORM``
-replays the two intermediate roundings so the fused output matches the unfused
-output to within a ULP.
+formula, and the two RMSNorm implementations round in different places --
+``diffusers`` RMSNorm rounds to the (bf16) weight dtype after the rstd-multiply
+and again after the affine-multiply, while ``torch.nn.RMSNorm`` stays in fp32
+throughout and rounds once at the end.  ``ROUND_AFTER_NORM`` /
+``ROUND_AFTER_AFFINE`` replay whichever schedule the caller's module uses (see
+:func:`_norm_schedule`) so the fused output matches the unfused output to within
+a ULP.  ``apply_rotary_emb`` then upcasts to fp32 for the rotate and rounds once
+at the end either way.
+
+Inputs may be non-contiguous: real models build q/k as chunks of a fused QKV
+projection, so the row stride is passed to the kernel at runtime and rows are
+read in place rather than copied.  Only the ``(H, D)`` block within a token has
+to be packed.  Outputs are always freshly allocated and contiguous.
 
 Envelope: bf16 activations, 4-D ``[B, S, H, D]`` (sequence_dim == 1), even ``D``
 that factors into a power-of-two lane count with an even per-lane width, plain
@@ -31,15 +39,17 @@ result, only the speed.
 
 # NOTE: no ``from __future__ import annotations`` -- PEP 563 stringifies the
 # annotations and defeats flydsl's runtime-arg detection for the Int32 kernel
-# params (cos_rows / pos_offset), forcing a fresh JIT per value.
+# params (cos_rows / tok_off / q_rs / k_rs), forcing a fresh JIT per value.
 
 import math
+import os
 from functools import lru_cache
 from typing import Optional, Tuple
 
 import torch
 
 from diffusers.models.embeddings import apply_rotary_emb
+from diffusers.models.normalization import RMSNorm as _DiffusersRMSNorm
 
 from xfuser.logger import init_logger
 from xfuser.model_executor.layers.flydsl_utils import get_device_wave_size
@@ -106,6 +116,8 @@ if _HAS_FLYDSL:
         HAS_WQ: bool,
         HAS_WK: bool,
         ROUND_AFTER_NORM: bool,
+        ROUND_AFTER_AFFINE: bool,
+        CONTIG: bool,
     ):
         """Build + cache the @flyc.jit launcher for one config.
 
@@ -115,21 +127,29 @@ if _HAS_FLYDSL:
         LOG2_BT = int(math.log2(BLOCK_THREADS))
         PAIRS = VEC // 2
         INV_D = 1.0 / D
+        HD = H * D
 
-        _kname = f"fused_qk_norm_rope_H{H}_D{D}_v{VEC}_flydsl"
+        # CONTIG must be in the symbol name: the two addressing variants are
+        # separate compilations and would otherwise share an MLIR symbol.
+        _kname = (
+            f"fused_qk_norm_rope_H{H}_D{D}_v{VEC}"
+            f"{'_c' if CONTIG else '_s'}_flydsl"
+        )
 
         @flyc.kernel(name=_kname)
         def kernel(
-            q_in: fx.Tensor,   # [n, H, D] bf16, contiguous (H, D)
-            k_in: fx.Tensor,   # [n, H, D] bf16, contiguous (H, D)
-            q_out: fx.Tensor,  # [n, H, D] bf16
-            k_out: fx.Tensor,  # [n, H, D] bf16
+            q_in: fx.Tensor,   # [T, H, D] bf16, row stride q_rs, (H, D) packed
+            k_in: fx.Tensor,   # [T, H, D] bf16, row stride k_rs, (H, D) packed
+            q_out: fx.Tensor,  # [T, H, D] bf16, contiguous
+            k_out: fx.Tensor,  # [T, H, D] bf16, contiguous
             wq: fx.Tensor,      # [D] bf16 (dummy when not HAS_WQ)
             wk: fx.Tensor,      # [D] bf16 (dummy when not HAS_WK)
             cos: fx.Tensor,     # [cos_rows, D] cos_dt
             sin: fx.Tensor,     # [cos_rows, D] cos_dt
             cos_rows: Int32,
-            pos_offset: Int32,  # global token index of this chunk's row 0
+            tok_off: Int32,     # global token index of this chunk's row 0
+            q_rs: Int32,        # q_in row stride in elements (H*D if contiguous)
+            k_rs: Int32,        # k_in row stride in elements
         ):
             fm_fast = FastMathFlags.fast
             # Resolve element types inside the kernel body: T.* needs a live MLIR
@@ -140,10 +160,35 @@ if _HAS_FLYDSL:
             tok = fx.Int32(fx.block_idx.y)
             tid = fx.Int32(fx.thread_idx.x)
 
-            # element bases: q/k are the chunk-local [n, H, D] view, so ``tok``
-            # is local; cos/sin index the global row.
-            base = (tok * H + head) * D + tid * VEC
-            row = (fx.Int32(pos_offset) + tok) % fx.Int32(cos_rows)
+            # ``tok`` is chunk-local; ``gtok`` is the global token row.  Folding
+            # the chunk offset in here rather than slicing the tensors in Python
+            # means the caller marshals whole tensors once per call no matter how
+            # many grid-Y chunks it takes.
+            #
+            # Inputs may be non-contiguous fused-QKV chunks (row stride > H*D),
+            # so their row offset is the runtime ``q_rs``/``k_rs``.  Outputs are
+            # two separate contiguous buffers -- NOT two halves of one.  Under
+            # mode="reduce-overhead" (CUDA Graphs, what FLUX.1-dev uses), views
+            # into a single output allocation get materialized by cudagraph
+            # trees, and that copy is baked into every replay: measured a
+            # consistent 1-3% loss on contiguous shapes, which showed up e2e.
+            gtok = fx.Int32(tok_off) + tok
+            hoff = head * D + tid * VEC
+            if const_expr(CONTIG):
+                # Row stride is exactly H*D, so all four addresses coincide and
+                # H*D is a compile-time constant the backend can strength-reduce
+                # -- one address computation, no runtime multiply.  This is the
+                # codegen the pre-stride kernel had, and on the small per-rank
+                # shapes an Ulysses-sharded run produces, the difference between
+                # one address and three is a measurable ~2%.
+                out_base = gtok * HD + hoff
+                q_base = out_base
+                k_base = out_base
+            else:
+                q_base = gtok * fx.Int32(q_rs) + hoff
+                k_base = gtok * fx.Int32(k_rs) + hoff
+                out_base = gtok * HD + hoff
+            row = gtok % fx.Int32(cos_rows)
             coff = row * D + tid * VEC
             woff = tid * VEC
 
@@ -178,8 +223,8 @@ if _HAS_FLYDSL:
                 ff = fx.Vector(bf).to(fx.Float32)
                 return [ff[i] for i in range_constexpr(VEC)]
 
-            def process(g_in, g_out, g_w, NORM, HAS_W):
-                x = fx.Vector(g_in.load(base, vec_size=VEC)).to(fx.Float32)
+            def process(g_in, in_base, g_out, out_base, g_w, NORM, HAS_W):
+                x = fx.Vector(g_in.load(in_base, vec_size=VEC)).to(fx.Float32)
 
                 if const_expr(NORM):
                     x2 = x * x
@@ -195,7 +240,7 @@ if _HAS_FLYDSL:
                 if const_expr(HAS_W):
                     w = fx.Vector(g_w.load(woff, vec_size=VEC)).to(fx.Float32)
                     scaled = [scaled[i] * w[i] for i in range_constexpr(VEC)]
-                    if const_expr(ROUND_AFTER_NORM):
+                    if const_expr(ROUND_AFTER_AFFINE):
                         scaled = round_bf16(scaled)
 
                 # interleaved GPT-J rope on lane-local pairs (2k, 2k+1):
@@ -211,10 +256,10 @@ if _HAS_FLYDSL:
                 out_v = fx.Vector.from_elements(
                     [o.ir_value() for o in outs], dtype=fx.Float32
                 )
-                g_out.store(base, out_v.truncf(T.vec(VEC, T.bf16)))
+                g_out.store(out_base, out_v.truncf(T.vec(VEC, T.bf16)))
 
-            process(qin_, qout_, wq_, NORM_Q, HAS_WQ)
-            process(kin_, kout_, wk_, NORM_K, HAS_WK)
+            process(qin_, q_base, qout_, out_base, wq_, NORM_Q, HAS_WQ)
+            process(kin_, k_base, kout_, out_base, wk_, NORM_K, HAS_WK)
 
         @flyc.jit
         def launch_fused_qk_norm_rope(
@@ -227,12 +272,25 @@ if _HAS_FLYDSL:
             cos: fx.Tensor,
             sin: fx.Tensor,
             cos_rows: fx.Int32,
-            pos_offset: fx.Int32,
+            tok_off: fx.Int32,
+            q_rs: fx.Int32,
+            k_rs: fx.Int32,
             n_tokens: fx.Int32,
             stream: fx.Stream = fx.Stream(None),
         ):
             k = kernel(
-                q_in, k_in, q_out, k_out, wq, wk, cos, sin, cos_rows, pos_offset
+                q_in,
+                k_in,
+                q_out,
+                k_out,
+                wq,
+                wk,
+                cos,
+                sin,
+                cos_rows,
+                tok_off,
+                q_rs,
+                k_rs,
             )
             # ``n_tokens`` is a runtime Int32.  Pass it to the grid raw and let
             # ``KernelLauncher.launch`` cast each dim to index (via
@@ -254,8 +312,8 @@ if _HAS_FLYDSL:
 
     @torch.library.custom_op("xfuser::flydsl_qk_norm_rope", mutates_args=())
     def _flydsl_qk_norm_rope_launch(
-        q: torch.Tensor,       # [T, H, D] bf16, contiguous
-        k: torch.Tensor,       # [T, H, D] bf16, contiguous
+        q: torch.Tensor,       # [B, S, H, D] bf16, (H, D) packed, any row stride
+        k: torch.Tensor,       # [B, S, H, D] bf16, (H, D) packed, any row stride
         wq: Optional[torch.Tensor],  # [D] bf16 or None (weightless RMSNorm)
         wk: Optional[torch.Tensor],
         cos: torch.Tensor,     # [cos_rows, D]
@@ -267,6 +325,7 @@ if _HAS_FLYDSL:
         norm_q: bool,
         norm_k: bool,
         round_after_norm: bool,
+        round_after_affine: bool,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Opaque launch boundary for torch.compile.
 
@@ -277,11 +336,48 @@ if _HAS_FLYDSL:
         only at runtime with real tensors.  Without it Dynamo traces into
         ``flyc.compile`` and faults on ``FakeTensor.__dlpack__`` (no data
         pointer).
+
+        All *stride* inspection also lives in here, not in the Python caller:
+        under torch.compile with dynamic shapes ``Tensor.stride(i)`` returns a
+        ``SymInt``, and Dynamo cannot trace it (it asserts trying to build a
+        ConstantVariable).  Inside an opaque custom op the tensors are real.
         """
-        t_tok, h, d = q.shape
+        b, s, h, d = q.shape
+        t_tok = b * s
         has_wq = wq is not None
         has_wk = wk is not None
 
+        # [T, H, D] without a copy where possible.  Real models hand us q/k as
+        # chunks of a fused QKV projection -- a copy here is a full extra pass
+        # over both tensors and on Wan it cost more than the fusion saved.
+        q = _as_token_view(q, b, s, h, d, vec)
+        k = _as_token_view(k, b, s, h, d, vec)
+
+        # Buffer loads scale the element offset by the element size in i32, so
+        # for bf16 the addressable range is 2**30 elements.  Bound the strided
+        # input extent; a contiguous copy shrinks the row stride back to H*D,
+        # which the caller already checked fits.
+        if (t_tok - 1) * max(q.stride(0), k.stride(0)) + h * d >= (1 << 30):
+            q = q.contiguous()
+            k = k.contiguous()
+
+        # Two separate contiguous allocations.  Merging them into one buffer and
+        # returning views saves a DLPack marshal per call, but that only matters
+        # in default compile mode -- under mode="reduce-overhead" the op's Python
+        # body is not replayed at all, while cudagraph trees materialize the
+        # views, and the resulting copy is permanent in the replay.  The models
+        # use reduce-overhead, so separate buffers win where it counts.
+        oq = q.new_empty((t_tok, h, d))
+        ok = k.new_empty((t_tok, h, d))
+
+        # Row strides come off the tensors we actually marshal, so they can
+        # never disagree with the data pointer DLPack hands the kernel.
+        q_rs = q.stride(0)
+        k_rs = k.stride(0)
+
+        # Build after the strides are known: a packed input compiles to a
+        # cheaper addressing variant.  Both variants live in the lru cache, so a
+        # model that mixes contiguous and fused-QKV layers pays one JIT each.
         launcher = _build_kernel(
             H=h,
             D=d,
@@ -294,40 +390,49 @@ if _HAS_FLYDSL:
             HAS_WQ=has_wq,
             HAS_WK=has_wk,
             ROUND_AFTER_NORM=round_after_norm,
+            ROUND_AFTER_AFFINE=round_after_affine,
+            CONTIG=(q_rs == h * d and k_rs == h * d),
         )
-
-        oq = torch.empty_like(q)
-        ok = torch.empty_like(k)
 
         # kernel always binds wq/wk params; pass a 1-elem dummy when unused (the
         # const_expr HAS_W gate DCEs the load, but the binding needs a valid
-        # tensor).
-        dummy = q.new_empty(1, dtype=torch.bfloat16).view(1)
-        wq_arg = wq if has_wq else dummy
-        wk_arg = wk if has_wk else dummy
+        # tensor).  Allocate it only when it is actually needed -- every real
+        # model has both weights, and an unconditional alloc here is a device
+        # allocation on the hot path for nothing.
+        if has_wq and has_wk:
+            wq_arg, wk_arg = wq, wk
+        else:
+            dummy = q.new_empty(1, dtype=torch.bfloat16)
+            wq_arg = wq if has_wq else dummy
+            wk_arg = wk if has_wk else dummy
 
+        # ``tok_off`` is folded into the kernel's addressing, so chunks no longer
+        # need sliced views of q/k/out -- whole tensors go in once per launch.
+        # Grid Y is a 16-bit field on AMD HIP, hence the chunking at all; T is
+        # under MAX_GRID_Y for every shape these models actually run.
         stream = torch.cuda.current_stream()
-        for start in range(0, t_tok, MAX_GRID_Y):
-            n = min(MAX_GRID_Y, t_tok - start)
-            end = start + n
-            with torch.cuda.device(q.device.index):
+        with torch.cuda.device(q.device.index):
+            for start in range(0, t_tok, MAX_GRID_Y):
+                n = min(MAX_GRID_Y, t_tok - start)
                 _run_compiled(
                     launcher,
-                    q[start:end],
-                    k[start:end],
-                    oq[start:end],
-                    ok[start:end],
+                    q,
+                    k,
+                    oq,
+                    ok,
                     wq_arg,
                     wk_arg,
                     cos,
                     sin,
                     cos_rows,
                     start,
+                    q_rs,
+                    k_rs,
                     n,
                     stream,
                 )
 
-        return oq, ok
+        return oq.view(b, s, h, d), ok.view(b, s, h, d)
 
     @_flydsl_qk_norm_rope_launch.register_fake
     def _flydsl_qk_norm_rope_launch_fake(
@@ -344,8 +449,11 @@ if _HAS_FLYDSL:
         norm_q,
         norm_k,
         round_after_norm,
+        round_after_affine,
     ):
-        return torch.empty_like(q), torch.empty_like(k)
+        # Contiguous, matching the real op exactly -- a fake/real stride
+        # mismatch is a silent miscompile under Inductor.
+        return q.new_empty(q.shape), k.new_empty(k.shape)
 
 
 def _supported(query, key, cos) -> bool:
@@ -368,15 +476,62 @@ def _supported(query, key, cos) -> bool:
     return True
 
 
-def _norm_is_plain_rmsnorm(m) -> bool:
+def _norm_schedule(m) -> Optional[Tuple[bool, bool]]:
+    """Return ``(round_after_norm, round_after_affine)`` for RMSNorm ``m``.
+
+    The kernel replays the reference's bf16 *rounding schedule*, not just its
+    formula, and the two RMSNorm implementations in play round in different
+    places:
+
+    * ``diffusers.models.normalization.RMSNorm`` rounds twice -- once after the
+      rstd multiply (it casts to the bf16 weight dtype) and again implicitly
+      from the bf16 x bf16 affine multiply.
+    * ``torch.nn.RMSNorm`` accumulates the whole thing in fp32 and rounds once,
+      at the end -- so after the affine when there is a weight, and after the
+      norm when there is not.
+
+    Returns ``None`` for anything that is not a recognised weightless-or-affine
+    RMSNorm, which sends the caller to the unfused reference.  ``m is None``
+    means "no norm at all" and reports a schedule that is never consulted.
+    """
     if m is None:
-        return True
+        return (False, False)
     if getattr(m, "bias", None) is not None:
-        return False
+        return None
     w = getattr(m, "weight", None)
     if w is not None and w.dim() != 1:
-        return False
-    return True
+        return None
+    if isinstance(m, torch.nn.RMSNorm):
+        return (w is None, w is not None)
+    if isinstance(m, _DiffusersRMSNorm):
+        return (True, True)
+    # An unrecognised module could be a LayerNorm (which the old duck-typed
+    # check let through and silently computed as an RMSNorm).
+    return None
+
+
+def _as_token_view(
+    x: torch.Tensor, b: int, s: int, h: int, d: int, vec: int
+) -> torch.Tensor:
+    """``[B, S, H, D]`` -> ``[B*S, H, D]``, without copying when it is legal.
+
+    The kernel indexes rows by a runtime stride, so an arbitrary row stride is
+    fine, but everything inside a token's ``(H, D)`` block must be packed and
+    the VEC-wide buffer loads need natural alignment.  ``view`` enforces the
+    remaining condition (``stride(0) == S * stride(1)``, so B and S can flatten)
+    for free -- ``as_strided`` would skip that check and happily alias.
+    """
+    if (
+        x.stride(-1) == 1
+        and x.stride(-2) == d
+        and x.stride(1) % vec == 0
+        and x.storage_offset() % vec == 0
+    ):
+        try:
+            return x.view(b * s, h, d)
+        except RuntimeError:
+            pass
+    return x.contiguous().view(b * s, h, d)
 
 
 def _reference(
@@ -424,8 +579,16 @@ def flydsl_fused_qk_norm_rope(
         or len(rotary_emb) != 2
     ):
         return _reference(query, key, norm_q, norm_k, rotary_emb)
-    if not (_norm_is_plain_rmsnorm(norm_q) and _norm_is_plain_rmsnorm(norm_k)):
+    sched_q = _norm_schedule(norm_q)
+    sched_k = _norm_schedule(norm_k)
+    if sched_q is None or sched_k is None:
         return _reference(query, key, norm_q, norm_k, rotary_emb)
+    # One kernel build serves q and k, so a single rounding schedule has to
+    # cover both.  Mixed norm implementations are not something any model does.
+    active = [s for s, m in ((sched_q, norm_q), (sched_k, norm_k)) if m is not None]
+    if len(set(active)) > 1:
+        return _reference(query, key, norm_q, norm_k, rotary_emb)
+    round_after_norm, round_after_affine = active[0] if active else (False, False)
 
     cos, sin = rotary_emb
     if not _supported(query, key, cos):
@@ -449,9 +612,14 @@ def flydsl_fused_qk_norm_rope(
         return _reference(query, key, norm_q, norm_k, rotary_emb)
     block_threads, vec = block_vec
 
-    # contiguous [T, H, D]
-    q = query.contiguous().view(b * s, h, d)
-    k = key.contiguous().view(b * s, h, d)
+    # Buffer loads scale the element offset by the element size in i32, so for
+    # bf16 the addressable range is 2**30 elements, not 2**31.  This is the
+    # contiguous bound; the strided one needs the row stride and so lives
+    # inside the custom op, which can fall back to a copy on its own.  Reading
+    # .stride() out here would break Dynamo under dynamic shapes.
+    if b * s * h * d >= (1 << 30):
+        return _reference(query, key, norm_q, norm_k, rotary_emb)
+
     cos2 = cos2.contiguous()
     sin2 = sin2.contiguous()
 
@@ -468,22 +636,23 @@ def flydsl_fused_qk_norm_rope(
     if (has_wq and wq.dtype != torch.bfloat16) or (has_wk and wk.dtype != torch.bfloat16):
         return _reference(query, key, norm_q, norm_k, rotary_emb)
 
-    # diffusers RMSNorm only rounds the activation to the weight dtype when that
-    # dtype is half; bf16 activations here always trigger it.
-    round_after_norm = True
-
     eps = 1e-6
     for m in (norm_q, norm_k):
-        e = getattr(m, "eps", None) if m is not None else None
-        if e is not None:
-            eps = float(e)
-            break
+        if m is None:
+            continue
+        e = getattr(m, "eps", None)
+        if e is None:
+            # torch.nn.RMSNorm reads eps=None as finfo(dtype).eps, which is not
+            # the 1e-6 default below.
+            return _reference(query, key, norm_q, norm_k, rotary_emb)
+        eps = float(e)
+        break
 
     # The build + grid launches run inside an opaque custom op so this whole
     # path is safe under torch.compile (see _flydsl_qk_norm_rope_launch).
     oq, ok = _flydsl_qk_norm_rope_launch(
-        q,
-        k,
+        query,
+        key,
         wq if has_wq else None,
         wk if has_wk else None,
         cos2,
@@ -495,6 +664,7 @@ def flydsl_fused_qk_norm_rope(
         norm_q is not None,
         norm_k is not None,
         round_after_norm,
+        round_after_affine,
     )
 
-    return oq.view(b, s, h, d), ok.view(b, s, h, d)
+    return oq, ok

--- a/xfuser/model_executor/models/transformers/transformer_flux2.py
+++ b/xfuser/model_executor/models/transformers/transformer_flux2.py
@@ -52,6 +52,11 @@ from xfuser.model_executor.layers import (
 )
 from xfuser.model_executor.models.transformers.transformer_flux import (
     xFuserFluxAttentionWrapper,
+    _split_rotary_emb,
+)
+from xfuser.model_executor.layers.fused_qk_rope_flydsl import (
+    flydsl_fused_qk_norm_rope,
+    _HAS_FLYDSL,
 )
 from xfuser.model_executor.models.transformers.register import (
     xFuserTransformerWrappersRegister,
@@ -89,27 +94,68 @@ class xFuserFlux2AttnProcessor(Flux2AttnProcessor):
         key = key.unflatten(-1, (attn.heads, -1))
         value = value.unflatten(-1, (attn.heads, -1))
 
-        query = attn.norm_q(query)
-        key = attn.norm_k(key)
-
         num_encoder_tokens = 0
         if attn.added_kv_proj_dim is not None:
             encoder_query = encoder_query.unflatten(-1, (attn.heads, -1))
             encoder_key = encoder_key.unflatten(-1, (attn.heads, -1))
             encoder_value = encoder_value.unflatten(-1, (attn.heads, -1))
 
-            encoder_query = attn.norm_added_q(encoder_query)
-            encoder_key = attn.norm_added_k(encoder_key)
-
             num_encoder_tokens = encoder_query.shape[1]
+            num_query_tokens = query.shape[1]
 
-            query = torch.cat([encoder_query, query], dim=1)
-            key = torch.cat([encoder_key, key], dim=1)
-            value = torch.cat([encoder_value, value], dim=1)
+            if _HAS_FLYDSL:
+                # AITER/FlyDSL present: fuse QK-RMSNorm and RoPE into one kernel
+                # per stream.  RoPE is per-token, so applying it before the
+                # joint concat over dim=1 is mathematically identical to
+                # applying it after.  Mirrors xFuserFluxAttnProcessor.
+                txt_rope, img_rope = _split_rotary_emb(
+                    image_rotary_emb, num_encoder_tokens, num_query_tokens
+                )
+                encoder_query, encoder_key = flydsl_fused_qk_norm_rope(
+                    encoder_query,
+                    encoder_key,
+                    attn.norm_added_q,
+                    attn.norm_added_k,
+                    txt_rope,
+                )
+                query, key = flydsl_fused_qk_norm_rope(
+                    query, key, attn.norm_q, attn.norm_k, img_rope
+                )
 
-        if image_rotary_emb is not None:
-            query = apply_rotary_emb(query, image_rotary_emb, sequence_dim=1)
-            key = apply_rotary_emb(key, image_rotary_emb, sequence_dim=1)
+                query = torch.cat([encoder_query, query], dim=1)
+                key = torch.cat([encoder_key, key], dim=1)
+                value = torch.cat([encoder_value, value], dim=1)
+
+                if txt_rope is None and image_rotary_emb is not None:
+                    # tables could not be split -> apply RoPE on the joint stream
+                    query, key = flydsl_fused_qk_norm_rope(
+                        query, key, None, None, image_rotary_emb
+                    )
+            else:
+                # No AITER: the original unfused diffusers path, unchanged.
+                query = attn.norm_q(query)
+                key = attn.norm_k(key)
+                encoder_query = attn.norm_added_q(encoder_query)
+                encoder_key = attn.norm_added_k(encoder_key)
+
+                query = torch.cat([encoder_query, query], dim=1)
+                key = torch.cat([encoder_key, key], dim=1)
+                value = torch.cat([encoder_value, value], dim=1)
+
+                if image_rotary_emb is not None:
+                    query = apply_rotary_emb(query, image_rotary_emb, sequence_dim=1)
+                    key = apply_rotary_emb(key, image_rotary_emb, sequence_dim=1)
+        else:
+            if _HAS_FLYDSL:
+                query, key = flydsl_fused_qk_norm_rope(
+                    query, key, attn.norm_q, attn.norm_k, image_rotary_emb
+                )
+            else:
+                query = attn.norm_q(query)
+                key = attn.norm_k(key)
+                if image_rotary_emb is not None:
+                    query = apply_rotary_emb(query, image_rotary_emb, sequence_dim=1)
+                    key = apply_rotary_emb(key, image_rotary_emb, sequence_dim=1)
 
         # PipeFusion stale-KV: cache image KV per patch, keep encoder (text) KV fresh.
         # Mirrors xFuserFluxAttnProcessor.
@@ -227,12 +273,24 @@ class xFuserFlux2ParallelSelfAttnProcessor(Flux2ParallelSelfAttnProcessor):
         key = key.unflatten(-1, (attn.heads, -1))
         value = value.unflatten(-1, (attn.heads, -1))
 
-        query = attn.norm_q(query)
-        key = attn.norm_k(key)
+        if _HAS_FLYDSL:
+            # AITER/FlyDSL present: fuse QK-RMSNorm and RoPE into one kernel.
+            # No stream splitting needed here -- the single block already runs
+            # on the concatenated [text, image] stream and image_rotary_emb is
+            # the joint table covering exactly it.  query/key are non-contiguous
+            # chunks of the fused to_qkv_mlp_proj; the kernel reads them in
+            # place, so do NOT make them contiguous first.
+            query, key = flydsl_fused_qk_norm_rope(
+                query, key, attn.norm_q, attn.norm_k, image_rotary_emb
+            )
+        else:
+            # No AITER: the original unfused diffusers path, unchanged.
+            query = attn.norm_q(query)
+            key = attn.norm_k(key)
 
-        if image_rotary_emb is not None:
-            query = apply_rotary_emb(query, image_rotary_emb, sequence_dim=1)
-            key = apply_rotary_emb(key, image_rotary_emb, sequence_dim=1)
+            if image_rotary_emb is not None:
+                query = apply_rotary_emb(query, image_rotary_emb, sequence_dim=1)
+                key = apply_rotary_emb(key, image_rotary_emb, sequence_dim=1)
 
         # PipeFusion stale-KV: single block runs on concatenated [text, image].
         # Cache only the image portion (text KV stays fresh). MLP part is NOT cached.


### PR DESCRIPTION
# What?

  Adds the FlyDSL fused QK-RMSNorm + interleaved RoPE kernel to FLUX.2, and reworks the shared kernel so it can serve FLUX.2 correctly and faster.

  Kernel (`fused_qk_rope_flydsl.py`):
  - Reads non-contiguous q/k in place via runtime row-stride args instead of forcing `.contiguous()`.
  - Selects the bf16 rounding schedule from the norm class rather than assuming diffusers' `RMSNorm`.
  - Folds the grid-Y chunk offset into kernel addressing, so no per-call tensor slicing.
  - Corrects the i32 addressing bound from 2^31 to 2^30 elements.

  Wiring (`transformer_flux2.py`): both the single-stream (48 layers) and dual-stream (8 layers) attention processors, gated on
  `_HAS_FLYDSL` with the existing eager path preserved as the `else` branch.

  FLUX.1 and Qwen-Image are numerically unchanged and no slower.

  # Why?

FLUX.2-dev needs no new kernel: it is H=48, D=128, bf16, `[B,S,H,D]` with real interleaved `(cos, sin)`, i.e. inside the existing kernel's envelope.
  Two things blocked a drop-in:

  1. **Strides.** FLUX.2's single-stream block builds q/k by chunking `to_qkv_mlp_proj` (width `3*6144 + 18432*2 = 55296`), so q/k arrive with row stride 55296 against `H*D = 6144`. The caller's `.contiguous()` was a full extra pass over both tensors — the same trap that cost more than the fusion saved on Wan. This is 48 of FLUX.2's 56 layers.

  2. **Rounding schedule.** FLUX.2 uses `torch.nn.RMSNorm`, which accumulates in fp32 and rounds to bf16 once. FLUX.1/Qwen use diffusers' `RMSNorm`, which rounds twice — after the rstd multiply and again from the bf16 affine multiply. The kernel replays the reference's rounding schedule, not just its formula, and hardcoded the diffusers one. Wiring FLUX.2 without fixing this would have been silently wrong by a few ULP, with no shape or dtype gate catching it.


# Tests

### FLUX.2-dev

Run command:
```
xdit --model FLUX.2-dev --prompt "Add a small hat to the cat" --height 1024 --width 1024 --num-inference-steps 50 --max-sequence-length 512 --warmup-calls 5 --ulysses-degree 8 --use-torch-compile --input-images /app/data/flux_cat.png --guidance-scale 4.0 --num-iterations 25
```

## Latency
 Run | E2e  | Gain, %
--- | --- | ---
baseline | 3.46s | 0%
kernel fusion | 3.38s | 2.4 %


## Output
###  Baseline
<img width="1024" height="1024" alt="flux_2_no" src="https://github.com/user-attachments/assets/8cb5a8f8-1264-4d63-85cf-758a8005609c" />


###  After
<img width="1024" height="1024" alt="flux_2_yes" src="https://github.com/user-attachments/assets/f80bd0de-77fb-4b82-805f-933f4675f28a" />
