### PR TITLE
Add determinism check

### DIFF
--- a/tests/core/test_determinism_check.py
+++ b/tests/core/test_determinism_check.py
@@ -1,0 +1,986 @@
+"""Determinism-check: exact comparison, snapshots, thresholds, logging, and CLI."""
+
+import copy
+import logging
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+from xfuser.config.args import FlexibleArgumentParser, xFuserArgs
+from xfuser.core.utils.determinism_check_results import (
+    _count_determinism_failures_in_log,
+    _failed_output_statistics,
+)
+from xfuser.core.utils.outputs_equal import _payloads_equal, outputs_equal
+from xfuser.core.utils.runner_utils import log_error
+from xfuser.model_executor.models.runner_models import base_model
+from xfuser.model_executor.models.runner_models.base_model import (
+    DiffusionOutput,
+    xFuserModel,
+)
+
+
+class _Runner(xFuserModel):
+    def _load_model(self):
+        raise NotImplementedError
+
+    def _run_pipe(self, input_args):
+        raise NotImplementedError
+
+
+class _AudioOutput(DiffusionOutput):
+    def __init__(
+        self,
+        images=None,
+        videos=None,
+        pipe_args=None,
+        audio=None,
+        audio_sample_rate=None,
+    ):
+        super().__init__(images=images, videos=videos, pipe_args=pipe_args or [])
+        self.audio = audio
+        self.audio_sample_rate = audio_sample_rate
+
+
+class _SlotBlob:
+    __slots__ = ()
+
+
+class _CopyableBox:
+    def __init__(self, value):
+        self.value = value
+
+
+class _Uncopyable:
+    def __deepcopy__(self, memo):
+        raise RuntimeError("cannot deepcopy uncopyable field")
+
+
+class _CudaEvent:
+    def __init__(self, enable_timing=True):
+        pass
+
+    def record(self):
+        pass
+
+    def elapsed_time(self, other):
+        return 1000.0
+
+
+def _eq(a, b, path=""):
+    return _payloads_equal(a, b, path)
+
+
+def _rgb(color=(1, 2, 3), size=(2, 2)):
+    return Image.new("RGB", size, color=color)
+
+
+def _paletted(fill, rgb_triple):
+    palette = [0] * 768
+    palette[0:3] = list(rgb_triple)
+    image = Image.new("P", (2, 2), color=fill)
+    image.putpalette(palette)
+    return image
+
+
+def _stub_cuda(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "Event", _CudaEvent)
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda: None)
+
+
+def _make_runner(
+    monkeypatch,
+    *,
+    num_iterations=1,
+    determinism_check=0,
+    warmup_calls=0,
+    batch_size=None,
+    data_parallel_degree=1,
+    rank=0,
+    determinism_check_report_ranks=None,
+    outputs=None,
+    batched_outputs=None,
+    stub_warmup=False,
+):
+    monkeypatch.setenv("RANK", "0")
+    monkeypatch.setenv("WORLD_SIZE", "1")
+    _stub_cuda(monkeypatch)
+    monkeypatch.setattr(
+        base_model,
+        "get_world_group",
+        lambda: SimpleNamespace(rank=rank),
+    )
+
+    model = object.__new__(_Runner)
+    if determinism_check_report_ranks is None:
+        determinism_check_report_ranks = frozenset({rank})
+    model.config = SimpleNamespace(
+        num_iterations=num_iterations,
+        determinism_check=determinism_check,
+        determinism_check_report_ranks=determinism_check_report_ranks,
+        warmup_calls=warmup_calls,
+        batch_size=batch_size,
+        data_parallel_degree=data_parallel_degree,
+    )
+    model.settings = SimpleNamespace(model_output_type="image")
+    model._validate_args = lambda input_args: None
+    model._split_prompts_for_dp = lambda input_args: input_args
+
+    if outputs is not None:
+        timed = iter(outputs)
+
+        def _run_timed_pipe(input_args):
+            return next(timed), 0.1
+
+        model._run_timed_pipe = _run_timed_pipe
+
+    if batched_outputs is not None:
+        batched = iter(batched_outputs)
+
+        def _run_pipe_batched(input_args):
+            return next(batched), [0.1]
+
+        model._run_pipe_batched = _run_pipe_batched
+
+    if stub_warmup:
+        model._run_warmup_calls = lambda input_args: None
+
+    return model
+
+
+def _record_determinism_checks(model):
+    checks = []
+    original_check = model._determinism_check
+
+    def _check(*args):
+        result = original_check(*args)
+        checks.append((args, result))
+        return result
+
+    model._determinism_check = _check
+    return checks
+
+
+# --- NumPy -----------------------------------------------------------------
+
+
+def test_numpy_identical_arrays_match():
+    a = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+    b = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+    assert _eq(a, b)
+
+
+def test_numpy_changed_value_diverges():
+    a = np.array([1.0, 2.0], dtype=np.float32)
+    b = np.array([1.0, 2.5], dtype=np.float32)
+    assert not _eq(a, b)
+
+
+def test_numpy_equal_values_different_dtypes_diverge():
+    a = np.array([1.0, 2.0], dtype=np.float32)
+    b = np.array([1.0, 2.0], dtype=np.float64)
+    assert not _eq(a, b)
+
+
+def test_numpy_reshaped_equal_values_diverge():
+    a = np.array([1.0, 2.0], dtype=np.float32)
+    b = np.array([[1.0, 2.0]], dtype=np.float32)
+    assert not _eq(a, b)
+
+
+def test_numpy_nans_match_including_distinct_payloads():
+    a = np.array([np.float32("nan"), 1.0], dtype=np.float32)
+    b = np.frombuffer(np.array([np.uint32(0x7FC00001)], dtype=np.uint32).tobytes(), dtype=np.float32)
+    b = np.concatenate([b, np.array([1.0], dtype=np.float32)])
+    assert _eq(a, np.array([np.float32("nan"), 1.0], dtype=np.float32))
+    assert _eq(a[:1], b[:1])
+
+
+def test_numpy_positive_and_negative_zero_match():
+    a = np.array([0.0], dtype=np.float64)
+    b = np.array([-0.0], dtype=np.float64)
+    assert _eq(a, b)
+
+
+def test_numpy_noncontiguous_view_matches_logical_values():
+    base = np.arange(6, dtype=np.float32).reshape(2, 3)
+    view = base.T
+    assert not view.flags.c_contiguous
+    assert _eq(view, np.ascontiguousarray(view))
+
+
+def test_numpy_infinities_match_and_finite_mismatch_diverges():
+    assert _eq(np.array([np.inf], dtype=np.float32), np.array([np.inf], dtype=np.float32))
+    assert _eq(np.array([-np.inf], dtype=np.float32), np.array([-np.inf], dtype=np.float32))
+    assert not _eq(np.array([np.inf], dtype=np.float32), np.array([-np.inf], dtype=np.float32))
+    assert not _eq(np.array([1.0], dtype=np.float32), np.array([np.nextafter(1.0, 2.0, dtype=np.float32)]))
+
+
+def test_numpy_object_array_recurses_and_mismatch_diverges():
+    left = np.empty(2, dtype=object)
+    right = np.empty(2, dtype=object)
+    left[0] = torch.tensor([1.0])
+    left[1] = np.array([2.0], dtype=np.float32)
+    right[0] = torch.tensor([1.0])
+    right[1] = np.array([2.0], dtype=np.float32)
+    assert _eq(left, right, "videos")
+
+    right[1] = np.array([3.0], dtype=np.float32)
+    assert not _eq(left, right, "videos")
+
+
+def test_numpy_object_array_unsupported_element_raises_indexed_typeerror():
+    left = np.empty(2, dtype=object)
+    right = np.empty(2, dtype=object)
+    left[0] = 1
+    right[0] = 1
+    left[1] = set()
+    right[1] = set()
+    with pytest.raises(TypeError, match=r"Unsupported payload type set at videos\[1\]"):
+        _eq(left, right, "videos")
+
+
+# --- PyTorch ---------------------------------------------------------------
+
+
+def test_torch_identical_tensors_match():
+    assert _eq(torch.tensor([[1, 2], [3, 4]]), torch.tensor([[1, 2], [3, 4]]))
+
+
+def test_torch_changed_data_shape_or_dtype_diverges():
+    base = torch.tensor([1.0, 2.0], dtype=torch.float32)
+    assert not _eq(base, torch.tensor([1.0, 2.5], dtype=torch.float32))
+    assert not _eq(base, torch.tensor([[1.0, 2.0]], dtype=torch.float32))
+    assert not _eq(base, torch.tensor([1.0, 2.0], dtype=torch.float64))
+
+
+def test_torch_noncontiguous_view_matches_logical_values():
+    base = torch.arange(6).reshape(2, 3)
+    view = base.t()
+    assert not view.is_contiguous()
+    assert _eq(view, view.contiguous())
+
+
+def test_torch_nan_equals_nan_and_signed_zeros_match():
+    assert _eq(torch.tensor([float("nan")]), torch.tensor([float("nan")]))
+    assert _eq(
+        torch.tensor([float("nan")], dtype=torch.float16),
+        torch.tensor([float("nan")], dtype=torch.float16),
+    )
+    assert _eq(
+        torch.tensor([float("nan")], dtype=torch.bfloat16),
+        torch.tensor([float("nan")], dtype=torch.bfloat16),
+    )
+    assert not _eq(torch.tensor([1.0]), torch.tensor([float("nan")]))
+    assert _eq(torch.tensor([0.0]), torch.tensor([-0.0]))
+    assert _eq(torch.tensor([float("inf")]), torch.tensor([float("inf")]))
+    assert _eq(torch.tensor([float("-inf")]), torch.tensor([float("-inf")]))
+
+
+def test_torch_requires_grad_does_not_cause_divergence():
+    a = torch.tensor([1.0, 2.0], requires_grad=True)
+    b = torch.tensor([1.0, 2.0], requires_grad=False)
+    assert _eq(a, b)
+
+
+# --- PIL -------------------------------------------------------------------
+
+
+def test_pil_identical_images_match():
+    assert _eq(_rgb(), _rgb())
+
+
+def test_pil_changed_size_mode_palette_or_pixels_diverge():
+    assert not _eq(_rgb(size=(2, 2)), _rgb(size=(3, 2)))
+    assert not _eq(_rgb(), Image.new("L", (2, 2), color=1))
+    assert not _eq(_rgb(color=(1, 2, 3)), _rgb(color=(9, 2, 3)))
+    assert not _eq(_paletted(0, (255, 0, 0)), _paletted(0, (0, 255, 0)))
+
+
+def test_pil_identical_palette_images_match():
+    assert _eq(_paletted(0, (255, 0, 0)), _paletted(0, (255, 0, 0)))
+
+
+def test_pil_different_concrete_classes_diverge():
+    FakePng = type("FakePng", (Image.Image,), {})
+    a = _rgb()
+    b = _rgb()
+    b.__class__ = FakePng
+    assert type(a) is not type(b)
+    assert a.size == b.size and a.mode == b.mode and a.tobytes() == b.tobytes()
+    assert not _eq(a, b)
+
+
+# --- Structure --------------------------------------------------------------
+
+
+def test_list_versus_tuple_of_same_content_diverges():
+    assert not _eq([1, 2], (1, 2))
+
+
+def test_sequence_length_and_order_matter():
+    assert _eq([1, 2], [1, 2])
+    assert not _eq([1, 2], [1, 2, 3])
+    assert not _eq([1, 2], [2, 1])
+
+
+def test_mapping_key_order_and_values_matter():
+    assert _eq({"a": 1, "b": 2}, {"a": 1, "b": 2})
+    assert not _eq({"a": 1, "b": 2}, {"b": 2, "a": 1})
+    assert not _eq({"a": 1, "b": 2}, {"a": 1, "b": 3})
+
+
+def test_nested_simplenamespace_audiovisual_payload_is_traversed():
+    frames = np.array([1.0, 2.0], dtype=np.float32)
+    audio = torch.tensor([0.5], dtype=torch.float32)
+    left = DiffusionOutput(
+        videos=[SimpleNamespace(frames=frames, audio=audio)],
+        pipe_args={},
+    )
+    right = DiffusionOutput(
+        videos=[
+            SimpleNamespace(
+                frames=np.array([1.0, 2.0], dtype=np.float32),
+                audio=torch.tensor([0.5], dtype=torch.float32),
+            )
+        ],
+        pipe_args={},
+    )
+    assert outputs_equal(left, right)
+
+    mismatched = DiffusionOutput(
+        videos=[
+            SimpleNamespace(
+                frames=np.array([1.0, 9.0], dtype=np.float32),
+                audio=torch.tensor([0.5], dtype=torch.float32),
+            )
+        ]
+    )
+    assert not outputs_equal(left, mismatched)
+
+
+# --- Scalars ----------------------------------------------------------------
+
+
+def test_scalar_nan_zero_inf_and_exact_ints_bools():
+    assert _eq(float("nan"), float("nan"))
+    assert not _eq(1.0, float("nan"))
+    assert _eq(0.0, -0.0)
+    assert _eq(float("inf"), float("inf"))
+    assert _eq(float("-inf"), float("-inf"))
+    assert not _eq(1.0, np.nextafter(1.0, 2.0))
+    assert _eq(3, 3)
+    assert not _eq(3, 4)
+    assert _eq(True, True)
+    assert not _eq(True, False)
+    assert not _eq(True, 1)
+
+
+def test_numpy_float64_scalar_diverges_from_python_float():
+    assert not _eq(np.float64(1.0), 1.0)
+
+
+# --- Output fields -----------------------------------------------------------
+
+
+def test_pipe_args_differences_are_ignored():
+    img = _rgb()
+    left = DiffusionOutput(images=[img], pipe_args={"prompt": "a"})
+    right = DiffusionOutput(images=[_rgb()], pipe_args={"prompt": "b", "seed": 7})
+    assert outputs_equal(left, right)
+
+
+def test_subclass_extra_audio_fields_are_compared():
+    tensor = torch.tensor([1.0, 2.0])
+    left = _AudioOutput(images=[_rgb()], audio=tensor, audio_sample_rate=16000)
+    right = _AudioOutput(
+        images=[_rgb()],
+        audio=torch.tensor([1.0, 2.0]),
+        audio_sample_rate=16000,
+        pipe_args={"ignored": True},
+    )
+    assert outputs_equal(left, right)
+
+    assert not outputs_equal(
+        left,
+        _AudioOutput(images=[_rgb()], audio=torch.tensor([1.0, 9.0]), audio_sample_rate=16000),
+    )
+    assert not outputs_equal(
+        left,
+        _AudioOutput(images=[_rgb()], audio=tensor, audio_sample_rate=8000),
+    )
+
+
+def test_different_concrete_output_types_diverge():
+    assert not outputs_equal(
+        DiffusionOutput(images=[_rgb()]),
+        _AudioOutput(images=[_rgb()], audio=None, audio_sample_rate=None),
+    )
+
+
+def test_extra_missing_or_reordered_instance_fields_diverge():
+    base = DiffusionOutput(images=[_rgb()])
+    extra = DiffusionOutput(images=[_rgb()])
+    extra.audio = torch.tensor([1.0])
+    assert not outputs_equal(base, extra)
+
+    ordered = DiffusionOutput(images=[_rgb()])
+    ordered.audio = 1
+    ordered.rate = 2
+    reordered = DiffusionOutput(images=[_rgb()])
+    reordered.rate = 2
+    reordered.audio = 1
+    assert not outputs_equal(ordered, reordered)
+
+
+# --- Unsupported values ------------------------------------------------------
+
+
+def test_unsupported_custom_class_in_images_raises_path_typeerror():
+    with pytest.raises(TypeError, match=r"Unsupported payload type _SlotBlob at images\[0\]"):
+        outputs_equal(
+            DiffusionOutput(images=[_SlotBlob()]),
+            DiffusionOutput(images=[_SlotBlob()]),
+        )
+
+
+def test_unsupported_set_raises_and_does_not_use_equality():
+    with pytest.raises(TypeError, match=r"Unsupported payload type set at <root>"):
+        _eq(set(), set(), "")
+
+
+def test_memoryview_is_unsupported_not_bytes():
+    with pytest.raises(TypeError, match=r"Unsupported payload type memoryview at images"):
+        _eq(memoryview(b"ab"), memoryview(b"ab"), "images")
+    assert _eq(b"ab", b"ab", "images")
+    assert not _eq(b"ab", bytearray(b"ab"), "images")
+
+
+def test_unsupported_nested_paths_include_index_attr_and_mapping_key():
+    with pytest.raises(TypeError, match=r"Unsupported payload type set at videos\[0\]\.audio"):
+        _eq([SimpleNamespace(audio=set())], [SimpleNamespace(audio=set())], "videos")
+    with pytest.raises(TypeError, match=r"Unsupported payload type set at audio\['key'\]"):
+        _eq({"key": set()}, {"key": set()}, "audio")
+
+
+# --- Snapshot / deepcopy -----------------------------------------------------
+
+
+def test_deepcopy_snapshot_is_independent_for_supported_payloads():
+    image = _rgb()
+    frames = np.array([1.0, 2.0], dtype=np.float32)
+    tensor = torch.tensor([3.0, 4.0])
+    nested = SimpleNamespace(frames=frames, audio=tensor)
+    original = _AudioOutput(
+        images=[image],
+        videos=[nested],
+        pipe_args={"prompt": "keep"},
+        audio=torch.tensor([5.0]),
+        audio_sample_rate=16000,
+    )
+    snapshot = copy.deepcopy(original)
+
+    image.putpixel((0, 0), (9, 9, 9))
+    frames[0] = 99.0
+    tensor.add_(1.0)
+    original.audio.add_(1.0)
+    original.audio_sample_rate = 8
+    original.pipe_args[0]["prompt"] = "mutated"
+
+    assert snapshot.images[0].tobytes() == _rgb().tobytes()
+    assert np.array_equal(snapshot.videos[0].frames, np.array([1.0, 2.0], dtype=np.float32))
+    assert torch.equal(snapshot.videos[0].audio, torch.tensor([3.0, 4.0]))
+    assert torch.equal(snapshot.audio, torch.tensor([5.0]))
+    assert snapshot.audio_sample_rate == 16000
+    assert snapshot.pipe_args == [{"prompt": "keep"}]
+
+
+def test_deepcopy_copies_custom_extra_field_independently():
+    original = DiffusionOutput(images=[_rgb()])
+    original.box = _CopyableBox(1)
+    snapshot = copy.deepcopy(original)
+    original.box.value = 99
+    assert snapshot.box is not original.box
+    assert snapshot.box.value == 1
+
+
+def test_deepcopy_surfaces_error_from_uncopyable_field():
+    original = DiffusionOutput(images=[_rgb()])
+    original.bad = _Uncopyable()
+    with pytest.raises(RuntimeError, match="cannot deepcopy uncopyable field"):
+        copy.deepcopy(original)
+
+
+# --- Run loop ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize("threshold", [0, -1])
+def test_nonpositive_threshold_skips_copy_error_and_determinism_check(monkeypatch, threshold):
+    first = DiffusionOutput(images=[_rgb((1, 0, 0))])
+    last = DiffusionOutput(images=[_rgb((9, 0, 0))])
+    model = _make_runner(
+        monkeypatch,
+        num_iterations=2,
+        determinism_check=threshold,
+        warmup_calls=0,
+        outputs=[first, last],
+    )
+    checks = _record_determinism_checks(model)
+    logged = []
+    monkeypatch.setattr(base_model, "log_error", lambda *args, **kwargs: logged.append((args, kwargs)))
+    deepcopy_calls = []
+    real_deepcopy = copy.deepcopy
+
+    def _spy(obj):
+        deepcopy_calls.append(obj)
+        return real_deepcopy(obj)
+
+    monkeypatch.setattr(base_model.copy, "deepcopy", _spy)
+
+    output, _timings = model.run({"prompt": "x"})
+
+    assert output is last
+    assert checks == []
+    assert logged == []
+    assert deepcopy_calls == []
+
+
+def test_one_enabled_iteration_establishes_baseline_without_failure(monkeypatch):
+    only = DiffusionOutput(images=[_rgb()])
+    model = _make_runner(
+        monkeypatch,
+        num_iterations=1,
+        determinism_check=1,
+        outputs=[only],
+    )
+    checks = _record_determinism_checks(model)
+    logged = []
+    monkeypatch.setattr(base_model, "log_error", lambda *args, **kwargs: logged.append((args, kwargs)))
+
+    output, _timings = model.run({"prompt": "x"})
+
+    assert output is only
+    assert len(checks) == 1
+    assert checks[0][0] == (0, None, only, 0)
+    failure_count, baseline = checks[0][1]
+    assert failure_count == 0
+    assert baseline is not only
+    assert outputs_equal(baseline, only)
+    assert logged == []
+
+
+def test_sequence_a_b_c_a_reports_iterations_against_first_snapshot(monkeypatch):
+    a1 = DiffusionOutput(videos=[np.array([1.0], dtype=np.float32)])
+    b = DiffusionOutput(videos=[np.array([2.0], dtype=np.float32)])
+    c = DiffusionOutput(videos=[np.array([3.0], dtype=np.float32)])
+    a2 = DiffusionOutput(videos=[np.array([1.0], dtype=np.float32)])
+    model = _make_runner(
+        monkeypatch,
+        num_iterations=4,
+        determinism_check=1,
+        rank=3,
+        outputs=[a1, b, c, a2],
+    )
+    checks = _record_determinism_checks(model)
+    model._save_determinism_check_failed_outputs = lambda *args: None
+    logged = []
+    monkeypatch.setattr(base_model, "log_error", lambda *a, **kw: logged.append((a, kw)))
+    gathers = []
+    original_gather = model._gather_dp_outputs
+
+    def _gather(output):
+        gathers.append(output)
+        return original_gather(output)
+
+    model._gather_dp_outputs = _gather
+
+    output, _timings = model.run({"prompt": "x"})
+
+    assert output is a2
+    assert gathers == [a2]
+    assert [call[0][0] for call in logged] == [
+        "determinism_check[rank 3]: iteration 2 diverged!",
+        "determinism_check[rank 3]: iteration 3 diverged!",
+    ]
+    assert all(call[1]["log_from_all_processes"] is True for call in logged)
+
+    assert [args[0] for args, _result in checks] == [0, 1, 2, 3]
+    assert [result[0] for _args, result in checks] == [0, 1, 2, 2]
+    baseline = checks[0][1][1]
+    assert baseline is not a1
+    assert [args[2] for args, _result in checks] == [a1, b, c, a2]
+    assert all(args[1] is baseline for args, _result in checks[1:])
+    a1.videos[0][0] = 99.0
+    assert np.array_equal(baseline.videos[0], np.array([1.0], dtype=np.float32))
+
+
+def test_determinism_check_counts_every_failure(monkeypatch):
+    outputs = [
+        DiffusionOutput(videos=[np.array([value], dtype=np.float32)])
+        for value in (1.0, 2.0, 3.0, 4.0)
+    ]
+    model = _make_runner(
+        monkeypatch,
+        num_iterations=4,
+        determinism_check=2,
+        rank=7,
+        outputs=outputs,
+    )
+    checks = _record_determinism_checks(model)
+    model._save_determinism_check_failed_outputs = lambda *args: None
+    logged = []
+    monkeypatch.setattr(base_model, "log_error", lambda *args, **kwargs: logged.append(args))
+
+    model.run({"prompt": "x"})
+
+    assert len(logged) == 3
+    assert [args[3] for args, _result in checks] == [0, 0, 1, 2]
+    assert [result[0] for _args, result in checks] == [0, 1, 2, 3]
+    assert [args[0] for args in logged] == [
+        "determinism_check[rank 7]: iteration 2 diverged!",
+        "determinism_check[rank 7]: iteration 3 diverged!",
+        "determinism_check[rank 7]: iteration 4 diverged!",
+    ]
+
+
+def test_default_determinism_check_serializes_selected_rank_and_run_returns(monkeypatch):
+    first = DiffusionOutput(images=[_rgb((1, 0, 0))])
+    last = DiffusionOutput(images=[_rgb((9, 0, 0))])
+    model = _make_runner(
+        monkeypatch,
+        num_iterations=2,
+        determinism_check=1,
+        rank=1,
+        outputs=[first, last],
+    )
+    saved = []
+    model._save_determinism_check_failed_outputs = lambda *args: saved.append(args)
+    monkeypatch.setattr(base_model, "log_error", lambda *args, **kwargs: None)
+
+    failure_count, baseline = model._determinism_check(1, first, last, 0)
+
+    assert failure_count == 1
+    assert baseline is first
+    assert saved == [(first, 0, 1), (last, 1, 1)]
+
+    saved.clear()
+
+    output, _timings = model.run({"prompt": "x"})
+    assert output is last
+    assert len(saved) == 2
+    assert saved[0][0] is not first
+    assert outputs_equal(saved[0][0], first)
+    assert saved[0][1:] == (0, 1)
+    assert saved[1] == (last, 1, 1)
+
+
+def test_result_parsers_match_determinism_failure_artifacts(monkeypatch, tmp_path):
+    pipe_args = {"height": 2, "width": 2}
+    first = DiffusionOutput(
+        images=[_rgb((1, 0, 0))],
+        pipe_args=[pipe_args],
+    )
+    last = DiffusionOutput(
+        images=[_rgb((9, 0, 0))],
+        pipe_args=[pipe_args],
+    )
+    model = _make_runner(
+        monkeypatch,
+        num_iterations=2,
+        determinism_check=1,
+        rank=7,
+        outputs=[first, last],
+    )
+    model.config.output_directory = str(tmp_path)
+    model.config.use_torch_compile = False
+    model.config.ulysses_degree = 1
+    model.config.ring_degree = 1
+    model.config.task = None
+    model.settings.output_name = "coupling"
+
+    log_file = tmp_path / "stdout.txt"
+    logger = logging.getLogger("xfuser.core.utils.runner_utils")
+    handler = logging.FileHandler(log_file, encoding="utf-8")
+    old_level = logger.level
+    logger.setLevel(logging.ERROR)
+    logger.addHandler(handler)
+    try:
+        model.run({"prompt": "x"})
+    finally:
+        logger.removeHandler(handler)
+        handler.close()
+        logger.setLevel(old_level)
+
+    assert _count_determinism_failures_in_log(log_file) == 1
+
+    files = [path for path in tmp_path.iterdir() if path != log_file]
+    assert len(files) == 2
+    size = sum(path.stat().st_size for path in files)
+    assert _failed_output_statistics(tmp_path) == (1, size)
+
+
+def test_default_determinism_check_skips_unselected_rank(monkeypatch):
+    first = DiffusionOutput(images=[_rgb((1, 0, 0))])
+    last = DiffusionOutput(images=[_rgb((9, 0, 0))])
+    model = _make_runner(
+        monkeypatch,
+        determinism_check=1,
+        rank=2,
+        determinism_check_report_ranks=frozenset({0, 1}),
+    )
+    saved = []
+    model._save_determinism_check_failed_outputs = lambda *args: saved.append(args)
+    monkeypatch.setattr(base_model, "log_error", lambda *args, **kwargs: None)
+
+    failure_count, baseline = model._determinism_check(1, first, last, 0)
+
+    assert failure_count == 1
+    assert baseline is first
+    assert saved == []
+
+
+def test_batched_and_unbatched_both_report_divergence(monkeypatch):
+    unbatched = _make_runner(
+        monkeypatch,
+        num_iterations=2,
+        determinism_check=1,
+        batch_size=None,
+        rank=3,
+        outputs=[
+            DiffusionOutput(images=[_rgb((1, 0, 0))]),
+            DiffusionOutput(images=[_rgb((2, 0, 0))]),
+        ],
+    )
+    batched = _make_runner(
+        monkeypatch,
+        num_iterations=2,
+        determinism_check=1,
+        batch_size=2,
+        rank=3,
+        batched_outputs=[
+            DiffusionOutput(images=[_rgb((1, 0, 0))]),
+            DiffusionOutput(images=[_rgb((2, 0, 0))]),
+        ],
+    )
+    for model in (unbatched, batched):
+        checks = _record_determinism_checks(model)
+        model._save_determinism_check_failed_outputs = lambda *args: None
+        monkeypatch.setattr(base_model, "log_error", lambda *args, **kwargs: None)
+        output, _timings = model.run({"prompt": ["a", "b"]})
+        assert len(checks) == 2
+        args, result = checks[1]
+        assert args[0] == 1
+        assert not outputs_equal(args[1], args[2])
+        assert result[0] == 1
+        assert output.images[0].tobytes() == _rgb((2, 0, 0)).tobytes()
+
+
+def test_warmup_output_is_not_the_baseline(monkeypatch):
+    warmup_seen = []
+    first_timed = DiffusionOutput(images=[_rgb((1, 0, 0))])
+    later = DiffusionOutput(images=[_rgb((2, 0, 0))])
+    model = _make_runner(
+        monkeypatch,
+        num_iterations=2,
+        determinism_check=1,
+        warmup_calls=2,
+        rank=3,
+        outputs=[first_timed, later],
+        stub_warmup=True,
+    )
+    model._run_warmup_calls = lambda input_args: warmup_seen.append(input_args)
+    checks = _record_determinism_checks(model)
+    model._save_determinism_check_failed_outputs = lambda *args: None
+    monkeypatch.setattr(base_model, "log_error", lambda *args, **kwargs: None)
+
+    output, _timings = model.run({"prompt": "x"})
+
+    assert warmup_seen
+    assert len(checks) == 2
+    args, result = checks[1]
+    assert args[2] is later
+    assert args[1].images[0].tobytes() == first_timed.images[0].tobytes()
+    assert result[0] == 1
+    assert output is later
+
+
+# --- Logging ---------------------------------------------------------------
+
+
+def _attach_stderr_handler():
+    logger = logging.getLogger("xfuser.core.utils.runner_utils")
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setLevel(logging.ERROR)
+    records = []
+
+    class _Recording(logging.Handler):
+        def emit(self, record):
+            records.append(record)
+
+    recorder = _Recording()
+    recorder.setLevel(logging.ERROR)
+    previous_level = logger.level
+    logger.setLevel(logging.ERROR)
+    logger.addHandler(handler)
+    logger.addHandler(recorder)
+    return logger, handler, recorder, records, previous_level
+
+
+def test_log_error_emits_error_level_message_on_stderr(monkeypatch, capsys):
+    monkeypatch.setenv("RANK", "0")
+    monkeypatch.setenv("WORLD_SIZE", "1")
+    logger, handler, recorder, records, previous_level = _attach_stderr_handler()
+    try:
+        log_error("determinism boom")
+        captured = capsys.readouterr()
+        assert "determinism boom" in captured.err
+        assert records
+        assert records[0].levelno == logging.ERROR
+        assert records[0].getMessage() == "determinism boom"
+    finally:
+        logger.removeHandler(handler)
+        logger.removeHandler(recorder)
+        logger.setLevel(previous_level)
+
+
+def test_log_from_all_processes_bypasses_final_rank_filter(monkeypatch, capsys):
+    monkeypatch.setenv("RANK", "0")
+    monkeypatch.setenv("WORLD_SIZE", "2")
+    logger, handler, recorder, records, previous_level = _attach_stderr_handler()
+    try:
+        log_error("hidden unless last", log_from_all_processes=False)
+        hidden = capsys.readouterr()
+        assert "hidden unless last" not in hidden.err
+        assert records == []
+
+        log_error("visible on every rank", log_from_all_processes=True)
+        shown = capsys.readouterr()
+        assert "visible on every rank" in shown.err
+        assert records[-1].levelno == logging.ERROR
+    finally:
+        logger.removeHandler(handler)
+        logger.removeHandler(recorder)
+        logger.setLevel(previous_level)
+
+
+# --- Configuration ----------------------------------------------------------
+
+
+@pytest.mark.parametrize("add_args", [xFuserArgs.add_runner_args, xFuserArgs.add_cli_args])
+def test_absent_options_use_determinism_defaults(add_args, monkeypatch):
+    monkeypatch.setenv("WORLD_SIZE", "4")
+    parser = add_args(FlexibleArgumentParser(description="xDiT"))
+    parsed = parser.parse_args(["--model", "test-model"])
+    config = xFuserArgs.from_cli_args(parsed)
+    assert config.determinism_check == 0
+    assert config.determinism_check_report_ranks == frozenset({3})
+
+
+@pytest.mark.parametrize("add_args", [xFuserArgs.add_runner_args, xFuserArgs.add_cli_args])
+@pytest.mark.parametrize("flag", ["--determinism-check", "--determinism_check"])
+def test_determinism_check_options_accept_integer_threshold(add_args, flag, monkeypatch):
+    monkeypatch.setenv("WORLD_SIZE", "1")
+    parser = add_args(FlexibleArgumentParser(description="xDiT"))
+    parsed = parser.parse_args(["--model", "test-model", flag, "3"])
+    assert xFuserArgs.from_cli_args(parsed).determinism_check == 3
+
+
+@pytest.mark.parametrize("add_args", [xFuserArgs.add_runner_args, xFuserArgs.add_cli_args])
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("all", frozenset({0, 1, 2, 3})),
+        ("first", frozenset({0})),
+        ("last", frozenset({3})),
+        ("none", frozenset()),
+        ("", frozenset()),
+        ("3, 1,3", frozenset({1, 3})),
+    ],
+)
+def test_report_ranks_option_normalizes_to_frozenset(
+    add_args, value, expected, monkeypatch
+):
+    monkeypatch.setenv("WORLD_SIZE", "4")
+    parser = add_args(FlexibleArgumentParser(description="xDiT"))
+    parsed = parser.parse_args(
+        [
+            "--model",
+            "test-model",
+            "--determinism-check-report-ranks",
+            value,
+        ]
+    )
+
+    config = xFuserArgs.from_cli_args(parsed)
+
+    assert config.determinism_check_report_ranks == expected
+    assert isinstance(config.determinism_check_report_ranks, frozenset)
+
+
+def test_report_ranks_underscore_option_is_accepted(monkeypatch):
+    monkeypatch.setenv("WORLD_SIZE", "3")
+    parser = xFuserArgs.add_runner_args(FlexibleArgumentParser(description="xDiT"))
+    parsed = parser.parse_args(
+        [
+            "--model",
+            "test-model",
+            "--determinism_check_report_ranks",
+            "0,2",
+        ]
+    )
+    assert xFuserArgs.from_cli_args(
+        parsed
+    ).determinism_check_report_ranks == frozenset({0, 2})
+
+
+@pytest.mark.parametrize("value", ["4", "-1", "0,,1", "middle"])
+def test_report_ranks_rejects_invalid_values(value, monkeypatch):
+    monkeypatch.setenv("WORLD_SIZE", "4")
+    with pytest.raises(ValueError, match="determinism_check_report_ranks"):
+        xFuserArgs(determinism_check_report_ranks=value)
+
+
+def test_report_ranks_assumes_single_rank_when_world_size_is_absent(monkeypatch):
+    monkeypatch.delenv("WORLD_SIZE", raising=False)
+    assert xFuserArgs().determinism_check_report_ranks == frozenset({0})
+
+
+def test_report_ranks_rejects_non_string_input(monkeypatch):
+    monkeypatch.setenv("WORLD_SIZE", "4")
+    with pytest.raises(TypeError, match="must be a string"):
+        xFuserArgs(determinism_check_report_ranks=[0, 1])
+
+
+def test_report_ranks_help_warns_about_large_output_files():
+    parser = xFuserArgs.add_runner_args(FlexibleArgumentParser(description="xDiT"))
+    action = next(
+        action
+        for action in parser._actions
+        if action.dest == "determinism_check_report_ranks"
+    )
+    assert "Many failures may produce many large output files" in action.help
+    assert "none value is useful with a positive --determinism_check" in action.help
+    assert "only log messages, but no files" in action.help
+
+
+def test_xfuserargs_default_and_runner_dict_propagation(monkeypatch):
+    monkeypatch.setenv("WORLD_SIZE", "4")
+    assert xFuserArgs().determinism_check == 0
+    config = xFuserArgs.from_runner_args(
+        {
+            "determinism_check": 4,
+            "determinism_check_report_ranks": "last",
+        }
+    )
+    assert config.determinism_check == 4
+    assert config.determinism_check_report_ranks == frozenset({3})
+
+if __name__ == "__main__":
+    import sys
+    import pytest
+
+    sys.exit(pytest.main(sys.argv))

