### PR TITLE
[bugfix] take start time of all ranks into account for performance measurements

### DIFF
--- a/tests/core/test_model_replica_group.py
+++ b/tests/core/test_model_replica_group.py
@@ -1,0 +1,228 @@
+"""Distributed tests for model-replica process-group membership."""
+
+import queue
+import time
+import traceback
+from contextlib import nullcontext
+from unittest.mock import patch
+
+import pytest
+
+_WORLD_SIZE = 4
+_DP_DEGREE = 2
+_CFG_DEGREE = 2
+
+
+def _model_replica_group_worker(
+    rank,
+    world_size,
+    init_method,
+    result_queue,
+    *,
+    backend,
+    mock_device_selection,
+):
+    dist = None
+    try:
+        import torch
+        import torch.distributed as dist
+
+        from xfuser.core.distributed import parallel_state
+
+        device_selection = (
+            patch.object(parallel_state, "set_device")
+            if mock_device_selection
+            else nullcontext()
+        )
+        with device_selection:
+            parallel_state.init_distributed_environment(
+                backend=backend,
+                distributed_init_method=init_method,
+                local_rank=rank,
+                rank=rank,
+                world_size=world_size,
+            )
+        parallel_state.initialize_model_parallel(
+            backend=backend,
+            classifier_free_guidance_degree=_CFG_DEGREE,
+            data_parallel_degree=_DP_DEGREE,
+        )
+
+        replica = parallel_state.get_model_replica_group()
+        device = (
+            torch.device(f"cuda:{rank}") if backend == "nccl" else torch.device("cpu")
+        )
+        gathered = replica.all_gather(
+            torch.tensor([rank], dtype=torch.int64, device=device)
+        )
+
+        # Only the first replica enters this extra barrier. The following world
+        # barrier proves that the second replica was not required to release it.
+        if rank < world_size // _DP_DEGREE:
+            replica.barrier()
+        parallel_state.get_world_group().barrier()
+
+        result_queue.put(
+            (
+                "returned",
+                rank,
+                parallel_state.get_data_parallel_rank(),
+                replica.ranks,
+                gathered.tolist(),
+            )
+        )
+    except Exception:  # noqa: BLE001 - report arbitrary child failures to the parent
+        result_queue.put(("error", rank, traceback.format_exc()))
+    finally:
+        if dist is not None and dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def _gloo_model_replica_group_worker(rank, world_size, init_method, result_queue):
+    _model_replica_group_worker(
+        rank,
+        world_size,
+        init_method,
+        result_queue,
+        backend="gloo",
+        mock_device_selection=True,
+    )
+
+
+def _nccl_model_replica_group_worker(rank, world_size, init_method, result_queue):
+    _model_replica_group_worker(
+        rank,
+        world_size,
+        init_method,
+        result_queue,
+        backend="nccl",
+        mock_device_selection=False,
+    )
+
+
+def _run_spawned(torch, worker, init_method, *, world_size, timeout):
+    context = torch.multiprocessing.get_context("spawn")
+    result_queue = context.Queue()
+    processes = [
+        context.Process(
+            target=worker,
+            args=(rank, world_size, init_method, result_queue),
+        )
+        for rank in range(world_size)
+    ]
+    for process in processes:
+        process.start()
+
+    deadline = time.monotonic() + timeout
+    for process in processes:
+        process.join(max(0.0, deadline - time.monotonic()))
+
+    hung = [process.pid for process in processes if process.is_alive()]
+    for process in processes:
+        if process.is_alive():
+            process.terminate()
+            process.join(5)
+
+    for process in processes:
+        if process.is_alive():
+            process.kill()
+            process.join(5)
+    survivors = [process.pid for process in processes if process.is_alive()]
+
+    results = []
+    while len(results) < world_size:
+        try:
+            results.append(result_queue.get(timeout=1))
+        except queue.Empty:
+            break
+    return processes, hung, survivors, results
+
+
+def _require_torch_distributed():
+    torch = pytest.importorskip(
+        "torch", reason="PyTorch is required for distributed process-group tests"
+    )
+    if not torch.distributed.is_available():
+        pytest.skip("torch.distributed is unavailable")
+    return torch
+
+
+def _real_gpu_unavailability(torch):
+    reasons = []
+    if not torch.cuda.is_available():
+        reasons.append("CUDA-compatible GPUs are unavailable")
+    visible_gpus = torch.cuda.device_count()
+    if visible_gpus < _WORLD_SIZE:
+        reasons.append(
+            f"{_WORLD_SIZE} visible CUDA-compatible GPUs are required; found {visible_gpus}"
+        )
+    if not torch.distributed.is_nccl_available():
+        reasons.append("NCCL/RCCL is unavailable")
+    return "; ".join(reasons) if reasons else None
+
+
+def _assert_replica_group_results(processes, hung, survivors, results):
+    assert not survivors, f"workers survived SIGKILL: {survivors}"
+    assert not hung, f"model-replica collective hung worker pids: {hung}"
+    assert [process.exitcode for process in processes] == [0] * _WORLD_SIZE
+    assert len(results) == _WORLD_SIZE
+    assert all(result[0] == "returned" for result in results), results
+
+    facts = {
+        rank: (dp_rank, replica_ranks, gathered_ranks)
+        for _, rank, dp_rank, replica_ranks, gathered_ranks in results
+    }
+    assert facts == {
+        0: (0, [0, 1], [0, 1]),
+        1: (0, [0, 1], [0, 1]),
+        2: (1, [2, 3], [2, 3]),
+        3: (1, [2, 3], [2, 3]),
+    }
+
+
+@pytest.mark.slow
+def test_model_replica_group_on_real_gpus_without_hanging(tmp_path):
+    torch = _require_torch_distributed()
+    unavailable = _real_gpu_unavailability(torch)
+    if unavailable:
+        pytest.skip(
+            f"real-GPU model-replica test requirements unsatisfied: {unavailable}"
+        )
+
+    processes, hung, survivors, results = _run_spawned(
+        torch,
+        _nccl_model_replica_group_worker,
+        f"file://{tmp_path / 'model-replica-nccl-init'}",
+        world_size=_WORLD_SIZE,
+        timeout=60,
+    )
+
+    _assert_replica_group_results(processes, hung, survivors, results)
+
+
+@pytest.mark.slow
+def test_model_replica_group_on_cpu_without_hanging(tmp_path):
+    torch = _require_torch_distributed()
+    if _real_gpu_unavailability(torch) is None:
+        pytest.skip(
+            "real GPUs are available; the NCCL test covers replica-group behavior"
+        )
+    if not torch.distributed.is_gloo_available():
+        pytest.skip("torch.distributed gloo backend is unavailable")
+
+    processes, hung, survivors, results = _run_spawned(
+        torch,
+        _gloo_model_replica_group_worker,
+        f"file://{tmp_path / 'model-replica-gloo-init'}",
+        world_size=_WORLD_SIZE,
+        timeout=30,
+    )
+
+    _assert_replica_group_results(processes, hung, survivors, results)
+
+
+if __name__ == "__main__":
+    import sys
+    import pytest
+
+    sys.exit(pytest.main(sys.argv))

