### PR TITLE
fix(flux): drop callback pops for nonexistent negative embeds

### DIFF
--- a/xfuser/model_executor/pipelines/pipeline_flux.py
+++ b/xfuser/model_executor/pipelines/pipeline_flux.py
@@ -641,13 +641,6 @@ class xFuserFluxPipeline(xFuserPipelineBaseWrapper):
                         prompt_embeds = callback_outputs.pop(
                             "prompt_embeds", prompt_embeds
                         )
-                        negative_prompt_embeds = callback_outputs.pop(
-                            "negative_prompt_embeds", negative_prompt_embeds
-                        )
-                        negative_pooled_prompt_embeds = callback_outputs.pop(
-                            "negative_pooled_prompt_embeds",
-                            negative_pooled_prompt_embeds,
-                        )
 
                     if i != len(timesteps) - 1:
                         get_pp_group().pipeline_isend(

--- a/xfuser/model_executor/pipelines/pipeline_flux_control.py
+++ b/xfuser/model_executor/pipelines/pipeline_flux_control.py
@@ -695,13 +695,6 @@ class xFuserPipelineFluxControlPipeline(xFuserPipelineBaseWrapper):
                         prompt_embeds = callback_outputs.pop(
                             "prompt_embeds", prompt_embeds
                         )
-                        negative_prompt_embeds = callback_outputs.pop(
-                            "negative_prompt_embeds", negative_prompt_embeds
-                        )
-                        negative_pooled_prompt_embeds = callback_outputs.pop(
-                            "negative_pooled_prompt_embeds",
-                            negative_pooled_prompt_embeds,
-                        )
 
                     if i != len(timesteps) - 1:
                         get_pp_group().pipeline_isend(


### PR DESCRIPTION
## Problem

`FluxPipeline` and `FluxControlPipeline` are guidance-distilled and have **no negative conditioning** — `negative_prompt_embeds` / `negative_pooled_prompt_embeds` are never defined anywhere in the denoising loop (they are not `__call__` parameters and are never assigned).

Nonetheless, the `callback_on_step_end` block references them as the *default* argument of `callback_outputs.pop(...)`:

```python
negative_prompt_embeds = callback_outputs.pop(
    "negative_prompt_embeds", negative_prompt_embeds          # <- default eval'd eagerly
)
negative_pooled_prompt_embeds = callback_outputs.pop(
    "negative_pooled_prompt_embeds",
    negative_pooled_prompt_embeds,
)
```

Python evaluates the second argument to `pop` before the call, so **any user who passes `callback_on_step_end` crashes**:

```
NameError: cannot access local variable 'negative_prompt_embeds' where it is not associated with a value
```

## Fix

Remove those two pops. The block now matches:

1. **The pipelines' own earlier callback block** in the same files, which correctly pops only `latents` and `prompt_embeds`:
   ```python
   latents = callback_outputs.pop("latents", latents)
   prompt_embeds = callback_outputs.pop("prompt_embeds", prompt_embeds)
   ```
2. **Upstream `diffusers` `FluxPipeline`**, whose callback likewise pops only `latents` and `prompt_embeds`.

## Verification

Minimal reproduction of the exact block logic:

```
BEFORE: NameError -> cannot access local variable 'negative_prompt_embeds' ...
AFTER : L
```

`pyflakes` reports no more undefined names in either file after the change. Fix is limited to the two Flux pipelines (each already contains a correct sibling block). HunyuanDiT / SD3 use classifier-free guidance and are a separate concern, so they are intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