--- a/xfuser/config/args.py
+++ b/xfuser/config/args.py
@@ -1,6 +1,7 @@
-import sys
 import argparse
 import dataclasses
+import os
+import sys
 import warnings
 from dataclasses import dataclass
 from typing import Optional, List, Tuple, Union
@@ -67,6 +68,72 @@ def nullable_str(val: str):
     if not val or val == "None":
         return None
     return val
+
+
+_DETERMINISM_CHECK_HELP = (
+    "Set to a positive failure threshold to compare every timed iteration with "
+    "the first using exact equality, not a tolerance. The failure handler is "
+    "called for each rank enabled by --determinism_check_report_ranks on each "
+    "divergence until the threshold is reached. "
+    "Disabled at 0 or below. Enabling retains and compares full output payloads, "
+    "which adds memory, synchronization, and transfer overhead."
+)
+
+_DETERMINISM_CHECK_REPORT_RANKS_DEFAULT = "last"
+
+_DETERMINISM_CHECK_REPORT_RANKS_HELP = (
+    "Ranks on which determinism failures save serialized outputs. Accepts a "
+    "comma-separated list of integers, an empty value, or one of: all, first, "
+    "last, none. Empty and none select no ranks. "
+    f"Defaults to {_DETERMINISM_CHECK_REPORT_RANKS_DEFAULT}. Many failures "
+    "may produce many large output files; restrict output to selected ranks "
+    "based on model specifics. The none value is useful with a positive "
+    "--determinism_check when only log messages, but no files, are needed."
+)
+
+
+def _normalize_determinism_check_report_ranks(value: str) -> frozenset[int]:
+    """Resolve a rank string; ``none`` and empty values select no ranks."""
+    try:
+        world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    except ValueError as exc:
+        raise ValueError("WORLD_SIZE must be a positive integer") from exc
+    if world_size <= 0:
+        raise ValueError("WORLD_SIZE must be a positive integer")
+    if not isinstance(value, str):
+        raise TypeError("determinism_check_report_ranks must be a string")
+
+    value = value.strip()
+    if value == "all":
+        ranks = frozenset(range(world_size))
+    elif value == "first":
+        ranks = frozenset({0})
+    elif value == "last":
+        ranks = frozenset({world_size - 1})
+    elif value in ("none", ""):
+        ranks = frozenset()
+    else:
+        parts = [p.strip() for p in value.split(",")]
+        if any(not part for part in parts):
+            raise ValueError(
+                "determinism_check_report_ranks must be a comma-separated list "
+                "of integers, empty, or one of: all, first, last, none"
+            )
+        try:
+            ranks = frozenset(int(part) for part in parts)
+        except ValueError as exc:
+            raise ValueError(
+                "determinism_check_report_ranks must be a comma-separated list "
+                "of integers, empty, or one of: all, first, last, none"
+            ) from exc
+
+    invalid_ranks = sorted(rank for rank in ranks if rank < 0 or rank >= world_size)
+    if invalid_ranks:
+        raise ValueError(
+            "determinism_check_report_ranks contains ranks outside "
+            f"0..{world_size - 1}: {invalid_ranks}"
+        )
+    return ranks
 
 
 @dataclass
