### PR TITLE
fix(sd3,hunyuandit): drop callback pops for undefined negative embeds

### DIFF
--- a/xfuser/model_executor/pipelines/pipeline_hunyuandit.py
+++ b/xfuser/model_executor/pipelines/pipeline_hunyuandit.py
@@ -646,14 +646,8 @@ class xFuserHunyuanDiTPipeline(xFuserPipelineBaseWrapper):
 
                 latents = callback_outputs.pop("latents", latents)
                 prompt_embeds = callback_outputs.pop("prompt_embeds", prompt_embeds)
-                negative_prompt_embeds = callback_outputs.pop(
-                    "negative_prompt_embeds", negative_prompt_embeds
-                )
                 prompt_embeds_2 = callback_outputs.pop(
                     "prompt_embeds_2", prompt_embeds_2
-                )
-                negative_prompt_embeds_2 = callback_outputs.pop(
-                    "negative_prompt_embeds_2", negative_prompt_embeds_2
                 )
 
             if sync_only and is_pipeline_last_stage() and i == len(timesteps) - 1:
@@ -839,14 +833,8 @@ class xFuserHunyuanDiTPipeline(xFuserPipelineBaseWrapper):
 
                 latents = callback_outputs.pop("latents", latents)
                 prompt_embeds = callback_outputs.pop("prompt_embeds", prompt_embeds)
-                negative_prompt_embeds = callback_outputs.pop(
-                    "negative_prompt_embeds", negative_prompt_embeds
-                )
                 prompt_embeds_2 = callback_outputs.pop(
                     "prompt_embeds_2", prompt_embeds_2
-                )
-                negative_prompt_embeds_2 = callback_outputs.pop(
-                    "negative_prompt_embeds_2", negative_prompt_embeds_2
                 )
 
         latents = None

--- a/xfuser/model_executor/pipelines/pipeline_stable_diffusion_3.py
+++ b/xfuser/model_executor/pipelines/pipeline_stable_diffusion_3.py
@@ -509,12 +509,6 @@ class xFuserStableDiffusion3Pipeline(xFuserPipelineBaseWrapper):
 
                     latents = callback_outputs.pop("latents", latents)
                     prompt_embeds = callback_outputs.pop("prompt_embeds", prompt_embeds)
-                    negative_prompt_embeds = callback_outputs.pop(
-                        "negative_prompt_embeds", negative_prompt_embeds
-                    )
-                    negative_pooled_prompt_embeds = callback_outputs.pop(
-                        "negative_pooled_prompt_embeds", negative_pooled_prompt_embeds
-                    )
             if i == len(timesteps) - 1 or (
                 (i + 1) > num_warmup_steps and (i + 1) % self.scheduler.order == 0
             ):
@@ -690,13 +684,6 @@ class xFuserStableDiffusion3Pipeline(xFuserPipelineBaseWrapper):
                         latents = callback_outputs.pop("latents", latents)
                         prompt_embeds = callback_outputs.pop(
                             "prompt_embeds", prompt_embeds
-                        )
-                        negative_prompt_embeds = callback_outputs.pop(
-                            "negative_prompt_embeds", negative_prompt_embeds
-                        )
-                        negative_pooled_prompt_embeds = callback_outputs.pop(
-                            "negative_pooled_prompt_embeds",
-                            negative_pooled_prompt_embeds,
                         )
 
                     if i != len(timesteps) - 1:


### PR DESCRIPTION
## Problem

In `pipeline_stable_diffusion_3.py` and `pipeline_hunyuandit.py`, both `_sync_pipeline` and `_async_pipeline` end their step with:

```python
latents = callback_outputs.pop("latents", latents)
prompt_embeds = callback_outputs.pop("prompt_embeds", prompt_embeds)
negative_prompt_embeds = callback_outputs.pop(
    "negative_prompt_embeds", negative_prompt_embeds        # <-- never bound here
)
...
```

`negative_prompt_embeds` / `negative_pooled_prompt_embeds` (SD3) and `negative_prompt_embeds` / `negative_prompt_embeds_2` (HunyuanDiT) are **not parameters of these methods and are never assigned in them**. `__call__` folds the negative conditioning into the positive tensors *before* the denoising loop:

```python
if self.do_classifier_free_guidance:
    prompt_embeds, pooled_prompt_embeds = self._process_cfg_split_batch(
        negative_prompt_embeds, prompt_embeds,
        negative_pooled_prompt_embeds, pooled_prompt_embeds,
    )
```

and then forwards only the merged tensors. So the name is a *local assigned only by that `pop` line*, and the `pop` default is evaluated **before** the assignment.

Result: **any** user-supplied `callback_on_step_end` raises on the very first step:

```
UnboundLocalError: cannot access local variable 'negative_prompt_embeds'
where it is not associated with a value
```

This is not limited to PipeFusion — for both models `__call__` dispatches to `_sync_pipeline` in the `else` branch, i.e. **the default non-pipeline-parallel path**, so the callback API is broken for every SD3 / HunyuanDiT run that uses it.

## Reference for the fix

`pipeline_flux._sync_pipeline` already gets this right — it pops only the locals that actually exist:

```python
latents = callback_outputs.pop("latents", latents)
prompt_embeds = callback_outputs.pop("prompt_embeds", prompt_embeds)
```

This PR applies that same shape to the four affected methods. It removes 4 dead `pop`s (25 lines, no additions); `prompt_embeds_2` in HunyuanDiT **is** a real parameter and is kept.

Sibling fix for the Flux family: #775.

## Verification

No GPU / distributed runtime needed. The `if callback_on_step_end is not None:` block is extracted **verbatim** from each real source file with `ast.get_source_segment` (no hand-transcription), executed inside a probe function whose local-binding set matches the enclosing method, and driven with an ordinary callback. Before/after, on the four sites:

| file :: method | before | after |
|---|---|---|
| `pipeline_stable_diffusion_3.py::_sync_pipeline` | `UnboundLocalError: negative_prompt_embeds` | ok |
| `pipeline_stable_diffusion_3.py::_async_pipeline` | `UnboundLocalError: negative_prompt_embeds` | ok |
| `pipeline_hunyuandit.py::_sync_pipeline` | `UnboundLocalError: negative_prompt_embeds` | ok |
| `pipeline_hunyuandit.py::_async_pipeline` | `UnboundLocalError: negative_prompt_embeds` | ok |

A round-trip check on the patched SD3 `_sync_pipeline` block confirms the callback still works as documented: it receives `{'latents': ..., 'prompt_embeds': ...}` and a returned `{"latents": ..., "prompt_embeds": ...}` is applied.

`pyflakes` on both patched files reports **no** undefined names (it reported 4 before).

## Note (not changed here)

`callback_kwargs[k] = locals()[k]` still means that requesting `negative_prompt_embeds` in `callback_on_step_end_tensor_inputs` raises `KeyError` — these pipelines genuinely cannot expose the negative tensors inside the loop, since they no longer exist separately at that point. Left alone to keep this change minimal; happy to follow up if you'd like the input list filtered/validated instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