--- a/xfuser/core/distributed/__init__.py
+++ b/xfuser/core/distributed/__init__.py
@@ -1,5 +1,6 @@
 from .parallel_state import (
     get_world_group,
+    get_model_replica_group,
     get_dp_group,
     get_cfg_group,
     get_sp_group,
@@ -41,6 +42,7 @@ from .sharding import shard_dit, shard_t5_encoder, shard_component, children_to_
 
 __all__ = [
     "get_world_group",
+    "get_model_replica_group",
     "get_dp_group",
     "get_cfg_group",
     "get_sp_group",

--- a/xfuser/core/distributed/parallel_state.py
+++ b/xfuser/core/distributed/parallel_state.py
@@ -45,6 +45,14 @@ _DP: Optional[GroupCoordinator] = None
 _FS: Optional[GroupCoordinator] = None
 _DIT: Optional[GroupCoordinator] = None
 _VAE: Optional[GroupCoordinator] = None
+_MODEL_REPLICA: Optional[GroupCoordinator] = None
+
+
+def get_model_replica_group() -> GroupCoordinator:
+    """Return a group of ranks constituting current DP replica, i.e.
+    the ranks with varying "tp-sp-pp-cfg" grid coordinates"""
+    assert _MODEL_REPLICA is not None
+    return _MODEL_REPLICA
 
 
 # * QUERY
@@ -286,7 +294,8 @@ def init_distributed_environment(
 def model_parallel_is_initialized():
     """Check if tensor and pipeline parallel groups are initialized."""
     return (
-        _DP is not None
+        _MODEL_REPLICA is not None
+        and _DP is not None
         and _CFG is not None
         and _SP is not None
         and _PP is not None
@@ -309,6 +318,7 @@ def init_model_parallel_group(
         "classifier_free_guidance",
         "fully_shard",
         "vae",
+        "model_replica",
     ], f"parallel_mode {parallel_mode} is not supported"
     if parallel_mode == "pipeline":
         return PipelineGroupCoordinator(
@@ -461,6 +471,16 @@ def initialize_model_parallel(
         fully_shard_degree,
         "tp-sp-pp-cfg-dp",
     )
+
+    global _MODEL_REPLICA
+    assert _MODEL_REPLICA is None
+    _MODEL_REPLICA = init_model_parallel_group(
+        group_ranks=rank_generator.get_ranks("tp-sp-pp-cfg"),
+        local_rank=get_world_group().local_rank,
+        backend=backend,
+        parallel_mode="model_replica",
+    )
+
     global _DP
     assert _DP is None, "data parallel group is already initialized"
     _DP = init_model_parallel_group(
@@ -554,6 +574,11 @@ def initialize_model_parallel(
 
 def destroy_model_parallel():
     """Set the groups to none and destroy them."""
+    global _MODEL_REPLICA
+    if _MODEL_REPLICA:
+        _MODEL_REPLICA.destroy()
+    _MODEL_REPLICA = None
+    
     global _DP
     if _DP:
         _DP.destroy()

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -31,6 +31,7 @@ from xfuser.model_executor.models.runner_models.vae_manager import (
 from xfuser.model_executor.cache.presets import DBCacheSettings, ModelCacheConfig
 from xfuser.core.distributed import (
     get_world_group,
+    get_model_replica_group,
     get_data_parallel_rank,
     get_data_parallel_world_size,
     get_sequence_parallel_rank,
@@ -841,18 +842,27 @@ class xFuserModel(abc.ABC):
         self._vae_manager.prepare_run(self._decoding_vaes(), input_args)
 
     def _run_timed_pipe(self, input_args: dict) -> Tuple[DiffusionOutput, float]:
-        """ Run a a full pipeline with timing information """
+        """ Run the pipeline and time its latency from the synchronized across all ranks beginning
+        of the model execution, till the moment the current rank finishes.
+        
+        Later, we typically discard timings of all ranks except the last one, which is assumed to
+        be the rank providing model's output.
+        """
 
         self.prepare_run(input_args)
+        replica = get_model_replica_group()
+
         start = torch.cuda.Event(enable_timing=True)
         end = torch.cuda.Event(enable_timing=True)
+
         torch.cuda.synchronize()
+        replica.barrier()     # aligns all ranks in the replica as closely as possible
 
         start.record()
         out = self._run_pipe(input_args)
         end.record()
+        end.synchronize()   # we don't care about other streams if there are any
 
-        torch.cuda.synchronize()
         elapsed_time = start.elapsed_time(end) / 1000  # Convert to seconds
         return out, elapsed_time
 


### PR DESCRIPTION
Current implementation measures the latency of each rank in isolation and then returns the latency of the last rank as the latency of the whole model execution. This is based on 2 assumptions:

1. the last rank start the model execution.
2. the last rank produces the output user cares about.

While the second assumption usually holds (with exception of SD3.5 and possibly other DP models; And it is not asserted, which is problematic), the first assumption is completely broken.

This change creates a DP replica group of ranks and places a barrier for all ranks participating the group before start of the execution, so all ranks start as closely to each other as possible, and then the latency of current rank is measured and is returned, which for the last rank (following the second assumption) yields the best estimate of the model run time that user cares about.

Implementation on the replica-scale barrier is simple, but not ideal. The problem is, making anything better seems to require a perfect clock synchronization between ranks, and an API update to return timestamps of `torch.cuda` events instead of providing only `elapsed_time(start)`.

## Effect

**Note**: this was measured using the previous iteration of the changeset based on the world-scale barrier, which also corresponded to a replica scale barrier since there were not a case with DP>1.

Effect of the change was measured 3 times using the following 8 configurations

```
    - flux.usp
    - flux2.default
    - flux2.quantgemm.gfx942
    - flux2.quantgemm.gfx950
    - stablediffusion_3_5.default
    - z_image.default
    - qwen_image.default
    - wan2_2.quantgemm_fp8attn.gfx950
```

on 8 x MI355x and compared to the original implementation and to an implementation collecting the longest across all ranks latency. Overall, the original implementation very slightly underestimates the run time for all these configurations with the exception of SD3.5, where underestimation is more than 4-5+%.

<details><summary>Full performance report</summary>

```
Benchmark comparison results ([Brunner Munzel test](https://en.wikipedia.org/wiki/Brunner_Munzel_Test), alpha=0.00100)                                                         
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃                                  Benchmark                                   ┃                                  real_time (means), [0%, 100%]                                  ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ flux.usp/a/res1 | 00_original vs 10_full_timings                             │ 726.4ms < 732.1ms {+0.8%} [720.6m,748.2m] < [725.1m,826.8m] {+0.6%,+10.5%} p=0.00005 (30 vs 30) │
│ flux.usp/a/res1 | 00_original vs 20_barrier_start                            │ 726.4ms < 729.0ms {+0.4%} [720.6m,748.2m] < [723.9m,732.6m] {+0.4%,-2.1%} p=0.00000+(30 vs 30)  │
│ flux.usp/a/res1 | 10_full_timings vs 20_barrier_start                        │ 732.1ms ~ 729.0ms {-0.4%} [725.1m,826.8m] ~ [723.9m,732.6m] {-0.2%,-11.4%} p=0.05980 (30 vs 30) │
│ flux.usp/a/res2 | 00_original vs 10_full_timings                             │ 728.4ms ~ 730.9ms {+0.3%} [721.7m,753.2m] ~ [725.3m,827.3m] {+0.5%,+9.8%} p=0.38502 (30 vs 30)  │
│ flux.usp/a/res2 | 00_original vs 20_barrier_start                            │ 728.4ms ~ 725.6ms {-0.4%} [721.7m,753.2m] ~ [722.3m,729.0m] {+0.1%,-3.2%} p=0.00269 (30 vs 30)  │
│ flux.usp/a/res2 | 10_full_timings vs 20_barrier_start                        │ 730.9ms > 725.6ms {-0.7%} [725.3m,827.3m] > [722.3m,729.0m] {-0.4%,-11.9%} p=0.00000+(30 vs 30) │
│ flux.usp/a/res3 | 00_original vs 10_full_timings                             │ 725.8ms ~ 727.4ms {+0.2%} [720.5m,729.4m] ~ [724.7m,734.6m] {+0.6%,+0.7%} p=0.00629 (30 vs 30)  │
│ flux.usp/a/res3 | 00_original vs 20_barrier_start                            │ 725.8ms ~ 726.5ms {+0.1%} [720.5m,729.4m] ~ [721.4m,746.2m] {+0.1%,+2.3%} p=0.45992 (30 vs 30)  │
│ flux.usp/a/res3 | 10_full_timings vs 20_barrier_start                        │ 727.4ms > 726.5ms {-0.1%} [724.7m,734.6m] > [721.4m,746.2m] {-0.5%,+1.6%} p=0.00099 (30 vs 30)  │
│ flux2.default/a/res1 | 00_original vs 10_full_timings                        │ 3.421s ~ 3.413s {-0.2%} [3.400,3.519] ~ [3.401,3.443] {+0.0%,-2.2%} p=0.03179 (30 vs 30)        │
│ flux2.default/a/res1 | 00_original vs 20_barrier_start                       │ 3.421s ~ 3.418s {-0.1%} [3.400,3.519] ~ [3.403,3.514] {+0.1%,-0.1%} p=0.29636 (30 vs 30)        │
│ flux2.default/a/res1 | 10_full_timings vs 20_barrier_start                   │ 3.413s ~ 3.418s {+0.1%} [3.401,3.443] ~ [3.403,3.514] {+0.0%,+2.1%} p=0.12007 (30 vs 30)        │
│ flux2.default/a/res2 | 00_original vs 10_full_timings                        │ 3.419s ~ 3.418s {-0.0%} [3.398,3.528] ~ [3.399,3.520] {+0.0%,-0.2%} p=0.04789 (30 vs 30)        │
│ flux2.default/a/res2 | 00_original vs 20_barrier_start                       │ 3.419s ~ 3.421s {+0.1%} [3.398,3.528] ~ [3.402,3.530] {+0.1%,+0.1%} p=0.48301 (30 vs 30)        │
│ flux2.default/a/res2 | 10_full_timings vs 20_barrier_start                   │ 3.418s ~ 3.421s {+0.1%} [3.399,3.520] ~ [3.402,3.530] {+0.1%,+0.3%} p=0.00698 (30 vs 30)        │
│ flux2.default/a/res3 | 00_original vs 10_full_timings                        │ 3.420s < 3.424s {+0.1%} [3.400,3.515] < [3.416,3.448] {+0.5%,-1.9%} p=0.00007 (30 vs 30)        │
│ flux2.default/a/res3 | 00_original vs 20_barrier_start                       │ 3.420s ~ 3.429s {+0.3%} [3.400,3.515] ~ [3.406,3.759] {+0.2%,+7.0%} p=0.32078 (30 vs 30)        │
│ flux2.default/a/res3 | 10_full_timings vs 20_barrier_start                   │ 3.424s > 3.429s {+0.1%} [3.416,3.448] > [3.406,3.759] {-0.3%,+9.0%} p=0.00031 (30 vs 30)        │
│ flux2.quantgemm.gfx950/a/res1 | 00_original vs 10_full_timings               │ 2.125s ~ 2.118s {-0.3%} [2.109,2.213] ~ [2.108,2.144] {-0.1%,-3.1%} p=0.00365 (30 vs 30)        │
│ flux2.quantgemm.gfx950/a/res1 | 00_original vs 20_barrier_start              │ 2.125s > 2.112s {-0.6%} [2.109,2.213] > [2.098,2.134] {-0.5%,-3.6%} p=0.00000+(30 vs 30)        │
│ flux2.quantgemm.gfx950/a/res1 | 10_full_timings vs 20_barrier_start          │ 2.118s > 2.112s {-0.3%} [2.108,2.144] > [2.098,2.134] {-0.5%,-0.5%} p=0.00009 (30 vs 30)        │
│ flux2.quantgemm.gfx950/a/res2 | 00_original vs 10_full_timings               │ 2.111s ~ 2.113s {+0.1%} [2.091,2.138] ~ [2.102,2.137] {+0.5%,-0.0%} p=0.13276 (30 vs 30)        │
│ flux2.quantgemm.gfx950/a/res2 | 00_original vs 20_barrier_start              │ 2.111s ~ 2.113s {+0.1%} [2.091,2.138] ~ [2.098,2.214] {+0.4%,+3.5%} p=0.27833 (30 vs 30)        │
│ flux2.quantgemm.gfx950/a/res2 | 10_full_timings vs 20_barrier_start          │ 2.113s ~ 2.113s {-0.0%} [2.102,2.137] ~ [2.098,2.214] {-0.2%,+3.6%} p=0.05941 (30 vs 30)        │
│ flux2.quantgemm.gfx950/a/res3 | 00_original vs 10_full_timings               │ 2.110s < 2.123s {+0.6%} [2.088,2.203] < [2.111,2.218] {+1.1%,+0.7%} p=0.00000+(30 vs 30)        │
│ flux2.quantgemm.gfx950/a/res3 | 00_original vs 20_barrier_start              │ 2.110s < 2.117s {+0.3%} [2.088,2.203] < [2.106,2.137] {+0.8%,-3.0%} p=0.00001 (30 vs 30)        │
│ flux2.quantgemm.gfx950/a/res3 | 10_full_timings vs 20_barrier_start          │ 2.123s ~ 2.117s {-0.3%} [2.111,2.218] ~ [2.106,2.137] {-0.2%,-3.6%} p=0.00705 (30 vs 30)        │
│ qwen_image.default/a/res1 | 00_original vs 10_full_timings                   │ 5.070s < 5.117s {+0.9%} [5.039,5.167] < [5.082,5.224] {+0.8%,+1.1%} p=0.00000+(30 vs 30)        │
│ qwen_image.default/a/res1 | 00_original vs 20_barrier_start                  │ 5.070s < 5.098s {+0.6%} [5.039,5.167] < [5.068,5.214] {+0.6%,+0.9%} p=0.00000+(30 vs 30)        │
│ qwen_image.default/a/res1 | 10_full_timings vs 20_barrier_start              │ 5.117s > 5.098s {-0.4%} [5.082,5.224] > [5.068,5.214] {-0.3%,-0.2%} p=0.00003 (30 vs 30)        │
│ qwen_image.default/a/res2 | 00_original vs 10_full_timings                   │ 5.063s ~ 5.076s {+0.2%} [5.030,5.167] ~ [5.038,5.111] {+0.2%,-1.1%} p=0.00105 (30 vs 30)        │
│ qwen_image.default/a/res2 | 00_original vs 20_barrier_start                  │ 5.063s ~ 5.061s {-0.1%} [5.030,5.167] ~ [5.031,5.173] {+0.0%,+0.1%} p=0.16892 (30 vs 30)        │
│ qwen_image.default/a/res2 | 10_full_timings vs 20_barrier_start              │ 5.076s > 5.061s {-0.3%} [5.038,5.111] > [5.031,5.173] {-0.1%,+1.2%} p=0.00006 (30 vs 30)        │
│ qwen_image.default/a/res3 | 00_original vs 10_full_timings                   │ 5.068s ~ 5.064s {-0.1%} [5.030,5.126] ~ [5.031,5.172] {+0.0%,+0.9%} p=0.10698 (30 vs 30)        │
│ qwen_image.default/a/res3 | 00_original vs 20_barrier_start                  │ 5.068s > 5.048s {-0.4%} [5.030,5.126] > [5.019,5.145] {-0.2%,+0.4%} p=0.00000+(30 vs 30)        │
│ qwen_image.default/a/res3 | 10_full_timings vs 20_barrier_start              │ 5.064s > 5.048s {-0.3%} [5.031,5.172] > [5.019,5.145] {-0.2%,-0.5%} p=0.00041 (30 vs 30)        │
│ stablediffusion_3_5.default/a/res1 | 00_original vs 10_full_timings          │ 786.0ms < 853.3ms {+8.6%} [769.5m,805.4m] < [825.6m,889.5m] {+7.3%,+10.4%} p=0.00000+(30 vs 30) │
│ stablediffusion_3_5.default/a/res1 | 00_original vs 20_barrier_start         │ 786.0ms < 820.4ms {+4.4%} [769.5m,805.4m] < [803.5m,883.4m] {+4.4%,+9.7%} p=0.00000+(30 vs 30)  │
│ stablediffusion_3_5.default/a/res1 | 10_full_timings vs 20_barrier_start     │ 853.3ms > 820.4ms {-3.8%} [825.6m,889.5m] > [803.5m,883.4m] {-2.7%,-0.7%} p=0.00000+(30 vs 30)  │
│ stablediffusion_3_5.default/a/res2 | 00_original vs 10_full_timings          │ 784.8ms < 846.7ms {+7.9%} [773.9m,848.4m] < [819.2m,895.7m] {+5.9%,+5.6%} p=0.00000+(30 vs 30)  │
│ stablediffusion_3_5.default/a/res2 | 00_original vs 20_barrier_start         │ 784.8ms < 839.1ms {+6.9%} [773.9m,848.4m] < [805.6m,919.1m] {+4.1%,+8.3%} p=0.00000+(30 vs 30)  │
│ stablediffusion_3_5.default/a/res2 | 10_full_timings vs 20_barrier_start     │ 846.7ms ~ 839.1ms {-0.9%} [819.2m,895.7m] ~ [805.6m,919.1m] {-1.7%,+2.6%} p=0.04888 (30 vs 30)  │
│ stablediffusion_3_5.default/a/res3 | 00_original vs 10_full_timings          │ 799.0ms < 831.3ms {+4.0%} [771.2m,897.1m] < [820.0m,911.7m] {+6.3%,+1.6%} p=0.00000+(30 vs 30)  │
│ stablediffusion_3_5.default/a/res3 | 00_original vs 20_barrier_start         │ 799.0ms < 833.7ms {+4.3%} [771.2m,897.1m] < [814.3m,865.7m] {+5.6%,-3.5%} p=0.00000+(30 vs 30)  │
│ stablediffusion_3_5.default/a/res3 | 10_full_timings vs 20_barrier_start     │ 831.3ms ~ 833.7ms {+0.3%} [820.0m,911.7m] ~ [814.3m,865.7m] {-0.7%,-5.0%} p=0.13180 (30 vs 30)  │
│ wan2_2.quantgemm_fp8attn.gfx950/b/res1 | 00_original vs 10_full_timings      │ 36.13s ~ 36.14s {+0.0%} [35.97,36.32] ~ [35.98,36.24] {+0.0%,-0.2%} p=0.37708 (25 vs 25)        │
│ wan2_2.quantgemm_fp8attn.gfx950/b/res1 | 00_original vs 20_barrier_start     │ 36.13s ~ 36.14s {+0.0%} [35.97,36.32] ~ [35.94,36.28] {-0.1%,-0.1%} p=0.40624 (25 vs 25)        │
│ wan2_2.quantgemm_fp8attn.gfx950/b/res1 | 10_full_timings vs 20_barrier_start │ 36.14s ~ 36.14s {-0.0%} [35.98,36.24] ~ [35.94,36.28] {-0.1%,+0.1%} p=0.48111 (25 vs 25)        │
│ wan2_2.quantgemm_fp8attn.gfx950/b/res2 | 00_original vs 10_full_timings      │ 36.08s < 36.19s {+0.3%} [35.97,36.24] < [36.05,36.30] {+0.2%,+0.2%} p=0.00000+(25 vs 25)        │
│ wan2_2.quantgemm_fp8attn.gfx950/b/res2 | 00_original vs 20_barrier_start     │ 36.08s ~ 36.08s {-0.0%} [35.97,36.24] ~ [35.99,36.18] {+0.1%,-0.2%} p=0.37088 (25 vs 25)        │
│ wan2_2.quantgemm_fp8attn.gfx950/b/res2 | 10_full_timings vs 20_barrier_start │ 36.19s > 36.08s {-0.3%} [36.05,36.30] > [35.99,36.18] {-0.2%,-0.3%} p=0.00000+(25 vs 25)        │
│ wan2_2.quantgemm_fp8attn.gfx950/b/res3 | 00_original vs 10_full_timings      │ 36.13s < 36.21s {+0.2%} [35.98,36.27] < [36.10,36.33] {+0.3%,+0.2%} p=0.00000+(25 vs 25)        │
│ wan2_2.quantgemm_fp8attn.gfx950/b/res3 | 00_original vs 20_barrier_start     │ 36.13s ~ 36.15s {+0.1%} [35.98,36.27] ~ [35.95,36.86] {-0.1%,+1.6%} p=0.45905 (25 vs 25)        │
│ wan2_2.quantgemm_fp8attn.gfx950/b/res3 | 10_full_timings vs 20_barrier_start │ 36.21s > 36.15s {-0.2%} [36.10,36.33] > [35.95,36.86] {-0.4%,+1.5%} p=0.00035 (25 vs 25)        │
│ z_image.default/a/res1 | 00_original vs 10_full_timings                      │ 2.292s > 2.279s {-0.6%} [2.277,2.313] > [2.263,2.338] {-0.6%,+1.1%} p=0.00000+(30 vs 30)        │
│ z_image.default/a/res1 | 00_original vs 20_barrier_start                     │ 2.292s > 2.276s {-0.7%} [2.277,2.313] > [2.264,2.294] {-0.6%,-0.8%} p=0.00000+(30 vs 30)        │
│ z_image.default/a/res1 | 10_full_timings vs 20_barrier_start                 │ 2.279s ~ 2.276s {-0.1%} [2.263,2.338] ~ [2.264,2.294] {+0.1%,-1.9%} p=0.23783 (30 vs 30)        │
│ z_image.default/a/res2 | 00_original vs 10_full_timings                      │ 2.292s ~ 2.289s {-0.1%} [2.276,2.308] ~ [2.272,2.387] {-0.2%,+3.4%} p=0.00479 (30 vs 30)        │
│ z_image.default/a/res2 | 00_original vs 20_barrier_start                     │ 2.292s > 2.288s {-0.2%} [2.276,2.308] > [2.274,2.396] {-0.1%,+3.8%} p=0.00049 (30 vs 30)        │
│ z_image.default/a/res2 | 10_full_timings vs 20_barrier_start                 │ 2.289s ~ 2.288s {-0.0%} [2.272,2.387] ~ [2.274,2.396] {+0.1%,+0.4%} p=0.17478 (30 vs 30)        │
│ z_image.default/a/res3 | 00_original vs 10_full_timings                      │ 2.292s > 2.282s {-0.4%} [2.274,2.394] > [2.271,2.310] {-0.1%,-3.5%} p=0.00054 (30 vs 30)        │
│ z_image.default/a/res3 | 00_original vs 20_barrier_start                     │ 2.292s ~ 2.289s {-0.1%} [2.274,2.394] ~ [2.277,2.387] {+0.1%,-0.3%} p=0.04580 (30 vs 30)        │
│ z_image.default/a/res3 | 10_full_timings vs 20_barrier_start                 │ 2.282s ~ 2.289s {+0.3%} [2.271,2.310] ~ [2.277,2.387] {+0.2%,+3.3%} p=0.01303 (30 vs 30)        │
└──────────────────────────────────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────┘
```
</details>