@@ -154,6 +221,8 @@ class xFuserArgs:
     fp8_precision_override_suffix_patterns: Optional[str] = None
     # Model runner specific
     num_iterations: int = 1
+    determinism_check: int = 0
+    determinism_check_report_ranks: str | frozenset[int] = "all"
     profile: bool = False
     profile_capture_phase: bool = False
     profile_with_stack: bool = False
@@ -205,6 +274,11 @@ class xFuserArgs:
     distilled_transformer_2_path: Optional[str] = None
 
     def __post_init__(self):
+        self.determinism_check_report_ranks = (
+            _normalize_determinism_check_report_ranks(
+                self.determinism_check_report_ranks
+            )
+        )
         if self.profile_with_stack and not self.profile:
             logger.warning(
                 "--profile_with_stack has no effect without --profile; "
@@ -554,6 +628,18 @@ class xFuserArgs:
             action="store_true",
             help="Use cache config for attention compression.",
         )
+        runtime_group.add_argument(
+            "--determinism_check",
+            type=int,
+            default=0,
+            help=_DETERMINISM_CHECK_HELP,
+        )
+        runtime_group.add_argument(
+            "--determinism_check_report_ranks",
+            type=str,
+            default=_DETERMINISM_CHECK_REPORT_RANKS_DEFAULT,
+            help=_DETERMINISM_CHECK_REPORT_RANKS_HELP,
+        )
 
         return parser
 
