### PR TITLE
Fix `DiffusionOutput` to not wrap `videos=None` into a list

### DIFF
--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -199,7 +199,7 @@ class DiffusionOutput:
         self.images = images
         if isinstance(videos, np.ndarray) and videos.ndim == 5:
             videos = list(videos)
-        elif not isinstance(videos, list):
+        elif videos is not None and not isinstance(videos, list):
             videos = [videos]
         self.videos = videos
         if not isinstance(pipe_args, list):


### PR DESCRIPTION
`class DiffusionOutput()` constructor sets `None` as default value for `videos` parameter. Few lines later it wraps it into a list turning `videos=None` into `videos=[None]`. Almost all other code of the project tests whether videos field is set with `if obj.videos:` and `bool( [None] ) == True`, so the code takes the `if` branch which isn't meant for that. Leaving `videos` set to `None` prevents that.