@@ -820,6 +906,18 @@ class xFuserArgs:
             type=int,
             default=1,
             help="Number of iterations to run the model."
+        )
+        parser.add_argument(
+            "--determinism_check",
+            type=int,
+            default=0,
+            help=_DETERMINISM_CHECK_HELP,
+        )
+        parser.add_argument(
+            "--determinism_check_report_ranks",
+            type=str,
+            default=_DETERMINISM_CHECK_REPORT_RANKS_DEFAULT,
+            help=_DETERMINISM_CHECK_REPORT_RANKS_HELP,
         )
         parser.add_argument(
             "--profile",

--- a/xfuser/core/utils/determinism_check_results.py
+++ b/xfuser/core/utils/determinism_check_results.py
@@ -1,0 +1,212 @@
+'''This module is meant to be an independent from the rest of xFuser self-contained collection
+of utilities for handling determinism check results, primarily for use by external
+higher-level runners. It's meant to couple with the xFuser only by externally visible
+artifacts it produces, such as logs or files. However, due to this coupling it has to be
+a part of the xFuser, so it's maintained and doesn't go obsolete.
+
+Due to the module being deep inside xFuser internal packages, importing it directly the
+standard way like
+import xfuser.core.utils.determinism_check_results
+would trigger importing of all parent modules of xFuser, that typically import pytorch and
+possibly other heavy dependencies. This could take a long time and produce lot's of spam to
+the console. To avoid this, you could import the module manually like this:
+
+```
+def import_xfuser_determinism_check_results():
+    """Imports the determinism check results functions from xfuser.
+    That roundtrip is necessary instead of a simple
+
+    ```
+    from xfuser.core.utils.determinism_check_results import (
+        determinism_check_results,
+        readable_bytes,
+    )
+    ```
+
+    to avoid importing all parent modules of xfuser, that typically import pytorch,
+    which takes a long time and could produce lot's of spam to the console.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    package = importlib.util.find_spec("xfuser")
+    assert package is not None, "xfuser package not found"
+    package_dir = Path(next(iter(package.submodule_search_locations)))
+    path = package_dir / "core/utils/determinism_check_results.py"
+
+    spec = importlib.util.spec_from_file_location(
+        "_xfuser_core_utils_determinism_check_results", path
+    )
+    assert spec is not None, "xfuser.core.utils.determinism_check_results module spec not found"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.determinism_check_results, module.readable_bytes
+
+determinism_check_results, readable_bytes = import_xfuser_determinism_check_results()
+```
+'''
+
+import os
+import re
+import stat
+from collections.abc import Iterable
+from pathlib import Path
+
+_FAILED_LOG_PATTERN = re.compile(
+    r"determinism_check\[rank [0-9]+\]: iteration [0-9]+ diverged"
+)
+_FAILED_OUTPUT_PATTERN = re.compile(r"_rank_([0-9]+)_iteration_([0-9]+)")
+
+
+def _count_determinism_failures_in_log(log_file: str | Path) -> int:
+    failure_count = 0
+    with open(log_file, encoding="utf-8") as stream:
+        for line in stream:
+            failure_count += len(_FAILED_LOG_PATTERN.findall(line))
+    return failure_count
+
+
+def _failed_output_statistics(directory: str | Path) -> tuple[int, int] | None:
+    failed_output_events: set[tuple[int, int]] = set()
+    failed_output_size = 0
+    found_failed_output = False
+
+    with os.scandir(directory) as scanner:
+        for entry in scanner:
+            if not entry.is_file(follow_symlinks=False):
+                continue
+
+            output_match = _FAILED_OUTPUT_PATTERN.search(entry.name)
+            if output_match is None:
+                continue
+
+            found_failed_output = True
+            failed_output_size += entry.stat(follow_symlinks=False).st_size
+            rank = int(output_match.group(1))
+            iteration = int(output_match.group(2))
+            if iteration != 0:
+                failed_output_events.add((rank, iteration))
+
+    if not found_failed_output:
+        return None
+    return len(failed_output_events), failed_output_size
+
+
+def determinism_check_results(
+    dir_tree: str | Path,
+    expected_log_files: str | Iterable[str] | None = None,
+) -> dict[str, tuple[int, int]]:
+    """For a given directory tree containing output directories as leaves, return a collection
+    of output directories (as keys of the returned dictionary having paths relative to the tree
+    root) that have determinism check failed, along with the number of failed checks and the total
+    size in bytes of dumped files related to the failed checks (as the dictionary's value, a tuple
+    of two integers in that order).
+
+    Args:
+        dir_tree: The root directory of the directory tree to check.
+        expected_log_files: name of log files to expect in the output directories. Empty string or
+            iterable disables checking in log files, None defaults to ["stdout.txt", "stderr.txt"].
+
+    Algorithm:
+    - Traverse the directory tree recursively, following symlinks (preventing infinite loops), and
+    assume each internal directory that doesn't have subdirectories to be a model config's output
+    directory.
+    - For each such output directory found perform two actions:
+        1. If it contains any of the `expected_log_files`, scan each of them to count occurrences of
+            a pattern corresponding to a failed determinism check error message:
+                `determinism_check[rank {rank}]: iteration {iteration + 1} diverged`
+            and then sum them up across all log files (otherwise assume 0).
+        2. Scan the directory for presence of files the pattern of names generated by
+            `xFuserModel._save_determinism_check_failed_outputs()`:
+                `_rank_{rank:d}_iteration_{iteration:d}`
+            and sum up their total size in bytes, and count the unique `(rank, iteration)` pairs
+            among such files, excluding pairs corresponding to the 0-th iteration. Otherwise
+            assume 0 and 0.
+        Whenever any of the above actions finds at least one failure, add relative to the root path
+        to the directory to the result dictionary as a key, and the tuple of
+        `(max(number_of_failed_checks_from_logs, number_of_failed_checks_from_files),
+        total_size_of_failed_output_files_in_bytes)` as the value.
+    """
+    if not isinstance(dir_tree, Path):
+        dir_tree = Path(dir_tree)
+    if expected_log_files is None:
+        expected_log_files = ["stdout.txt", "stderr.txt"]
+    if isinstance(expected_log_files, str):
+        if expected_log_files:
+            expected_log_files = frozenset((expected_log_files,))
+        else:
+            expected_log_files = frozenset()
+    else:
+        expected_log_files = frozenset(expected_log_files)
+
+    for log_file_name in expected_log_files:
+        if not isinstance(log_file_name, str):
+            raise TypeError("expected_log_files entries must be strings")
+        log_file_path = Path(log_file_name)
+        if (
+            not log_file_name
+            or log_file_path.is_absolute()
+            or len(log_file_path.parts) != 1
+            or log_file_path.name != log_file_name
+            or log_file_name in (".", "..")
+        ):
+            raise ValueError(
+                "expected_log_files entries must be direct-child filenames"
+            )
+
+    root_stat = dir_tree.stat()
+    if not stat.S_ISDIR(root_stat.st_mode):
+        raise NotADirectoryError(f"Not a directory: {dir_tree}")
+
+    results: dict[str, tuple[int, int]] = {}
+    stack: list[tuple[Path, frozenset[tuple[int, int]]]] = [(dir_tree, frozenset())]
+
+    while stack:
+        directory, ancestors = stack.pop()
+        directory_stat = directory.stat()
+        directory_identity = (directory_stat.st_dev, directory_stat.st_ino)
+        if directory_identity in ancestors:
+            continue
+
+        with os.scandir(directory) as scanner:
+            entries = list(scanner)
+        subdirectories = [
+            entry for entry in entries if entry.is_dir(follow_symlinks=True)
+        ]
+
+        if subdirectories:
+            child_ancestors = ancestors | {directory_identity}
+            stack.extend(
+                (directory / entry.name, child_ancestors)
+                for entry in reversed(subdirectories)
+            )
+            continue
+
+        failed_logs = 0
+
+        for entry in entries:
+            if not entry.is_file(follow_symlinks=False):
+                continue
+
+            if entry.name in expected_log_files:
+                failed_logs += _count_determinism_failures_in_log(entry.path)
+
+        failed_stats = _failed_output_statistics(directory)
+        if failed_logs or failed_stats is not None:
+            failed_events, failed_size = failed_stats or (0, 0)
+            rel_dir = directory.relative_to(dir_tree)
+            result_key = "" if rel_dir == Path(".") else str(rel_dir)
+            results[result_key] = (max(failed_logs, failed_events), failed_size)
+
+    return results
+
+
+def readable_bytes(size: int) -> str:
+    """Convert a size in bytes to a human-readable string."""
+    if size < 1024:
+        return f"{size} B"
+    if size < 1024 * 1024:
+        return f"{size / 1024:.1f} KB"
+    if size < 1024 * 1024 * 1024:
+        return f"{size / 1024 / 1024:.1f} MB"
+    return f"{size / 1024 / 1024 / 1024:.1f} GB"

--- a/xfuser/core/utils/outputs_equal.py
+++ b/xfuser/core/utils/outputs_equal.py
@@ -1,0 +1,199 @@
+import math
+from collections.abc import Mapping
+from typing import Any
+
+import numpy as np
+import torch
+from PIL.Image import Image
+
+
+def _index_path(path: str, index: int) -> str:
+    return f"{path}[{index}]" if path else f"[{index}]"
+
+
+def _mapping_key_path(path: str, key) -> str:
+    key_part = f"['{key}']" if isinstance(key, str) else f"[{key!r}]"
+    return f"{path}{key_part}" if path else key_part
+
+
+def _payload_family(value):
+    if value is None:
+        return "none"
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, np.generic):
+        return "np.generic"
+    if isinstance(value, (int, float, complex)):
+        return "number"
+    if isinstance(value, str):
+        return "str"
+    if isinstance(value, torch.Tensor):
+        return "tensor"
+    if isinstance(value, np.ndarray):
+        return "ndarray"
+    if isinstance(value, Image):
+        return "pil"
+    if isinstance(value, (bytes, bytearray)):
+        return "bytes"
+    if isinstance(value, (list, tuple)):
+        return "sequence"
+    if isinstance(value, Mapping):
+        return "mapping"
+    instance_dict = getattr(value, "__dict__", None)
+    if isinstance(instance_dict, dict):
+        return "object"
+    return None
+
+
+def _float_values_equal(a, b) -> bool:
+    return (math.isnan(a) and math.isnan(b)) or (a == b)
+
+
+def _numeric_values_equal(a, b) -> bool:
+    if isinstance(a, complex) or np.issubdtype(type(a), np.complexfloating):
+        return _float_values_equal(a.real, b.real) and _float_values_equal(a.imag, b.imag)
+    if isinstance(a, float) or np.issubdtype(type(a), np.floating):
+        return _float_values_equal(a, b)
+    return a == b
+
+
+def _tensors_equal(a: torch.Tensor, b: torch.Tensor) -> bool:
+    if a.shape != b.shape or a.dtype != b.dtype:
+        return False
+    left = a.detach()
+    right = b.detach()
+    if left.device != right.device:
+        left = left.cpu()
+        right = right.cpu()
+    left = left.contiguous()
+    right = right.contiguous()
+    if left.is_complex():
+        return _tensors_equal(torch.view_as_real(left), torch.view_as_real(right))
+    if left.is_floating_point():
+        equal = left == right
+        both_nan = torch.isnan(left) & torch.isnan(right)
+        return bool(torch.all(equal | both_nan).item())
+    return bool(torch.equal(left, right))
+
+
+def _ndarrays_equal(a: np.ndarray, b: np.ndarray, path: str) -> bool:
+    if a.shape != b.shape or a.dtype != b.dtype:
+        return False
+    if a.dtype == object:
+        for index, (left, right) in enumerate(zip(a.flat, b.flat)):
+            if not _payloads_equal(left, right, _index_path(path, index)):
+                return False
+        return True
+    return bool(np.array_equal(a, b, equal_nan=True))
+
+
+def _pil_palette_data(image: Image):
+    palette = image.palette
+    if palette is None:
+        return None
+    return (palette.mode, palette.rawmode, bytes(palette.palette))
+
+
+def _pil_images_equal(a: Image, b: Image) -> bool:
+    if type(a) is not type(b):
+        return False
+    if a.size != b.size or a.mode != b.mode:
+        return False
+    if _pil_palette_data(a) != _pil_palette_data(b):
+        return False
+    return a.tobytes() == b.tobytes()
+
+
+def _payloads_equal(a, b, path: str) -> bool:
+    family_a = _payload_family(a)
+    family_b = _payload_family(b)
+    if family_a is None or family_b is None:
+        unsupported = a if family_a is None else b
+        raise TypeError(
+            f"Unsupported payload type {type(unsupported).__name__} at {path or '<root>'}"
+        )
+    if family_a != family_b:
+        return False
+    if family_a == "none":
+        return True
+    if family_a in ("bool", "np.generic", "number", "str"):
+        if type(a) is not type(b):
+            return False
+        if family_a == "str":
+            return a == b
+        return _numeric_values_equal(a, b)
+    if family_a == "tensor":
+        return _tensors_equal(a, b)
+    if family_a == "ndarray":
+        return _ndarrays_equal(a, b, path)
+    if family_a == "pil":
+        return _pil_images_equal(a, b)
+    if family_a == "bytes":
+        return type(a) is type(b) and a == b
+    if family_a == "sequence":
+        if type(a) is not type(b) or len(a) != len(b):
+            return False
+        for index, (left, right) in enumerate(zip(a, b)):
+            if not _payloads_equal(left, right, _index_path(path, index)):
+                return False
+        return True
+    if family_a == "mapping":
+        if type(a) is not type(b):
+            return False
+        keys_a = list(a.keys())
+        keys_b = list(b.keys())
+        if keys_a != keys_b:
+            return False
+        for key in keys_a:
+            if not _payloads_equal(a[key], b[key], _mapping_key_path(path, key)):
+                return False
+        return True
+    if type(a) is not type(b):
+        return False
+    keys_a = list(a.__dict__.keys())
+    keys_b = list(b.__dict__.keys())
+    if keys_a != keys_b:
+        return False
+    for name in keys_a:
+        if not _payloads_equal(
+            a.__dict__[name], b.__dict__[name], f"{path}.{name}" if path else name
+        ):
+            return False
+    return True
+
+
+def outputs_equal(expected: Any, actual: Any) -> bool:
+    """Compare generated payloads of two DiffusionOutput-like objects.
+
+    Used by the determinism check in ``xFuserModel.run()`` to decide whether a
+    later timed iteration matches the first-iteration snapshot.
+
+    Assumptions:
+    - Both operands are instances of ``DiffusionOutput`` or a subclass, exposed
+      only as ``Any`` so this module does not import ``base_model``.
+    - Operands are compared by concrete type and instance ``__dict__`` field
+      names in insertion order.
+    - The root ``pipe_args`` field is ignored; every other field, including
+      subclass extras such as audio, is compared recursively.
+    - Comparison is exact: same types, shapes, and dtypes, with IEEE float
+      equality plus ``NaN == NaN`` and ``+0 == -0``. Unsupported nested types
+      raise ``TypeError`` rather than falling back to ``==``.
+
+    This is a freestanding function rather than a ``DiffusionOutput`` method
+    because that class's ``get_outputs()`` pairs generated items with
+    ``pipe_args`` and does not expose subclass payload fields. Determinism
+    equality is not whole-object equality, so attaching it to the class would
+    imply ``__eq__`` semantics that exclude ``pipe_args``. Additionally, this
+    function has to operate on any subclass of ``DiffusionOutput``, so putting
+    it into the class itself seems weird, though possible.
+    """
+    if type(expected) is not type(actual):
+        return False
+    expected_fields = [name for name in expected.__dict__ if name != "pipe_args"]
+    actual_fields = [name for name in actual.__dict__ if name != "pipe_args"]
+    if expected_fields != actual_fields:
+        return False
+    for name in expected_fields:
+        if not _payloads_equal(expected.__dict__[name], actual.__dict__[name], name):
+            return False
+    return True

--- a/xfuser/core/utils/runner_utils.py
+++ b/xfuser/core/utils/runner_utils.py
@@ -29,6 +29,11 @@ def log(message: str, debug=False, log_from_all_processes: bool = False) -> None
         else:
             logger.info(message)
 
+def log_error(message: str, log_from_all_processes: bool = False) -> None:
+    """Log error. By default, only from the last process to avoid duplicates."""
+    if log_from_all_processes or is_last_process():
+        logger.error(message)
+
 def is_last_process() -> bool:
     """
     Checks based on env rank and world size if this is last process in

--- a/xfuser/model_executor/models/runner_models/base_model.py
+++ b/xfuser/model_executor/models/runner_models/base_model.py
@@ -3,6 +3,7 @@ import torch
 import copy
 import json
 import os
+from pathlib import Path
 from PIL.Image import Image
 from typing import Callable, List, Optional, Tuple, Generator
 from dataclasses import dataclass, field, replace
@@ -18,8 +19,10 @@ from xfuser.envs import (
     _is_hip,
     _is_cuda,
 )
+from xfuser.core.utils.outputs_equal import outputs_equal
 from xfuser.core.utils.runner_utils import (
     log,
+    log_error,
     load_dataset_prompts,
     rgetattr,
 )
@@ -237,6 +240,7 @@ class DiffusionOutput:
         elif self.videos:
             for video, single_pipe_args in zip(self.videos, self.pipe_args):
                 yield (video, single_pipe_args)
+
 
 class xFuserModel(abc.ABC):
     """ Base class for xFuser models """
@@ -668,19 +672,90 @@ class xFuserModel(abc.ABC):
             compile_args["num_inference_steps"] = warmup_steps
         self._run_compile_warmup(compile_args)
 
+    def _save_determinism_check_failed_outputs(
+        self,
+        output: DiffusionOutput,
+        iteration: int,
+        rank: int,
+    ) -> None:
+        if not output or (not output.images and not output.videos):
+            return  # otherwise save_output() will throw or die
+
+        orig_get_output_name = self.get_output_name
+        def _get_output_name(*args, **kwargs):
+            return (
+                orig_get_output_name(*args, **kwargs)
+                + f"_rank_{rank:02d}_iteration_{iteration:03d}"
+                # WARNING: xfuser/core/utils/determinism_check_results.py depends on the
+                # specific format of the filename, keep it in sync.
+            )
+
+        self.get_output_name = _get_output_name
+        try:
+            self.save_output(output)
+        finally:
+            self.get_output_name = orig_get_output_name
+
+
+    def _determinism_check(
+        self,
+        iteration: int,
+        expected_output: DiffusionOutput,
+        output: DiffusionOutput,
+        determinism_failures: int,
+    ) -> tuple[int, DiffusionOutput]:
+        """Determinism check implementation."""
+        if iteration == 0:
+            expected_output = copy.deepcopy(output)
+        elif not outputs_equal(expected_output, output):
+            rank = get_world_group().rank
+            # WARNING: xfuser/core/utils/determinism_check_results.py depends on this log
+            # message format, keep it in sync.
+            log_error(
+                f"determinism_check[rank {rank}]: iteration {iteration + 1} diverged!",
+                log_from_all_processes=True,
+            )
+            determinism_failures += 1
+
+            if (
+                determinism_failures <= self.config.determinism_check
+                and rank in self.config.determinism_check_report_ranks
+            ):
+                if determinism_failures == 1:
+                    self._save_determinism_check_failed_outputs(expected_output, 0, rank)
+                self._save_determinism_check_failed_outputs(output, iteration, rank)
+            # else: do nothing, above is enough
+
+        return determinism_failures, expected_output
+
 
     def run(self, input_args: dict) -> Tuple[DiffusionOutput, list]:
-        """ Run the model with given input arguments and return output and timings """
+        """Run the model and optionally check repeated outputs for determinism.
+
+        A positive ``determinism_check`` value enables exact comparisons against
+        the first timed output and sets the failure count at which the failure
+        handler starts being called.
+        """
         self._validate_args(input_args)
         input_args = self._split_prompts_for_dp(input_args)
         timings = []
         output: DiffusionOutput = None
+        expected_output = None
+        determinism_failures = 0
 
         if self.config.warmup_calls:
             warmup_args = copy.deepcopy(input_args)
             if self.config.batch_size and isinstance(warmup_args.get("prompt"), list):
                 warmup_args["prompt"] = warmup_args["prompt"][: self.config.batch_size]
             self._run_warmup_calls(warmup_args)
+
+        if self.config.determinism_check > 0:
+            log(
+                f"Since determinism check is enabled ({self.config.determinism_check}), "
+                "'Total time spent' reported at the end of all iterations will be "
+                "inflated and include the time spent on the check. "
+                "Individual iteration timings will not be affected."
+            )
 
         inference_start = torch.cuda.Event(enable_timing=True)
         inference_end = torch.cuda.Event(enable_timing=True)
@@ -697,6 +772,14 @@ class xFuserModel(abc.ABC):
                 output, timing = self._run_timed_pipe(input_args)
                 timings.append(timing)
                 log(f"Iteration {iteration + 1} completed in {timing:.2f}s")
+
+            if self.config.determinism_check > 0:
+                determinism_failures, expected_output = self._determinism_check(
+                    iteration,
+                    expected_output,
+                    output,
+                    determinism_failures,
+                )
 
         inference_end.record()
         torch.cuda.synchronize()


### PR DESCRIPTION
This PR adds two CLI/config arguments: integer `--determinism_check` and string `--determinism_check_report_ranks`. When `--determinism_check` value is positive, this enables deterministic inference check in the xFuser: in the inference loop, on the first iteration, the output a model produces is saved (on each rank independently), and is compared to what the model returns on each next iteration. Whenever the outputs mismatch, an error message is produced, and if the total number of checks failed to the moment is less than or equal to `int(determinism_check)`, the baseline and the differing outputs are dumped to the same output directory for further inspection. Hence a value of `--determinism_check` enables the check and lets the user to limit the number of dump files (since usually it's enough to have a single evidence of non-deterministic behavior).

Value of `--determinism_check_report_ranks` helps with limiting the number of output dumps by letting a user to restrict outputs of which ranks are dumped to files.

Additionally, an independent `determinism_check_results()` helper method is provided to enable detection of determinism check failures for external model runners. The helper should stay in the repo to maintain coupling between certain format of error messages and dump file names, which is enforced by tests.